### PR TITLE
feat(secure-share): new service, PBKDF2 password hashing, email/password gating, real-time revoke broadcast

### DIFF
--- a/acl/secure_share.json
+++ b/acl/secure_share.json
@@ -1,0 +1,101 @@
+{
+  "modules": {
+    "private": "service/private/secure_share",
+    "public": ""
+  },
+  "services": {
+    "create": {
+      "doc": "Create a per-email unique secure share token for a file or folder. Stores the token in secure_share_token (yellow_page), sends an invitation email to the recipient, and returns the share link.",
+      "scope": "hub",
+      "permission": {
+        "src": "write",
+        "fast_check": "user_permission"
+      },
+      "log": true,
+      "params": {
+        "nid": {
+          "type": "string",
+          "required": true,
+          "doc": "Node ID of the file or folder to share"
+        },
+        "email": {
+          "type": "string",
+          "required": true,
+          "doc": "Recipient email. Access is restricted to this address unless domain_restriction is also set."
+        },
+        "domain_restriction": {
+          "type": "string",
+          "required": false,
+          "doc": "Optional domain restriction (e.g. company.com). When set, any email from that domain may use the link."
+        },
+        "days": {
+          "type": "integer",
+          "required": false,
+          "default": 0,
+          "doc": "Expiry in days, combined with hours. 0 means no expiry."
+        },
+        "hours": {
+          "type": "integer",
+          "required": false,
+          "default": 0,
+          "doc": "Expiry in hours, combined with days. 0 means no expiry."
+        }
+      },
+      "returns": {
+        "id":              { "type": "string",  "doc": "Unique share token" },
+        "link":            { "type": "string",  "doc": "Full share URL to send to the recipient" },
+        "recipient_email": { "type": "string" },
+        "expiry_time":     { "type": "integer", "doc": "Unix timestamp, 0 = no expiry" }
+      },
+      "errors": [
+        { "code": "CREATE_FAILED", "message": "Token creation failed" },
+        { "code": "MISSING_PARAM", "message": "nid and email are required", "http_status": 400 }
+      ]
+    },
+    "list": {
+      "doc": "List all secure share tokens created by the current user for a given node, including status (active / expired / revoked) and access counts.",
+      "scope": "hub",
+      "permission": {
+        "src": "write",
+        "fast_check": "user_permission"
+      },
+      "params": {
+        "nid": {
+          "type": "string",
+          "required": true,
+          "doc": "Node ID to list secure share tokens for"
+        }
+      }
+    },
+    "revoke": {
+      "doc": "Revoke a secure share token (soft delete — sets revoked_at timestamp). Broadcasts a secure_share_revoked event via Redis to all hub socket connections so the recipient loses access instantly.",
+      "scope": "hub",
+      "permission": {
+        "src": "write"
+      },
+      "log": true,
+      "params": {
+        "token": {
+          "type": "string",
+          "required": true,
+          "doc": "Secure share token to revoke"
+        }
+      }
+    },
+    "delete": {
+      "doc": "Hard-delete a secure share token. Only succeeds when the token is already revoked or expired — active tokens are rejected.",
+      "scope": "hub",
+      "permission": {
+        "src": "write"
+      },
+      "log": true,
+      "params": {
+        "token": {
+          "type": "string",
+          "required": true,
+          "doc": "Token to permanently delete. Must already be revoked or expired."
+        }
+      }
+    }
+  }
+}

--- a/acl/secure_share.json
+++ b/acl/secure_share.json
@@ -39,6 +39,11 @@
           "required": false,
           "default": 0,
           "doc": "Expiry in hours, combined with days. 0 means no expiry."
+        },
+        "password": {
+          "type": "string",
+          "required": false,
+          "doc": "Optional password the recipient must enter after email verification. Communicated out-of-band. Stored as salted PBKDF2-SHA512 hash — never in plain text."
         }
       },
       "returns": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
-        "@drumee/server-core": "^1.1.75",
+        "@drumee/server-core": "^1.1.76",
         "@drumee/server-essentials": "^1.2.44",
         "@drumee/ui-core": "^1.1.41",
         "@hyzyla/pdfium": "^2.1.9",
@@ -1262,6 +1262,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@drumee/schemas-utils": "^1.0.0",
-    "@drumee/server-core": "^1.1.75",
+    "@drumee/server-core": "^1.1.76",
     "@drumee/server-essentials": "^1.2.44",
     "@drumee/ui-core": "^1.1.41",
     "@hyzyla/pdfium": "^2.1.9",

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -137,9 +137,13 @@ class __dmz extends Mfs {
 
     // If not found in dmz_token, check secure_share_token (no-op for normal DMZ tokens)
     if (isEmpty(res) || res.failed) {
-      const secureRes = await this.yp.await_proc('secure_share_info', token);
-      if (!isEmpty(secureRes) && !secureRes.failed) {
-        res = secureRes;
+      try {
+        const secureRes = await this.yp.await_proc('secure_share_info', token);
+        if (!isEmpty(secureRes) && !secureRes.failed) {
+          res = secureRes;
+        }
+      } catch (e) {
+        this.warn('[dmz.info] secure_share_info lookup failed:', e && e.message);
       }
     }
 
@@ -261,9 +265,13 @@ class __dmz extends Mfs {
     let password = this.input.get(Attr.password);
 
     // Check secure_share_token first — leaves normal dmz_token flow completely untouched
-    const secureInfo = await this.yp.await_proc('secure_share_info', token);
-    if (!isEmpty(secureInfo) && !secureInfo.failed) {
-      return this._loginSecureShare(token, secureInfo);
+    try {
+      const secureInfo = await this.yp.await_proc('secure_share_info', token);
+      if (!isEmpty(secureInfo) && !secureInfo.failed) {
+        return this._loginSecureShare(token, secureInfo);
+      }
+    } catch (e) {
+      this.warn('[dmz.login] secure_share_info lookup failed:', e && e.message);
     }
 
     let info = await this.yp.await_proc('dmz_info_next', token);

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -230,6 +230,18 @@ class __dmz extends Mfs {
       this.warn('[dmz.login] secure_share access_log failed:', e && e.message);
     }
 
+    // Associate session with share creator so hub endpoints (media.show_node_by) work —
+    // mirrors the cookie_touch done for normal DMZ tokens at login line 330.
+    if (info.creator_id) {
+      try {
+        await this.yp.await_proc('cookie_touch', {
+          sid: this.input.sid(), uid: info.creator_id
+        });
+      } catch (e) {
+        this.warn('[dmz.login] secure_share cookie_touch failed:', e && e.message);
+      }
+    }
+
     // Hub-level expiry display fields (same as normal login)
     let rows = await this.yp.await_proc('forward_proc', info.hub_id, 'dmz_settings', ``);
     if (rows && rows[0]) {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -250,6 +250,20 @@ class __dmz extends Mfs {
       info.dmz_expiry = rows[0].dmz_expiry;
     }
 
+    // If the shared node is a file (not a folder/hub), show_node_by(file_nid) returns
+    // empty because files have no children. Use the parent folder instead so the file
+    // appears in the listing. Keep node_id as-is for reference.
+    try {
+      const nodeRows = await this.yp.await_proc('forward_proc', info.hub_id, 'mfs_node_attr', `'${info.nid}'`);
+      const nodeAttr = toArray(nodeRows)[0] || {};
+      if (nodeAttr.filetype && nodeAttr.filetype !== 'folder' && nodeAttr.filetype !== 'hub' && nodeAttr.pid) {
+        info.file_nid = info.nid;  // specific file — sent to UI for filtering
+        info.nid = nodeAttr.pid;   // parent folder — used by show_node_by
+      }
+    } catch (e) {
+      this.warn('[dmz.login] secure_share node type check failed:', e && e.message);
+    }
+
     let area     = this.hub.get(Attr.area);
     let is_guest = (guest_id === user.id);
     if (user.profile) {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -129,14 +129,27 @@ class __dmz extends Mfs {
 
 
   /**
- * 
+ *
  */
   async info() {
-    let res = await this.yp.await_proc('dmz_info_next', this.input.need(Attr.token));
-    if (isEmpty(res)) {
-      res.status = 'WRONG_TICKET'
+    const token = this.input.need(Attr.token);
+    let res = await this.yp.await_proc('dmz_info_next', token);
+
+    // If not found in dmz_token, check secure_share_token (no-op for normal DMZ tokens)
+    if (isEmpty(res) || res.failed) {
+      const secureRes = await this.yp.await_proc('secure_share_info', token);
+      if (!isEmpty(secureRes) && !secureRes.failed) {
+        res = secureRes;
+      }
+    }
+
+    if (isEmpty(res) || res.failed) {
+      res = res || {};
+      res.status = 'WRONG_TICKET';
+    } else if (res.is_secure) {
+      res.status = res.validity === 'TICKET_OK' ? 'REQUIRED_EMAIL' : res.validity;
     } else if (res.require_password) {
-      res.status = 'REQUIRED_PASSWORD'
+      res.status = 'REQUIRED_PASSWORD';
     }
     const guest_id = Cache.getSysConf("guest_id");
     res.guest_id = guest_id;
@@ -145,11 +158,114 @@ class __dmz extends Mfs {
 
 
   /**
-   * 
+   *
+   */
+  async _loginSecureShare(token, info) {
+    if (info.validity === 'TICKET_REVOKED') {
+      return this.output.data({ status: 'TICKET_REVOKED', is_secure: 1 });
+    }
+    if (info.validity === 'TICKET_EXPIRED') {
+      return this.output.data({ status: 'TICKET_EXPIRED', is_secure: 1 });
+    }
+
+    // Resolve logged-in side user from cookie (mirrors normal login flow)
+    let user = this.user.toJSON();
+    const guest_id = Cache.getSysConf("guest_id");
+    let { regsid } = this.input.get(Attr.cookie);
+    if (regsid) {
+      let u = await this.yp.await_proc("cookie_retrieve_user", regsid);
+      if (u && ![ID_NOBODY, guest_id].includes(u.id)) {
+        if (u.profile) {
+          user.profile = u.profile;
+          user.uid = u.id;
+          user.id  = u.id;
+        }
+      }
+    }
+
+    // Email validation
+    const submittedEmail = (this.input.get(Attr.email) || '').toLowerCase().trim();
+    if (!submittedEmail) {
+      return this.output.data({ ...info, status: 'REQUIRED_EMAIL', is_secure: 1 });
+    }
+
+    const recipientEmail = (info.recipient_email || '').toLowerCase().trim();
+    let emailValid = (submittedEmail === recipientEmail);
+
+    if (!emailValid && info.domain_restriction) {
+      const submittedDomain = submittedEmail.split('@')[1] || '';
+      emailValid = (submittedDomain === info.domain_restriction.toLowerCase().trim());
+    }
+
+    if (!emailValid) {
+      return this.output.data({ status: 'EMAIL_MISMATCH', is_secure: 1 });
+    }
+
+    // Valid access — log it and notify sender in real time
+    const actor_id = (guest_id === user.id) ? null : (user.id || null);
+    try {
+      const track = await this.yp.await_proc('secure_share_access_log', token, actor_id);
+      const row   = toArray(track)[0] || {};
+      if (row.hub_id) {
+        const recipients = await this.yp.await_proc('entity_sockets', { hub_id: row.hub_id });
+        await RedisStore.sendData(
+          this.payload(
+            {
+              event           : 'secure_share_opened',
+              token,
+              nid             : info.node_id,
+              recipient_email : submittedEmail,
+              access_count    : (info.access_count || 0) + 1,
+            },
+            { service: 'share.track_event' }
+          ),
+          recipients
+        );
+      }
+    } catch (e) {
+      this.warn('[dmz.login] secure_share access_log failed:', e && e.message);
+    }
+
+    // Hub-level expiry display fields (same as normal login)
+    let rows = await this.yp.await_proc('forward_proc', info.hub_id, 'dmz_settings', ``);
+    if (rows && rows[0]) {
+      info.hours      = rows[0].hours;
+      info.days       = rows[0].days;
+      info.dmz_expiry = rows[0].dmz_expiry;
+    }
+
+    let area     = this.hub.get(Attr.area);
+    let is_guest = (guest_id === user.id);
+    if (user.profile) {
+      user.profile.is_guest = is_guest;
+    }
+    user.uid = user.id;
+
+    return this.output.data({
+      ...user,
+      ...info,
+      is_secure : 1,
+      status    : 'TICKET_OK',
+      validity  : 'TICKET_OK',
+      guest_id  : info.uid || guest_id,
+      area,
+      is_guest,
+    });
+  }
+
+  /**
+   *
    */
   async login() {
     let token = this.input.need(Attr.token);
     let password = this.input.get(Attr.password);
+
+    // Check secure_share_token first — leaves normal dmz_token flow completely untouched
+    const secureInfo = await this.yp.await_proc('secure_share_info', token);
+    if (!isEmpty(secureInfo) && !secureInfo.failed) {
+      return this._loginSecureShare(token, secureInfo);
+    }
+
     let info = await this.yp.await_proc('dmz_info_next', token);
     if (!info) {
       this.output.data({ status: "TICKET_INVALID" });

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -268,10 +268,14 @@ class __dmz extends Mfs {
 
     // Associate session with share creator so hub endpoints (media.show_node_by) work —
     // mirrors the cookie_touch done for normal DMZ tokens at login line 330.
+    // socket_id must be passed so entity_sockets() includes this guest socket in
+    // hub broadcasts (e.g. secure_share_revoked) — same pattern as session.dmz_login.
     if (info.creator_id) {
       try {
         await this.yp.await_proc('cookie_touch', {
-          sid: this.input.sid(), uid: info.creator_id
+          sid       : this.input.sid(),
+          uid       : info.creator_id,
+          socket_id : this.input.get(Attr.socket_id)
         });
       } catch (e) {
         this.warn('[dmz.login] secure_share cookie_touch failed:', e && e.message);

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -187,8 +187,27 @@ class __dmz extends Mfs {
       }
     }
 
-    // Email validation
-    const submittedEmail = (this.input.get(Attr.email) || '').toLowerCase().trim();
+    // Email validation — logged-in Drumee members skip the form if their account
+    // email matches the share (session auth is stronger proof than typing an email)
+    let submittedEmail = (this.input.get(Attr.email) || '').toLowerCase().trim();
+
+    if (!submittedEmail && user.id && ![ID_NOBODY, guest_id].includes(user.id)) {
+      try {
+        const p = typeof user.profile === 'string' ? JSON.parse(user.profile) : (user.profile || {});
+        const accountEmail = (p.email || '').toLowerCase().trim();
+        if (accountEmail) {
+          const recipientCheck = (info.recipient_email || '').toLowerCase().trim();
+          let autoMatch = (accountEmail === recipientCheck);
+          if (!autoMatch && info.domain_restriction) {
+            autoMatch = (accountEmail.split('@')[1] || '') === info.domain_restriction.toLowerCase().trim();
+          }
+          if (autoMatch) submittedEmail = accountEmail;
+        }
+      } catch (e) {
+        this.warn('[dmz.login] secure_share auto-grant parse failed:', e && e.message);
+      }
+    }
+
     if (!submittedEmail) {
       return this.output.data({ ...info, status: 'REQUIRED_EMAIL', is_secure: 1 });
     }

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -244,7 +244,7 @@ class __dmz extends Mfs {
     // Valid access — log it and notify sender in real time
     const actor_id = (guest_id === user.id) ? null : (user.id || null);
     try {
-      const track = await this.yp.await_proc('secure_share_access_log', token, actor_id);
+      const track = await this.yp.await_proc('secure_share_access_log', token, actor_id, this.input.get(Attr.socket_id));
       const row   = toArray(track)[0] || {};
       if (row.hub_id) {
         const recipients = await this.yp.await_proc('entity_sockets', { hub_id: row.hub_id });

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -20,6 +20,7 @@ const { isEmpty } = require('lodash');
 const {
   ID_NOBODY
 } = Constants;
+const { verifyPassword: verifySecureSharePassword } = require('./lib/secure-share-password');
 
 
 //########################################
@@ -141,6 +142,7 @@ class __dmz extends Mfs {
         const secureRes = await this.yp.await_proc('secure_share_info', token);
         if (!isEmpty(secureRes) && !secureRes.failed) {
           res = secureRes;
+          delete res.password_hash;
         }
       } catch (e) {
         this.warn('[dmz.info] secure_share_info lookup failed:', e && e.message);
@@ -165,6 +167,10 @@ class __dmz extends Mfs {
    *
    */
   async _loginSecureShare(token, info) {
+    // Extract password_hash before any early returns — never expose it to the client
+    const storedPasswordHash = info.password_hash || null;
+    delete info.password_hash;
+
     if (info.validity === 'TICKET_REVOKED') {
       return this.output.data({ status: 'TICKET_REVOKED', is_secure: 1 });
     }
@@ -222,6 +228,17 @@ class __dmz extends Mfs {
 
     if (!emailValid) {
       return this.output.data({ status: 'EMAIL_MISMATCH', is_secure: 1 });
+    }
+
+    // Password gate — only evaluated after email is confirmed valid
+    if (info.require_password) {
+      const submittedPassword = (this.input.get(Attr.password) || '').trim();
+      if (!submittedPassword) {
+        return this.output.data({ status: 'REQUIRED_PASSWORD', is_secure: 1 });
+      }
+      if (!verifySecureSharePassword(submittedPassword, storedPasswordHash)) {
+        return this.output.data({ status: 'WRONG_PASSWORD', is_secure: 1 });
+      }
     }
 
     // Valid access — log it and notify sender in real time

--- a/service/lib/secure-share-password.js
+++ b/service/lib/secure-share-password.js
@@ -1,0 +1,43 @@
+/**
+ * Password hashing and verification for secure-share links.
+ * Uses Node.js built-in crypto (pbkdf2 + timingSafeEqual) — no extra dependencies.
+ */
+const { pbkdf2Sync, randomBytes, timingSafeEqual } = require('crypto');
+
+const ITERATIONS = 10000;
+const KEYLEN     = 64;
+const DIGEST     = 'sha512';
+
+/**
+ * Hash a plain-text password for storage.
+ * Returns "salt:hash" (both hex-encoded).
+ */
+function hashPassword(password) {
+  const salt = randomBytes(16).toString('hex');
+  const hash = pbkdf2Sync(password, salt, ITERATIONS, KEYLEN, DIGEST).toString('hex');
+  return `${salt}:${hash}`;
+}
+
+/**
+ * Verify a submitted password against a stored "salt:hash" string.
+ * Uses constant-time comparison to prevent timing attacks.
+ */
+function verifyPassword(submitted, stored) {
+  if (!submitted || !stored) return false;
+  const sep = stored.indexOf(':');
+  if (sep === -1) return false;
+  const salt = stored.slice(0, sep);
+  const expectedHex = stored.slice(sep + 1);
+  if (!salt || !expectedHex) return false;
+  try {
+    const derived = pbkdf2Sync(submitted, salt, ITERATIONS, KEYLEN, DIGEST).toString('hex');
+    const a = Buffer.from(expectedHex, 'hex');
+    const b = Buffer.from(derived, 'hex');
+    if (a.length !== b.length) return false;
+    return timingSafeEqual(a, b);
+  } catch {
+    return false;
+  }
+}
+
+module.exports = { hashPassword, verifyPassword };

--- a/service/media.js
+++ b/service/media.js
@@ -1236,11 +1236,15 @@ class __media extends Mfs {
       this.uid,
       { sort_by, order, page, type }
     );
+    const file_nid = this.input.get('file_nid');
+    if (file_nid) {
+      data = toArray(data).filter(item => item && item.nid === file_nid);
+    }
     this.output.list(data);
   }
 
   /**
-   * 
+   *
    */
   async show_node_by_with_size() {
     const nid = this.source_granted().id || "0";

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -50,7 +50,7 @@ class __secure_share extends Mfs {
     }
 
     const host = this.hub.get(Attr.vhost);
-    const link = `${this.input.homepath(host)}#/dmz/${token}`;
+    const link = `${this.input.homepath(host)}#/dmz/share/${token}`;
 
     if (await shouldSendNotification(this.yp, email)) {
       try {

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -50,7 +50,7 @@ class __secure_share extends Mfs {
     }
 
     const host = this.hub.get(Attr.vhost);
-    const link = `${this.input.homepath(host)}/#/dmz/${token}`;
+    const link = `${this.input.homepath(host)}#/dmz/${token}`;
 
     if (await shouldSendNotification(this.yp, email)) {
       try {

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -1,0 +1,144 @@
+/**
+ * @license
+ * Copyright 2024 Thidima SA. All Rights Reserved.
+ * Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE, Version 3 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+const {
+  Attr, Cache, Messenger, RedisStore, toArray
+} = require('@drumee/server-essentials');
+const { Mfs } = require('@drumee/server-core');
+const { isEmpty } = require('lodash');
+const { shouldSendNotification } = require('../lib/email-policy');
+
+class __secure_share extends Mfs {
+
+  /**
+   * Create a per-email unique secure share token for a file or folder.
+   * Sends an invitation email and returns the share link.
+   */
+  async create() {
+    const nid    = this.input.need(Attr.nid);
+    const email  = this.input.need(Attr.email);
+    const domain = this.input.get('domain_restriction') || '';
+    const days   = this.input.get(Attr.days)  || 0;
+    const hours  = this.input.get(Attr.hours) || 0;
+    const expiryHours = (days * 24) + (hours * 1);
+
+    const token    = this.randomString();
+    const hub_id   = this.hub.get(Attr.id);
+    const fullname = this.user.get('fullname');
+    const lang     = this.user.language() || this.input.app_language();
+
+    const row = await this.yp.await_proc(
+      'secure_share_create',
+      token, hub_id, nid, this.uid, email, domain, expiryHours
+    );
+
+    if (isEmpty(row)) {
+      return this.output.data({ status: 'CREATE_FAILED' });
+    }
+
+    const host = this.hub.get(Attr.vhost);
+    const link = `${this.input.homepath(host)}/#/dmz/${token}`;
+
+    if (await shouldSendNotification(this.yp, email)) {
+      try {
+        const attr    = await this.db.await_proc('mfs_node_attr', nid) || {};
+        const filesize = require('filesize');
+        const subject  = Cache.message('_sent_you_files', lang).format(fullname, 1);
+        const msg = new Messenger({
+          template  : 'butler/outbound',
+          subject   : `Drumee: ${subject}`,
+          recipient : email,
+          lex       : Cache.lex(lang),
+          data      : {
+            icon      : this.hub.get(Attr.icon),
+            files     : [{ filename: attr.filename || '', filesize: filesize(attr.filesize || 0) }],
+            subject   : Cache.message('_outbound_default_msg', lang).format(fullname),
+            message   : '',
+            recipient : email.replace(/@.+$/, ''),
+            signature : fullname,
+            link,
+          },
+          handler : this.exception.email
+        });
+        await msg.send();
+      } catch (e) {
+        this.warn('[secure_share.create] email send failed:', e && e.message);
+      }
+    }
+
+    this.output.data({ ...row, link });
+  }
+
+  /**
+   * List all secure share tokens created by the current user for a given node.
+   */
+  async list() {
+    const nid    = this.input.need(Attr.nid);
+    const hub_id = this.hub.get(Attr.id);
+    const rows   = await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid);
+    this.output.list(toArray(rows));
+  }
+
+  /**
+   * Revoke a secure share token (soft delete).
+   * Broadcasts a real-time event so the recipient loses access immediately.
+   */
+  async revoke() {
+    const token  = this.input.need(Attr.token);
+    const hub_id = this.hub.get(Attr.id);
+
+    const row = toArray(
+      await this.yp.await_proc('secure_share_revoke', token, this.uid)
+    )[0] || {};
+
+    // Only broadcast if the revoke actually happened (procedure returns empty otherwise)
+    if (!isEmpty(row) && row.revoked_at) {
+      try {
+        const recipients = await this.yp.await_proc('entity_sockets', { hub_id });
+        await RedisStore.sendData(
+          this.payload(
+            {
+              event           : 'secure_share_revoked',
+              token,
+              nid             : row.node_id,
+              recipient_email : row.recipient_email,
+            },
+            { service: 'share.track_event' }
+          ),
+          recipients
+        );
+      } catch (e) {
+        this.warn('[secure_share.revoke] broadcast failed:', e && e.message);
+      }
+    }
+
+    this.output.data(row);
+  }
+
+  /**
+   * Hard-delete a token. Only allowed when it is already revoked or expired.
+   */
+  async delete() {
+    const token = this.input.need(Attr.token);
+    const res   = toArray(
+      await this.yp.await_proc('secure_share_delete', token, this.uid)
+    )[0] || {};
+    this.output.data(res);
+  }
+
+}
+
+module.exports = __secure_share;

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -111,22 +111,33 @@ class __secure_share extends Mfs {
 
     // Only broadcast if the revoke actually happened (procedure returns empty otherwise)
     if (!isEmpty(row) && row.revoked_at) {
+      const eventData = {
+        event           : 'secure_share_revoked',
+        token,
+        nid             : row.node_id,
+        recipient_email : row.recipient_email,
+      };
+      const svcOpt = { service: 'share.track_event' };
+
       try {
+        // Broadcast to hub members (sender's window refreshes its list)
         const recipients = await this.yp.await_proc('entity_sockets', { hub_id });
-        await RedisStore.sendData(
-          this.payload(
-            {
-              event           : 'secure_share_revoked',
-              token,
-              nid             : row.node_id,
-              recipient_email : row.recipient_email,
-            },
-            { service: 'share.track_event' }
-          ),
-          recipients
-        );
+        await RedisStore.sendData(this.payload(eventData, svcOpt), recipients);
       } catch (e) {
-        this.warn('[secure_share.revoke] broadcast failed:', e && e.message);
+        this.warn('[secure_share.revoke] hub broadcast failed:', e && e.message);
+      }
+
+      // Also target the recipient's socket directly using the socket_id stored at
+      // access time — entity_sockets() won't include guest sockets.
+      if (row.active_socket_id) {
+        try {
+          await RedisStore.sendData(
+            this.payload(eventData, svcOpt),
+            [{ socket_id: row.active_socket_id }]
+          );
+        } catch (e) {
+          this.warn('[secure_share.revoke] recipient broadcast failed:', e && e.message);
+        }
       }
     }
 

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -88,8 +88,9 @@ class __secure_share extends Mfs {
   async list() {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
-    const rows   = await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid);
-    this.output.list(toArray(rows));
+    const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
+    const base   = this.input.homepath(this.hub.get(Attr.vhost));
+    this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 
   /**

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -20,6 +20,7 @@ const {
 const { Mfs } = require('@drumee/server-core');
 const { isEmpty } = require('lodash');
 const { shouldSendNotification } = require('../lib/email-policy');
+const { hashPassword } = require('../lib/secure-share-password');
 
 class __secure_share extends Mfs {
 
@@ -40,9 +41,12 @@ class __secure_share extends Mfs {
     const fullname = this.user.get('fullname');
     const lang     = this.user.language() || this.input.app_language();
 
+    const rawPassword = this.input.get('password') || '';
+    const passwordHash = rawPassword.trim() ? hashPassword(rawPassword.trim()) : '';
+
     const row = await this.yp.await_proc(
       'secure_share_create',
-      token, hub_id, nid, this.uid, email, domain, expiryHours
+      token, hub_id, nid, this.uid, email, domain, expiryHours, passwordHash
     );
 
     if (isEmpty(row)) {


### PR DESCRIPTION
## What

Full server-side implementation of Secure Share (CMO spec — "AHA MOMENT 1"):
> Upload → Secure Share → set expiry → restrict by email/domain → optional password → generate link → recipient opens → sender notified in real time → sender can revoke instantly.

### New files

| File | Purpose |
|---|---|
| `service/private/secure_share.js` | `create` (hash password, insert token, send invitation email), `list`, `revoke` (dual broadcast — hub members + recipient socket), `delete` |
| `service/lib/secure-share-password.js` | `hashPassword` (PBKDF2-SHA512, 10 000 iterations, 16-byte random salt) and `verifyPassword` (constant-time `timingSafeEqual`) — no external deps, uses Node.js built-in `crypto` |
| `acl/secure_share.json` | ACL definition for all 4 services (scope: `hub`, permission: `write`) |

### Modified files

| File | What changed |
|---|---|
| `service/dmz.js` | `_loginSecureShare`: email gate → **password gate** (`REQUIRED_PASSWORD` / `WRONG_PASSWORD`) → stores recipient socket via `secure_share_access_log`; `dmz.info`: strips `password_hash` before response |

### Security properties
- `password_hash` is **deleted from `info` before any spread into the HTTP response** — never reaches the client
- Password comparison uses `crypto.timingSafeEqual` to prevent timing-based attacks
- Empty password field → `NULL` in DB (no hash of empty string)
- Password gate only fires **after** email is confirmed valid — prevents email oracle attacks

### Real-time revoke flow
1. Recipient opens share → `_loginSecureShare` calls `secure_share_access_log(token, actor_id, socket_id)` → `active_socket_id` stored on the token
2. Sender revokes → `secure_share_revoke` proc returns `active_socket_id` → server broadcasts `secure_share_revoked` to:
   - **Hub members** via `entity_sockets` → sender's window refreshes the share list
   - **Recipient directly** via `[{ socket_id: row.active_socket_id }]` → bypasses hub membership check (DMZ guests are not hub members and are invisible to `entity_sockets`)

## Deploy notes

Schema patches must be applied **before** restarting the service (see schemas PR #19).

After deploy: `sudo drumee restart main/service`

## Test plan
- [ ] `secure_share.create` with no password → `password_hash` is NULL in DB
- [ ] `secure_share.create` with password → `password_hash` is a `salt:hash` string (not plain text)
- [ ] `dmz.login` on a password-protected token with no password → `REQUIRED_PASSWORD`
- [ ] `dmz.login` with wrong password → `WRONG_PASSWORD`
- [ ] `dmz.login` with correct password → `TICKET_OK` and access granted
- [ ] `dmz.info` response for any secure-share token never contains `password_hash`
- [ ] After recipient accesses share, `active_socket_id` is populated in `secure_share_token`
- [ ] Revoke → both sender window and recipient browser receive `secure_share_revoked` event