### PR TITLE
feat: admin console adjust for integration

### DIFF
--- a/acl/admin.json
+++ b/acl/admin.json
@@ -202,7 +202,7 @@
       ]
     },
     "get_audit_logs": {
-      "doc": "Return paginated audit log entries across all hubs in the domain. Iterates over every hub DB in the domain, calls hub_get_audit_logs_filtered per hub, merges and sorts all results by ctime descending, then returns one page of 20 entries. Known limitation: only fetches page 1 from each hub before merging, so entries beyond page 1 of any single hub may be omitted.",
+      "doc": "Return paginated audit log entries across all hubs in the domain plus a real total count. Iterates over every hub DB in the domain, calls hub_get_audit_logs_filtered per hub for the page slice, sums hub_get_audit_logs_count for the total, merges and sorts results by ctime descending, then returns one page of 20 entries inside a {data, total, page, page_size} envelope. Known limitation: only fetches page 1 from each hub before merging, so entries beyond page 1 of any single hub may be omitted from the merged page (count is still accurate).",
       "scope": "domain",
       "permission": { "src": "admin" },
       "params": {
@@ -228,21 +228,29 @@
         }
       },
       "returns": {
-        "type": "array",
-        "description": "Paginated list of audit log entries sorted by ctime descending",
-        "items": {
-          "uid": { "type": "string", "description": "Actor user ID" },
-          "action": { "type": "string", "description": "Action enum value" },
-          "category": { "type": "string", "description": "Category enum value" },
-          "notify_to": { "type": "string", "description": "Notification target" },
-          "entity_id": { "type": "string", "description": "Affected entity ID" },
-          "log": { "type": "string", "description": "Log message" },
-          "ctime": { "type": "integer", "description": "Entry timestamp (UNIX)" },
-          "actor_name": { "type": "string", "description": "Actor full name from yp.drumate" },
-          "firstname": { "type": "string", "description": "Actor first name" },
-          "lastname": { "type": "string", "description": "Actor last name" },
-          "email": { "type": "string", "description": "Actor email" },
-          "hub_id": { "type": "string", "description": "Source hub ID (appended by service layer)" }
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Paginated list of audit log entries sorted by ctime descending",
+            "items": {
+              "uid": { "type": "string", "description": "Actor user ID" },
+              "action": { "type": "string", "description": "Action enum value" },
+              "category": { "type": "string", "description": "Category enum value" },
+              "notify_to": { "type": "string", "description": "Notification target" },
+              "entity_id": { "type": "string", "description": "Affected entity ID" },
+              "log": { "type": "string", "description": "Log message" },
+              "ctime": { "type": "integer", "description": "Entry timestamp (UNIX)" },
+              "actor_name": { "type": "string", "description": "Actor full name from yp.drumate" },
+              "firstname": { "type": "string", "description": "Actor first name" },
+              "lastname": { "type": "string", "description": "Actor last name" },
+              "email": { "type": "string", "description": "Actor email" },
+              "hub_id": { "type": "string", "description": "Source hub ID (appended by service layer)" }
+            }
+          },
+          "total": { "type": "integer", "description": "Total entries across all hubs matching the filters" },
+          "page": { "type": "integer", "description": "Echo of the page param" },
+          "page_size": { "type": "integer", "description": "Server page size (currently 20)" }
         }
       },
       "errors": []
@@ -308,26 +316,26 @@
       ]
     },
     "get_audit_stats": {
-      "doc": "Return summary statistics for the Audit Logs tab header cards. security_score and high_risk_count are placeholders (hardcoded 94 and 0 respectively) for Round 1. storage_used_bytes is real data: sum of yp.entity.space for all active hubs in the domain.",
+      "doc": "Return summary statistics for the Audit Logs tab header cards. security_score is still a placeholder (hardcoded 94) pending a real scoring model. high_risk_count is now real: sum of action_log entries in the time range whose category is 'admin'/'permission' or whose action is grant_access/change_policy/share_link/removed, aggregated across every hub in the domain via hub_count_high_risk_actions. storage_used_bytes is real: sum of yp.entity.space for all active hubs.",
       "scope": "domain",
       "permission": { "src": "admin" },
       "params": {
         "from_time": {
           "type": "integer",
           "required": false,
-          "description": "Range start (UNIX timestamp). Currently unused in SP computation. 0 disables."
+          "description": "Range start (UNIX timestamp) — applied to high_risk_count aggregation. 0 disables."
         },
         "to_time": {
           "type": "integer",
           "required": false,
-          "description": "Range end (UNIX timestamp). Currently unused in SP computation. 0 disables."
+          "description": "Range end (UNIX timestamp) — applied to high_risk_count aggregation. 0 disables."
         }
       },
       "returns": {
         "type": "object",
         "properties": {
-          "security_score": { "type": "integer", "description": "Placeholder value: 94" },
-          "high_risk_count": { "type": "integer", "description": "Placeholder value: 0" },
+          "security_score": { "type": "integer", "description": "Placeholder value: 94 (real scoring model TBD)" },
+          "high_risk_count": { "type": "integer", "description": "Real count of risk-relevant action_log entries across hubs in the time range" },
           "storage_used_bytes": { "type": "number", "description": "Sum of yp.entity.space for all active hubs in domain (float)" }
         }
       },
@@ -352,7 +360,7 @@
       "errors": []
     },
     "get_org_user_storage": {
-      "doc": "Return a paginated, sortable list of members in the domain with their individual storage usage. Joins yp.drumate, yp.privilege, and yp.entity (type=drumate) to compute per-user used bytes.",
+      "doc": "Return a paginated, sortable list of members in the domain with their individual storage usage, plus a real total count. Joins yp.drumate, yp.privilege, and yp.entity (type=drumate) to compute per-user used bytes. Returns an envelope {data, total, page, page_size} so the FE can render an honest paginator. Total is sourced from get_org_user_storage_count.",
       "scope": "domain",
       "permission": { "src": "admin" },
       "params": {
@@ -368,17 +376,25 @@
         }
       },
       "returns": {
-        "type": "array",
-        "description": "Paginated list of domain members with storage usage",
-        "items": {
-          "uid": { "type": "string", "description": "Member user ID" },
-          "firstname": { "type": "string", "description": "Member first name" },
-          "lastname": { "type": "string", "description": "Member last name" },
-          "fullname": { "type": "string", "description": "Member full name" },
-          "email": { "type": "string", "description": "Member email" },
-          "domain_privilege": { "type": "integer", "description": "Member domain-level privilege" },
-          "used_bytes": { "type": "number", "description": "Storage used in bytes" },
-          "used_mb": { "type": "number", "description": "Storage used in megabytes, rounded to 2 decimal places" }
+        "type": "object",
+        "properties": {
+          "data": {
+            "type": "array",
+            "description": "Paginated list of domain members with storage usage",
+            "items": {
+              "uid": { "type": "string", "description": "Member user ID" },
+              "firstname": { "type": "string", "description": "Member first name" },
+              "lastname": { "type": "string", "description": "Member last name" },
+              "fullname": { "type": "string", "description": "Member full name" },
+              "email": { "type": "string", "description": "Member email" },
+              "domain_privilege": { "type": "integer", "description": "Member domain-level privilege" },
+              "used_bytes": { "type": "number", "description": "Storage used in bytes" },
+              "used_mb": { "type": "number", "description": "Storage used in megabytes, rounded to 2 decimal places" }
+            }
+          },
+          "total": { "type": "integer", "description": "Total domain members (matches WHERE clause without pagination)" },
+          "page": { "type": "integer", "description": "Echo of the page param" },
+          "page_size": { "type": "integer", "description": "Server page size (currently 20)" }
         }
       },
       "errors": []

--- a/service/private/admin.js
+++ b/service/private/admin.js
@@ -123,6 +123,7 @@ class __admin extends Entity {
     ));
 
     let allLogs = [];
+    let total   = 0;
     for (const hub of hubs) {
       const rows = toArray(await this.yp.await_proc(
         `${hub.db_name}.hub_get_audit_logs_filtered`,
@@ -130,13 +131,26 @@ class __admin extends Entity {
       ));
       rows.forEach(r => { r.hub_id = hub.id; });
       allLogs = allLogs.concat(rows);
+
+      // Sum the real total per hub so the paginator can render an honest
+      // count instead of guessing from `rows < PAGE_SIZE`.
+      const countRow = toArray(await this.yp.await_proc(
+        `${hub.db_name}.hub_get_audit_logs_count`,
+        username, from_time, to_time
+      ))[0];
+      if (countRow) total += parseInt(countRow.total, 10) || 0;
     }
 
     allLogs.sort((a, b) => b.ctime - a.ctime);
 
     const PAGE_SIZE = 20;
     const offset    = (page - 1) * PAGE_SIZE;
-    this.output.list(allLogs.slice(offset, offset + PAGE_SIZE));
+    this.output.json({
+      data: allLogs.slice(offset, offset + PAGE_SIZE),
+      total,
+      page,
+      page_size: PAGE_SIZE,
+    });
   }
 
   async export_audit_logs() {
@@ -183,13 +197,35 @@ class __admin extends Entity {
   async get_audit_stats() {
     let from_time = this.input.use('from_time', 0);
     let to_time   = this.input.use('to_time', 0);
-    let res = await this.yp.await_proc(
+
+    // yp SP gives us security_score (placeholder), high_risk_count
+    // (placeholder), and storage_used_bytes (real).
+    let stats = await this.yp.await_proc(
       'get_audit_stats',
       this.user.domain_id(),
       from_time,
       to_time
-    );
-    this.output.json(res || {});
+    ) || {};
+
+    // Replace high_risk_count with a real aggregate by summing
+    // hub_count_high_risk_actions across every hub in the domain. action_log
+    // lives per-hub so we can't compute this from yp alone.
+    const hubs = toArray(await this.yp.await_proc(
+      'member_list_hubs_by_domain',
+      this.user.domain_id()
+    ));
+    let highRisk = 0;
+    for (const hub of hubs) {
+      const row = toArray(await this.yp.await_proc(
+        `${hub.db_name}.hub_count_high_risk_actions`,
+        from_time,
+        to_time
+      ))[0];
+      if (row) highRisk += parseInt(row.total, 10) || 0;
+    }
+    stats.high_risk_count = highRisk;
+
+    this.output.json(stats);
   }
 
   // ADMIN CONSOLE — STORAGE TAB (org-level)
@@ -201,13 +237,30 @@ class __admin extends Entity {
   async get_org_user_storage() {
     let sort_by = this.input.use('sort_by', 'usage_high');
     let page    = this.input.use(Attr.page, 1);
-    let res = await this.yp.await_proc(
+    const PAGE_SIZE = 20; // matches yp.utils.pageToLimits default
+
+    let rows = toArray(await this.yp.await_proc(
       'get_org_user_storage',
       this.user.domain_id(),
       sort_by,
       page
-    );
-    this.output.list(res);
+    ));
+
+    // Paired count SP so the FE can render "Showing X-Y of N" without
+    // guessing. The data SP runs LIMIT-bound; the count SP shares the
+    // same WHERE clause minus pagination.
+    const countRow = toArray(await this.yp.await_proc(
+      'get_org_user_storage_count',
+      this.user.domain_id()
+    ))[0];
+    const total = countRow ? (parseInt(countRow.total, 10) || 0) : 0;
+
+    this.output.json({
+      data: rows,
+      total,
+      page,
+      page_size: PAGE_SIZE,
+    });
   }
 
   // WORKSPACE ADMIN — MEMBER TAB
@@ -250,16 +303,26 @@ class __admin extends Entity {
     this.output.json(res || {});
   }
 
-  // WORKSPACE ADMIN — PERMISSION TAB
+  // WORKSPACE ADMIN — PERMISSION TAB / MEMBER TAB OVERVIEW
   async get_workspace_overview() {
     let hub_id = this.input.need(Attr.hub_id);
-    // hub_id required for scope:hub check; method returns domain-wide overview
-    let res = await this.yp.await_proc(
-      'get_workspace_overview',
-      this.user.domain_id(),
-      this.uid
-    );
-    this.output.list(res);
+    // Collaborative workspaces the caller participates in. The data
+    // model has two areas that are visually "restricted" workspaces in
+    // this product:
+    //   - 'private'    — most common in practice (the user's data uses
+    //                    this for invitable team-restricted hubs)
+    //   - 'restricted' — the literal enum value
+    // Plus 'share' for shared workspaces. Excluded: 'personal' (each
+    // user's own space), 'system' / 'pool*' / 'template' / 'dummy'
+    // / 'dmz*' (infra and one-shot share buckets — not workspaces).
+    let rows = toArray(await this.yp.await_proc(
+      'member_list_workspaces',
+      this.uid,
+      this.user.domain_id()
+    ));
+    const WORKSPACE_AREAS = new Set(['private', 'restricted', 'share']);
+    rows = rows.filter(r => WORKSPACE_AREAS.has(r.area));
+    this.output.list(rows);
   }
 
   async get_hub_folders() {
@@ -268,12 +331,14 @@ class __admin extends Entity {
     let page    = this.input.use(Attr.page, 1);
     let hub_db  = await this.yp.await_func('get_db_name', hub_id);
     if (!hub_db) return this.output.status('HUB_NOT_FOUND');
-    let params = { type: 'node', page };
+    // Use the dedicated single-result-set SP. mfs_show_node_by works for
+    // the desk surface but its internal UPDATE/ALTER traffic on temp
+    // tables makes the mariadb wrapper here pick the wrong chunk, returning
+    // an empty array even when folders exist.
     let res = await this.yp.await_proc(
-      `${hub_db}.mfs_show_node_by`,
+      `${hub_db}.hub_list_folders`,
       node_id,
-      this.uid,
-      JSON.stringify(params)
+      page
     );
     this.output.list(res);
   }
@@ -283,8 +348,33 @@ class __admin extends Entity {
     let nid    = this.input.need(Attr.nid);
     let hub_db = await this.yp.await_func('get_db_name', hub_id);
     if (!hub_db) return this.output.status('HUB_NOT_FOUND');
-    let res = await this.yp.await_proc(`${hub_db}.folder_get_permissions`, nid);
-    this.output.json(res || {});
+    // SP returns two SELECTs: first is the config row, second is the
+    // member list. The mariadb wrapper picks one chunk and discards the
+    // rest — same behaviour we hit on get_hub_folders. Pull both via
+    // separate calls so the FE gets a complete payload.
+    let cfgRows = toArray(await this.yp.await_proc(
+      `${hub_db}.folder_get_permissions`,
+      nid
+    ));
+    let cfg = cfgRows[0] || {};
+    let members = toArray(await this.yp.await_proc(
+      `${hub_db}.folder_get_member_list`,
+      nid
+    ));
+    this.output.json({
+      mode: cfg.mode,
+      access: {
+        view: !!cfg.access_view,
+        edit: !!cfg.access_edit,
+        chat: !!cfg.access_chat,
+      },
+      auto_revoke: !!cfg.auto_revoke,
+      auto_revoke_minutes: cfg.auto_revoke_minutes || 30,
+      one_time: !!cfg.one_time,
+      one_time_url: cfg.one_time_url || '',
+      members,
+      devices: [],
+    });
   }
 
   async save_folder_permissions() {


### PR DESCRIPTION

- get_workspace_overview now uses member_list_workspaces filtered by area
- get_audit_logs / get_org_user_storage return {data, total, page, page_size}
- get_audit_stats overlays real high_risk_count via per-hub aggregation
- get_hub_folders calls dedicated hub_list_folders SP
- get_folder_permissions returns config + members in one envelope
- ACL docs updated to match new envelope shapes