### PR TITLE
refactor(secure-share): pass JSON object to secure_share_create proc (per Somanos review)

### DIFF
--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -44,10 +44,16 @@ class __secure_share extends Mfs {
     const rawPassword = this.input.get('password') || '';
     const passwordHash = rawPassword.trim() ? hashPassword(rawPassword.trim()) : '';
 
-    const row = await this.yp.await_proc(
-      'secure_share_create',
-      token, hub_id, nid, this.uid, email, domain, expiryHours, passwordHash
-    );
+    const row = await this.yp.await_proc('secure_share_create', {
+      token,
+      hub_id,
+      node_id        : nid,
+      creator_id     : this.uid,
+      recipient_email: email,
+      domain_restriction: domain  || null,
+      expiry_hours   : expiryHours,
+      password_hash  : passwordHash || null,
+    });
 
     if (isEmpty(row)) {
       return this.output.data({ status: 'CREATE_FAILED' });


### PR DESCRIPTION
## Context

Follow-up to #32. @somanos requested during review that `secure_share_create` accept a single JSON argument. This PR updates the server-side caller to match the updated proc in drumee/schemas#20.

## What changed

The `await_proc` call in `service/private/secure_share.js` now passes a JSON object instead of 8 positional arguments:

```js
// Before
await this.yp.await_proc('secure_share_create',
  token, hub_id, nid, this.uid, email, domain, expiryHours, passwordHash
);

// After
await this.yp.await_proc('secure_share_create', {
  token,
  hub_id,
  node_id:            nid,
  creator_id:         this.uid,
  recipient_email:    email,
  domain_restriction: domain || null,
  expiry_hours:       expiryHours,
  password_hash:      passwordHash || null,
});
```

**Only `service/private/secure_share.js` is touched** — no other services, ACL, or files affected.

## Deploy

Must be deployed **together** with drumee/schemas#20 so proc and caller stay in sync.


## Test plan
- [ ] Create a secure share link (no password, with expiry) → link is generated correctly
- [ ] Create a secure share link with password → password gate works for recipient
- [ ] Create a secure share link with domain restriction → domain stored correctly