### PR TITLE
fix(dmz): navigate sharebox to file location when Share link targets a specific file

### DIFF
--- a/service/dmz.js
+++ b/service/dmz.js
@@ -419,11 +419,11 @@ class __dmz extends Mfs {
       try {
         const nodeRows = await this.yp.await_proc('forward_proc', info.hub_id, 'mfs_node_attr', `'${req_file_nid}'`);
         const nodeAttr = toArray(nodeRows)[0] || {};
-        if (nodeAttr.pid && nodeAttr.filetype !== 'folder' && nodeAttr.filetype !== 'hub'
-            && nodeAttr.pid !== info.nid) {
-          // File is inside a subfolder — navigate to that folder so the file
-          // appears in the listing. Skip when already at workspace root to
-          // preserve the existing "show all files" UX for root-level files.
+        if (nodeAttr.pid && nodeAttr.filetype !== 'folder' && nodeAttr.filetype !== 'hub') {
+          // Set file_nid so show_node_by filters to just this file (fast,
+          // works for both root and subfolder files).
+          // For root files out.nid stays workspace root (nodeAttr.pid === info.nid);
+          // for subfolder files out.nid becomes the parent folder.
           out.file_nid = req_file_nid;
           out.nid = nodeAttr.pid;
         }

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -410,6 +410,28 @@ class __dmz extends Mfs {
     }
     let out = { ...user, ...info, guest_id: info.uid, area, is_guest };
 
+    // If a specific file nid is provided (Share button URL has /<file_nid>/play),
+    // navigate to its parent folder — same pattern as _loginSecureShare.
+    // Validate as 16-char hex before any DB call to prevent SQL injection.
+    const req_file_nid = this.input.use('file_nid');
+    const NID_RE = /^[0-9a-f]{16}$/;
+    if (NID_RE.test(req_file_nid) && out.validity === 'TICKET_OK') {
+      try {
+        const nodeRows = await this.yp.await_proc('forward_proc', info.hub_id, 'mfs_node_attr', `'${req_file_nid}'`);
+        const nodeAttr = toArray(nodeRows)[0] || {};
+        if (nodeAttr.pid && nodeAttr.filetype !== 'folder' && nodeAttr.filetype !== 'hub'
+            && nodeAttr.pid !== info.nid) {
+          // File is inside a subfolder — navigate to that folder so the file
+          // appears in the listing. Skip when already at workspace root to
+          // preserve the existing "show all files" UX for root-level files.
+          out.file_nid = req_file_nid;
+          out.nid = nodeAttr.pid;
+        }
+      } catch (e) {
+        this.warn('[dmz.login] file_nid navigation failed:', e && e.message);
+      }
+    }
+
     // Track link_opened
     try {
       const actor_id = is_guest ? null : (user.id || null);


### PR DESCRIPTION
## Summary

- `dmz.login` now reads an optional `file_nid` param sent by the UI when a share URL contains `/<file_nid>/play`
- Resolves the file's parent folder via `mfs_node_attr`, sets `out.nid = parent_folder` and `out.file_nid = file_nid` on the response
- `show_node_by` on the client then filters to just that one file, and `checkAutoRun()` finds and opens it
- Mirrors the identical pattern already in `_loginSecureShare`
- Input validated as `/^[0-9a-f]{16}$/` before any DB call (SQL injection prevention)
- All existing flows (workspace-level links, password-protected, secure-share, meeting) are unchanged — the new block only runs when `file_nid` is provided AND `validity === 'TICKET_OK'`

## Root cause

When the Share button is clicked on a file inside a shared workspace, `viewerLink()` generates a URL of the form `.../#/dmz/share/<token>/<file_nid>/play`. Previously `dmz.login` always returned the workspace root nid, so `show_node_by` listed root-level files only. Files in subfolders were never found by `checkAutoRun()` (empty listing). Root-level files were also not found if the workspace root happened to show empty.

## Known limitation (separate bug)

Subfolder markdown files: `editor_markdown._loadContent` calls `xhRequest` to the vhost path `/subfolder/file.md` which fails in DMZ context (pre-existing file-serving limitation, not introduced by this PR). Filed separately.

## Test plan

- [ ] Share button on a file at workspace root → link opens sharebox → file shown → auto-opens
- [ ] Share button on a file in a subfolder → link opens sharebox → file shown → auto-opens
- [ ] Workspace-level share link (no `/<nid>/play`) → sharebox opens normally, unchanged
- [ ] Password-protected share → REQUIRED_PASSWORD still returned, unchanged
- [ ] Secure-share token → `_loginSecureShare` still handles it, unchanged