### PR TITLE
fix(dmz): isolate hub session cookie from regsid to prevent identity corruption

### DIFF
--- a/client/page.js
+++ b/client/page.js
@@ -3,6 +3,7 @@ const { RuntimeEnv } = require('@drumee/server-core');
 const { resolve, join } = require("path");
 const { readFileSync, existsSync } = require("fs");
 const { readFileSync: readJsonSync } = require("jsonfile");
+const { randomBytes } = require('crypto');
 const {
   DrumeeCache, sysEnv, Permission, Attr, Events, nullValue, getUiInfo, toArray
 } = require("@drumee/server-essentials/lib");
@@ -87,6 +88,19 @@ class MainPage extends RuntimeEnv {
       data.icon = `${endpoint_path}/avatar/${data.owner_id}?type=vignette`;
       keysel = this.hub.get(Attr.id);
       host = this.input.host();
+      // The hub cookie must use its own independent session so that
+      // cookie_touch in dmz.login (which sets uid = dmz guest) cannot
+      // overwrite the authenticated user's regsid session and force a
+      // login prompt when they navigate back.  Reuse an existing separate
+      // hub session if one is already in place; otherwise issue a fresh
+      // one — dmz.login's cookie_touch will register it in the session store.
+      const regsidVal = this.input.cookie(Attr.regsid);
+      const existingHubSid = this.input.cookie(keysel);
+      if (!existingHubSid || existingHubSid === regsidVal) {
+        id = randomBytes(16).toString('hex');
+      } else {
+        id = existingHubSid;
+      }
     }
 
     if (nullValue(keysel)) keysel = Attr.regsid;

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -270,6 +270,8 @@ class __dmz extends Mfs {
     // mirrors the cookie_touch done for normal DMZ tokens at login line 330.
     // socket_id must be passed so entity_sockets() includes this guest socket in
     // hub broadcasts (e.g. secure_share_revoked) — same pattern as session.dmz_login.
+    // Safe: page.js ensures the hub cookie always has its own independent session id,
+    // so this UPDATE never touches the authenticated user's regsid row.
     if (info.creator_id) {
       try {
         await this.yp.await_proc('cookie_touch', {


### PR DESCRIPTION
## Summary

- **Root cause**: `refreshAuthorization` in `client/page.js` was setting the hub cookie (`keysel = hub_id`) to the same session ID as the user's `regsid`. When `dmz.login` called `cookie_touch(uid = creator_id)` on that shared session, it executed `UPDATE cookie SET uid = <creator_id> WHERE id = <regsid_session>` — overwriting the authenticated user's main session with the creator's identity (the Natrix→Theo incident on 2026-06-03).
- **Fix (`client/page.js`)**: For DMZ/share pages, generate a fresh `crypto.randomBytes(16)` session ID for the hub cookie when it would otherwise share a value with `regsid`. `cookie_touch` in `dmz.login` only ever updates the isolated hub session — the `regsid` row is structurally unreachable.
- **Doc (`service/dmz.js`)**: Two comment lines explain why `cookie_touch(uid = creator_id)` is safe after this fix, preventing a future regression.

## Test plan

- [ ] Open a secure-share link as a logged-in Drumee user — account must NOT switch to creator's identity on reload
- [ ] Open a normal DMZ share link as a logged-in user — same check
- [ ] Open a share link as an anonymous guest — content loads normally
- [ ] After visiting a share link, navigate back to main workspace — own account intact
- [ ] Returning visitor with an already-independent hub session cookie — it is reused, no new session generated