### PR TITLE
feat(seo): add poster generation for PDF documents

### DIFF
--- a/offline/media/backfill-posters.js
+++ b/offline/media/backfill-posters.js
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * @license
+ * Copyright 2024 Thidima SA. All Rights Reserved.
+ * Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE, Version 3.
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ * =============================================================================
+ */
+
+/**
+ * One-shot backfill of document content posters (first-page thumbnails).
+ *
+ * For every existing document/pdf node that has no poster yet
+ * (metadata.poster unset), this re-enqueues the node through the NORMAL
+ * indexing pipeline: indexQueue.addFile() -> (running) indexWorker ->
+ * seo_lib.index() -> generatePoster() -> writes {mfs}/thumb.png and flags
+ * the node via mfs_set_poster. It only ENQUEUES; the indexWorker process
+ * must be running to actually generate the posters.
+ *
+ * Usage:
+ *   node offline/media/backfill-posters.js                 # every hub
+ *   node offline/media/backfill-posters.js --dry-run       # count only, enqueue nothing
+ *   node offline/media/backfill-posters.js --hub=<hubHex>  # a single hub
+ *   node offline/media/backfill-posters.js --limit=500     # cap nodes per hub
+ *   node offline/media/backfill-posters.js --delay=50      # ms between enqueues (throttle)
+ *
+ * VALIDATE FIRST: run with --dry-run (optionally --hub on a test hub) before a
+ * full pass. If addFile rejects nodes, inspect the fields returned by
+ * mfs_node_attr and adjust (it must supply id, hub_id, mfs_root, extension).
+ */
+
+const Minimist = require('minimist');
+const { Mariadb } = require('@drumee/server-essentials');
+const indexQueue = require('../queues/indexQueue');
+
+// Extensions seo_lib.index() can turn into a poster (PDF + office it converts).
+const POSTER_EXTS = ['pdf', 'doc', 'docx', 'xls', 'xlsx', 'ppt', 'pptx', 'odt', 'odp'];
+const EXT_LIST = POSTER_EXTS.map((e) => `'${e}'`).join(',');
+
+const argv = Minimist(process.argv.slice(2));
+const DRY = !!argv['dry-run'];
+const ONE_HUB = argv.hub
+  ? String(argv.hub).replace(/[^0-9a-fA-F]/g, '').toLowerCase()
+  : null;
+const LIMIT = parseInt(argv.limit || '0', 10);      // 0 = no cap
+const DELAY_MS = parseInt(argv.delay || '50', 10);  // throttle between enqueues
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const firstRow = (r) => (Array.isArray(r) ? r[0] : r);
+
+async function listHubs(yp) {
+  // NOTE: entity.id is an ASCII string stored in VARBINARY — use CAST(.. AS CHAR),
+  // NOT HEX() (which double-encodes). User spaces are type='drumate' area='personal'
+  // and DO hold media, so include them alongside type='hub' (area='hub' alone misses them).
+  let sql =
+    `SELECT CAST(id AS CHAR) AS id, db_name FROM entity ` +
+    `WHERE type IN ('hub','drumate') AND status='active' ` +
+    `AND db_name IS NOT NULL AND db_name <> ''`;
+  if (ONE_HUB) sql += ` AND CAST(id AS CHAR)='${ONE_HUB}'`;
+  const rows = await yp.await_query(sql);
+  return Array.isArray(rows) ? rows : [];
+}
+
+async function processHub(hub, totals) {
+  const db = new Mariadb({ name: hub.db_name });
+  try {
+    let sql =
+      `SELECT CAST(id AS CHAR) AS id FROM media ` +
+      `WHERE category='document' AND LOWER(extension) IN (${EXT_LIST}) ` +
+      `AND (metadata IS NULL OR JSON_EXTRACT(metadata, '$.poster') IS NULL)`;
+    if (LIMIT > 0) sql += ` LIMIT ${LIMIT}`;
+    const rows = await db.await_query(sql);
+    const list = Array.isArray(rows) ? rows : [];
+    totals.found += list.length;
+    console.log(`[backfill] hub ${hub.id} (${hub.db_name}): ${list.length} node(s) missing poster`);
+    if (DRY || !list.length) return;
+
+    for (const row of list) {
+      try {
+        let node = firstRow(await db.await_proc('mfs_node_attr', row.id));
+        if (!node || !node.id || !node.hub_id) {
+          console.warn(`[backfill]   skip ${row.id}: missing node attrs`);
+          totals.errors += 1;
+          continue;
+        }
+        node.xdb = hub.db_name;
+        node.actual_db = hub.db_name;
+        node.hub_db = hub.db_name;
+        await indexQueue.addFile(node, { uid: node.owner_id, hub_id: node.hub_id });
+        totals.queued += 1;
+        if (DELAY_MS) await sleep(DELAY_MS);
+      } catch (e) {
+        totals.errors += 1;
+        console.warn(`[backfill]   enqueue ${row.id} failed: ${e.message}`);
+      }
+    }
+  } finally {
+    try { await db.end(); } catch (_) { /* ignore */ }
+  }
+}
+
+async function main() {
+  console.log(`[backfill] start dry-run=${DRY} hub=${ONE_HUB || 'ALL'} limit=${LIMIT || '∞'} delay=${DELAY_MS}ms`);
+  const yp = new Mariadb({ name: 'yp' });
+  const totals = { found: 0, queued: 0, errors: 0 };
+  try {
+    const hubs = await listHubs(yp);
+    console.log(`[backfill] ${hubs.length} hub(s) to scan`);
+    for (const hub of hubs) {
+      await processHub(hub, totals);
+    }
+  } finally {
+    try { await yp.end(); } catch (_) { /* ignore */ }
+  }
+  console.log(`[backfill] done: found=${totals.found} queued=${totals.queued} errors=${totals.errors}`);
+  // Let Bull flush queued jobs to Redis, then exit.
+  setTimeout(() => process.exit(0), 1500);
+}
+
+main().catch((e) => { console.error('[backfill] fatal:', e); process.exit(1); });

--- a/offline/media/seo_lib.js
+++ b/offline/media/seo_lib.js
@@ -296,6 +296,36 @@ class SeoIndexer {
   }
 
   /**
+   * Render the document's first page to a static content poster (thumb.png)
+   * so the file browser shows it instead of a generic icon. gm rasterizes PDF
+   * page 0 at natural aspect (the client cover+top-crops it). thumb.png is NOT
+   * in cleanup()'s temp list, so it persists. On success we flag the node
+   * (metadata.poster) so the client only shows the poster once it exists.
+   */
+  async generatePoster(pdfPath) {
+    if (!pdfPath || !existsSync(pdfPath)) return;
+    const mfs_dir = resolve(this.node.mfs_root, this.node.id);
+    const out = join(mfs_dir, 'thumb.png');
+    if (!existsSync(out)) {
+      // -density for crisp text; flatten onto white (PDF pages are transparent);
+      // -resize WxH keeps natural page aspect (no square crop / no letterbox).
+      const cmd = `gm convert -density 150 -auto-orient "${pdfPath}[0]" ` +
+        `-background white -flatten -resize 600x600 +profile "*" "${out}"`;
+      this.execCommand(cmd, 60000);
+    }
+    if (existsSync(out)) {
+      try {
+        await this.db.await_proc('mfs_set_poster', this.node.id);
+        this.log('Poster ready:', out);
+      } catch (e) {
+        this.log('mfs_set_poster failed:', e.message);
+      }
+    } else {
+      this.log('Poster not produced by gm for', pdfPath);
+    }
+  }
+
+  /**
    * Main indexing function
    */
   async index() {
@@ -305,6 +335,8 @@ class SeoIndexer {
     const src = resolve(mfs_dir, `orig.${node.extension}`);
 
     let text = '';
+    // Source PDF used to render the first-page content poster (thumb.png).
+    let posterSrc = null;
     const startTime = Date.now();
 
     try {
@@ -320,6 +352,7 @@ class SeoIndexer {
       switch (ext) {
         // PDF
         case 'pdf':
+          posterSrc = src;
           text = await this.extractFromPdf(src, index);
           break;
 
@@ -333,6 +366,7 @@ class SeoIndexer {
         case 'odt':
         case 'odp':
           const pdfPath = await this.convertToPdf(node);
+          posterSrc = pdfPath;
           text = await this.extractFromPdf(pdfPath, index);
           break;
 
@@ -362,6 +396,18 @@ class SeoIndexer {
 
         default:
           throw new Error(`Unsupported file extension: ${ext}`);
+      }
+
+      // Phase 2: render the first-page content poster while the source PDF
+      // still exists (cleanup() removes preview.pdf afterwards). Done before
+      // text validation so scanned / text-less docs still get a thumbnail;
+      // a poster failure must never abort indexing.
+      if (posterSrc) {
+        try {
+          await this.generatePoster(posterSrc);
+        } catch (e) {
+          this.log('Poster generation failed:', e.message);
+        }
       }
 
       // Validate extraction


### PR DESCRIPTION
- Implemented `generatePoster` method to create a thumbnail from the first page of PDF documents, enhancing the visual representation in file browsers.
- Integrated poster generation into the indexing process, ensuring thumbnails are created even for scanned or text-less documents.
- Added error handling for poster generation failures to maintain indexing integrity.