### PR TITLE
feat(task): folder-scoped tasks + multi-assignee (backend)

### DIFF
--- a/acl/task.json
+++ b/acl/task.json
@@ -1,12 +1,24 @@
 {
   "services": {
     "list": {
-      "doc": "List all tasks in the current hub (folder), ordered by Kanban column then rank. Returns all tasks regardless of status.",
+      "doc": "List tasks scoped to a folder node, ordered by Kanban column then rank. Returns all statuses for that folder.",
       "scope": "hub",
       "permission": {
         "src": "read"
       },
-      "params": {},
+      "params": {
+        "nid": {
+          "type": "string",
+          "required": false,
+          "doc": "Folder node id to scope to. Absent/null returns legacy unscoped (nid IS NULL) tasks."
+        },
+        "include_unscoped": {
+          "type": "number",
+          "required": false,
+          "default": 0,
+          "doc": "When 1 (workspace-root view), also include legacy tasks with no folder (nid IS NULL)."
+        }
+      },
       "returns": {
         "type": "array",
         "doc": "Array of task objects ordered by status column then rank",
@@ -20,7 +32,8 @@
             "priority": { "type": "string", "doc": "Priority: low | medium | high | urgent" },
             "due_date": { "type": "string", "doc": "Due date (YYYY-MM-DD), null if not set" },
             "created_by": { "type": "string", "doc": "UID of the user who created the task" },
-            "assignee_uid": { "type": "string", "doc": "UID of the assignee, null if unassigned" },
+            "nid": { "type": "string", "doc": "Folder node id the task belongs to, null if workspace-level (legacy)" },
+            "assignee_uids": { "type": "string", "doc": "Comma-separated list of assignee UIDs, null if unassigned" },
             "rank": { "type": "number", "doc": "Position within the status column" },
             "ctime": { "type": "number", "doc": "Unix timestamp of creation" },
             "mtime": { "type": "number", "doc": "Unix timestamp of last update" },
@@ -30,7 +43,7 @@
       }
     },
     "create": {
-      "doc": "Create a new task in the current hub (folder). The task is placed at the bottom of the target status column.",
+      "doc": "Create a new task scoped to a folder node. The task is placed at the bottom of the target status column within that folder.",
       "scope": "hub",
       "permission": {
         "src": "write"
@@ -65,10 +78,21 @@
           "required": false,
           "doc": "Due date in YYYY-MM-DD format. Optional."
         },
+        "nid": {
+          "type": "string",
+          "required": false,
+          "doc": "Folder node id the task belongs to. Absent/null = workspace-level."
+        },
+        "assignee_uids": {
+          "type": "array",
+          "required": false,
+          "doc": "UIDs of the users to assign. Optional. Each must be a valid drumate.",
+          "items": { "type": "string" }
+        },
         "assignee_uid": {
           "type": "string",
           "required": false,
-          "doc": "UID of the user to assign the task to. Optional."
+          "doc": "Deprecated single-assignee form (use assignee_uids). Still accepted."
         }
       },
       "returns": {
@@ -151,7 +175,7 @@
       ]
     },
     "update_assignee": {
-      "doc": "Assign or unassign a task. Pass assignee_uid=null to clear the assignment.",
+      "doc": "Replace a task's assignee set (multi-assignee). Pass the full new set in assignee_uids; an empty array clears all assignees.",
       "scope": "hub",
       "permission": {
         "src": "write"
@@ -162,10 +186,16 @@
           "required": true,
           "doc": "Task ID"
         },
+        "assignee_uids": {
+          "type": "array",
+          "required": false,
+          "doc": "Full new set of assignee UIDs. [] clears all. Each must be a valid drumate.",
+          "items": { "type": "string" }
+        },
         "assignee_uid": {
           "type": "string",
           "required": false,
-          "doc": "UID of the user to assign the task to. Null to unassign."
+          "doc": "Deprecated single-assignee form (use assignee_uids). Still accepted; null unassigns."
         }
       },
       "returns": {

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -55,11 +55,51 @@ class __private_task extends Entity {
   }
 
   /**
-   * List all tasks in the current hub (folder), ordered by status column then rank.
+   * List tasks scoped to a folder node.
+   * Params: nid (folder node id; null/absent = legacy unscoped), include_unscoped
+   * (1 on the workspace-root view to also surface legacy nid-less tasks).
    */
   async list() {
-    const data = await this.db.await_proc('task_list');
+    const nid = this.input.use('nid', null);
+    const include_unscoped = this.input.use('include_unscoped', 0) ? 1 : 0;
+    // await_run (not await_proc) preserves a JS null nid when binding.
+    const data = await this.db.await_run(
+      'CALL task_list(?, ?)',
+      [nid, include_unscoped]
+    );
     this.output.list(data);
+  }
+
+  /**
+   * Validate that every uid in the list references a real drumate.
+   * Returns the de-duplicated, cleaned uid array, or throws a user exception.
+   */
+  async _validateAssignees(uids) {
+    const clean = [];
+    for (const uid of uids) {
+      if (!uid) continue;
+      if (clean.includes(uid)) continue;
+      const drumate = await this.yp.await_proc('drumate_exists', uid);
+      if (isEmpty(drumate)) {
+        this.exception.user('INVALID_ASSIGNEE');
+        return null;
+      }
+      clean.push(uid);
+    }
+    return clean;
+  }
+
+  /**
+   * Read the assignee set from the request, accepting the multi-assignee
+   * `assignee_uids` array and falling back to the legacy single `assignee_uid`.
+   * Returns null when the caller supplied neither key (i.e. "unchanged").
+   */
+  _readAssignees() {
+    const raw = this.input.use('assignee_uids', null);
+    if (raw != null) return toArray(raw);
+    const single = this.input.use('assignee_uid', null);
+    if (single != null) return single ? [single] : [];
+    return null;
   }
 
   /**
@@ -72,25 +112,30 @@ class __private_task extends Entity {
     let status = this.input.use(Attr.status, 'todo');
     let priority = this.input.use('priority', 'medium');
     const due_date = this.input.use('due_date', null);
-    const assignee_uid = this.input.use('assignee_uid', null);
+    // Folder scope: media node id of the folder the task belongs to (nullable).
+    const nid = this.input.use('nid', null);
+    // Multi-assignee: array (or legacy single). null/[] = unassigned.
+    const assignees = (await this._validateAssignees(this._readAssignees() || []));
+    if (assignees == null) return; // invalid assignee — exception already raised
 
     if (!VALID_STATUSES.includes(status)) status = 'todo';
     if (!VALID_PRIORITIES.includes(priority)) priority = 'medium';
 
-    if (assignee_uid) {
-      const drumate = await this.yp.await_proc('drumate_exists', assignee_uid);
-      if (isEmpty(drumate)) {
-        return this.exception.user('INVALID_ASSIGNEE');
-      }
-    }
-
     const id = await this.yp.await_func('uniqueId');
     // Bypass `await_proc` which coerces JS null to '' before binding —
     // STRICT_TRANS_TABLES rejects '' for nullable DATE / VARCHAR columns.
-    const data = await this.db.await_run(
+    let data = await this.db.await_run(
       'CALL task_create(?, ?, ?, ?, ?, ?, ?, ?)',
-      [id, title, description, status, priority, due_date, this.uid, assignee_uid]
+      [id, title, description, status, priority, due_date, this.uid, nid]
     );
+    if (assignees.length) {
+      // Re-reads the row with assignee_uids populated, so the response/broadcast
+      // reflect the assignments.
+      data = await this.db.await_run(
+        'CALL task_set_assignees(?, ?)',
+        [id, assignees.join(',')]
+      );
+    }
     await this._broadcast('task.create', data);
     this.output.data(data);
   }
@@ -144,23 +189,18 @@ class __private_task extends Entity {
   }
 
   /**
-   * Assign / unassign a task.
-   * Params: id (required), assignee_uid (required — pass null to unassign).
+   * Replace a task's assignee set (multi-assignee).
+   * Params: id (required); assignee_uids (array — the full new set; [] clears
+   * all). Legacy single `assignee_uid` is still accepted.
    */
   async update_assignee() {
     const id = this.input.need(Attr.id);
-    const assignee_uid = this.input.use('assignee_uid', null);
-
-    if (assignee_uid) {
-      const drumate = await this.yp.await_proc('drumate_exists', assignee_uid);
-      if (isEmpty(drumate)) {
-        return this.exception.user('INVALID_ASSIGNEE');
-      }
-    }
+    const assignees = await this._validateAssignees(this._readAssignees() || []);
+    if (assignees == null) return; // invalid assignee — exception already raised
 
     const data = await this.db.await_run(
-      'CALL task_update_assignee(?, ?)',
-      [id, assignee_uid]
+      'CALL task_set_assignees(?, ?)',
+      [id, assignees.join(',')]
     );
     if (isEmpty(data)) {
       return this.exception.user('TASK_NOT_FOUND');


### PR DESCRIPTION
- list: accept nid + include_unscoped; create: accept nid + assignee_uids[]
- update_assignee: replace full assignee set (multi); legacy single still accepted
- validate every assignee uid via drumate_exists
- ACL: document nid / include_unscoped / assignee_uids params + assignee_uids return