### PR TITLE
fix(channel): promote staged folder attachments on post

### DIFF
--- a/acl/channel.json
+++ b/acl/channel.json
@@ -240,6 +240,16 @@
           "required": false,
           "doc": "Array of file node IDs to attach to the message. Files are moved to the message directory in the sharebox hub."
         },
+        "nid": {
+          "type": "string",
+          "required": false,
+          "doc": "Folder node ID for folder-scoped posts. Scopes the message to that folder and enables folder_attachment promotion."
+        },
+        "folder_attachment": {
+          "type": "array",
+          "required": false,
+          "doc": "Subset of attachment: staged device uploads to move into the folder identified by nid on send. Each node must sit in the hub chat staging directory, be owned by the caller, and the caller must hold write permission on the destination folder; otherwise the node is kept as a regular sbox-only attachment."
+        },
         "socket_id": {
           "type": "string",
           "required": true,

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -15,12 +15,14 @@
  * =============================================================================
  */
 
-const { Attr, RedisStore, toArray } = require("@drumee/server-essentials");
-const { Entity, MfsTools } = require("@drumee/server-core");
-const { remove_node, move_node, copy_node } = MfsTools;
+const {
+  Attr, RedisStore, toArray
+} = require("@drumee/server-essentials");
+const { Entity, MfsTools } = require('@drumee/server-core');
+const { remove_node, move_node, copy_node, } = MfsTools;
 
 const { stringify } = JSON;
-const { isEmpty } = require("lodash");
+const { isEmpty } = require('lodash');
 const Crypto = require("crypto");
 
 /** ========================================== */
@@ -34,7 +36,6 @@ class __private_channel extends Entity {
     this.read = this.read.bind(this);
     this.notify_chat = this.notify_chat.bind(this);
     this.acknowledge = this.acknowledge.bind(this);
-    this.typing = this.typing.bind(this);
     this.bookmark_add = this.bookmark_add.bind(this);
     this.bookmark_remove = this.bookmark_remove.bind(this);
     this.bookmark_list = this.bookmark_list.bind(this);
@@ -48,52 +49,40 @@ class __private_channel extends Entity {
   }
 
   /**
-   *
+   * 
    */
   notify_chat() {
-    this.db.call_proc("channel_notify_messages", this.uid, this.output.data);
+    this.db.call_proc('channel_notify_messages', this.uid, this.output.data);
   }
 
   /**
-   *
-   * @returns
+   * 
+   * @returns 
    */
   async _get_wicket(uid) {
     let sbox = await this.db.call_proc("mfs_wicket_home", uid);
-    if (sbox && sbox[5]) {
-      /** Created by desk_create_hub */
-      return sbox[5];
+    if (sbox && sbox[5]) { /** Created by desk_create_hub */
+      return sbox[5]
     }
     return sbox;
   }
   /**
-   *
+   * 
    */
   async messages() {
-    const order = this.input.use(Attr.order, "asc");
+    const order = this.input.use(Attr.order, 'asc');
     const page = this.input.use(Attr.page) || 1;
     const nid = this.input.use(Attr.nid);
-    let data = await this.db.await_proc(
-      "channel_list_messages",
-      this.uid,
-      "date",
-      order,
-      page,
-    );
+    let data = await this.db.await_proc('channel_list_messages', this.uid, 'date', order, page);
     data = toArray(data);
     if (!isEmpty(nid)) {
       // Legacy messages (no _scope_nid) appear in every folder context for
       // backward compatibility. New messages scoped via _scope_nid stay isolated.
-      data = data.filter((msg) => {
+      data = data.filter(msg => {
         try {
-          const meta =
-            typeof msg.metadata === "string"
-              ? JSON.parse(msg.metadata)
-              : msg.metadata || {};
+          const meta = typeof msg.metadata === 'string' ? JSON.parse(msg.metadata) : (msg.metadata || {});
           return !meta._scope_nid || meta._scope_nid === `${nid}`;
-        } catch (e) {
-          return true;
-        }
+        } catch (e) { return true; }
       });
     }
     let messages = [];
@@ -101,47 +90,30 @@ class __private_channel extends Entity {
     let cache = {};
     let hub_id = this.hub.get(Attr.id);
     for (let message of data) {
-      message.entity = { id: this.uid };
+
+      message.entity = { id: this.uid }
       if (message.author_id != this.uid) {
         let key = message.author_id;
 
         if (cache[key]) {
           message.entity = cache[key];
-        } else {
-          message.entity = await this.yp.await_proc(
-            "forward_proc",
-            this.uid,
-            "shareroom_contact_get",
-            `'${message.author_id}'`,
-          );
+        }
+        else {
+          message.entity = await this.yp.await_proc('forward_proc', this.uid, 'shareroom_contact_get', `'${message.author_id}'`)
           cache[key] = message.entity;
+
         }
       }
       if (!isEmpty(message.thread_id)) {
-        message.thread = await this.threadInfo(message.thread_id, hub_id);
+        message.thread = await this.threadInfo(message.thread_id, hub_id)
       }
-      messages.push(message);
+      messages.push(message)
     }
-
-    let newest = null;
-    for (const m of messages) {
-      if (!newest || (m.ctime || 0) > (newest.ctime || 0)) newest = m;
-    }
-    if (newest && newest.message_id) {
-      await this.db.await_proc(
-        "channel_read_messages",
-        newest.message_id,
-        this.uid,
-      );
-    }
-    let dest = await this.yp.await_proc("entity_sockets", hub_id);
+    let dest = await this.yp.await_proc('entity_sockets', hub_id);
     dest = toArray(dest).filter((e) => {
       return e.uid != this.uid;
-    });
-    await RedisStore.sendData(
-      this.payload(messages, { service: "channel.acknowledge" }),
-      dest,
-    );
+    })
+    await RedisStore.sendData(this.payload(messages, { service: "channel.acknowledge" }), dest);
 
     // Why do we need to inform the reader ?
     // dest = await this.yp.await_proc('user_sockets', this.uid);
@@ -150,94 +122,71 @@ class __private_channel extends Entity {
     // await RedisStore.sendData(this.payload(model, { service: "messages.read" }), dest);
 
     this.output.list(messages);
+
   }
 
   /**
-   * To get the  Attachments or media details for a array of ids
+   * To get the  Attachments or media details for a array of ids 
    * @params {string[]} attachments - array of the media ids (nid)
    * @params {string} uid - hubid of the media
-   * @todo Need to add to globle function
+   * @todo Need to add to globle function 
    */
   async _getAttachmentsInfo(attachments, uid) {
     let files = [];
     attachments = toArray(attachments);
     for (let media of attachments) {
       let file = await this._getAttachmentInfo(uid, media);
-      files.push(file);
+      files.push(file)
     }
     return files;
   }
 
   /**
-   * To get the  Attachment or media details for a  ids
+   * To get the  Attachment or media details for a  ids 
    * @params {string} uid - hubid of the media
    * @params {string} mediaId - id of a media (nid)
-   * @todo Need to add to globle function
+   * @todo Need to add to globle function 
    */
   async _getAttachmentInfo(uid, media) {
-    let attr;
-    if (typeof media.hub_id !== "undefined") {
-      attr = await this.yp.await_proc(
-        "forward_proc",
-        media.hub_id,
-        "mfs_access_node",
-        `'${uid}', '${media.nid}'`,
-      );
+    let attr
+    if (typeof media.hub_id !== 'undefined') {
+      attr = await this.yp.await_proc('forward_proc', media.hub_id, 'mfs_access_node', `'${uid}', '${media.nid}'`)
     } else {
-      attr = await this.db.await_proc("mfs_access_node", uid, media);
+      attr = await this.db.await_proc('mfs_access_node', uid, media);
     }
     return this.output.sanitize(attr);
   }
 
-  async move_attachemnt(
-    sbox,
-    desdir,
-    attachment,
-    message_id,
-    copy_only = false,
-  ) {
-    let src = [];
-    message_id = [message_id];
+
+  async move_attachemnt(sbox, desdir, attachment, message_id, copy_only = false) {
+    let src = []
+    message_id = [message_id]
     for (let media of attachment) {
-      src.push({ nid: media, hub_id: this.hub.get(Attr.id) });
+      src.push({ nid: media, hub_id: this.hub.get(Attr.id) })
     }
 
-    const proc = copy_only ? "mfs_copy_all" : "mfs_move_all";
-    let data = await this.db.call_proc(
-      proc,
-      stringify(src),
-      this.hub.get(Attr.id),
-      desdir.id,
-      sbox.hub_id,
-    );
+    const proc = copy_only ? 'mfs_copy_all' : 'mfs_move_all';
+    let data = await this.db.call_proc(proc, stringify(src), this.hub.get(Attr.id), desdir.id, sbox.hub_id);
     data = toArray(data);
 
-    let tempattachment = [];
+    let tempattachment = []
     for (let node of data) {
-      let dest = {};
+      let dest = {}
       switch (node.action) {
-        case "move":
+        case 'move':
           src = { nid: node.nid, mfs_root: node.src_mfs_root };
-          dest = {
-            nid: node.des_id,
-            hub_id: sbox.hub_id,
-            mfs_root: node.des_mfs_root,
-          };
-          tempattachment.push({ hub_id: sbox.hub_id, nid: node.des_id });
+          dest = { nid: node.des_id, hub_id: sbox.hub_id, mfs_root: node.des_mfs_root };
+          tempattachment.push({ hub_id: sbox.hub_id, nid: node.des_id })
           if (copy_only) {
             await copy_node(src, dest, 1);
           } else {
             await move_node(src, dest);
           }
           break;
-        case "copy":
+        case 'copy':
           src = { nid: node.nid, mfs_root: node.src_mfs_root };
-          dest = {
-            nid: node.des_id,
-            hub_id: sbox.hub_id,
-            mfs_root: node.des_mfs_root,
-          };
-          tempattachment.push({ hub_id: sbox.hub_id, nid: node.des_id });
+          dest = { nid: node.des_id, hub_id: sbox.hub_id, mfs_root: node.des_mfs_root };
+          tempattachment.push({ hub_id: sbox.hub_id, nid: node.des_id })
           await copy_node(src, dest, 1);
       }
     }
@@ -245,12 +194,8 @@ class __private_channel extends Entity {
     if (!copy_only) {
       for (let node of data) {
         switch (node.action) {
-          case "delete":
-            src = {
-              nid: node.nid,
-              hub_id: sbox.hub_id,
-              mfs_root: node.src_mfs_root,
-            };
+          case 'delete':
+            src = { nid: node.nid, hub_id: sbox.hub_id, mfs_root: node.src_mfs_root };
             await remove_node(src, 1);
         }
       }
@@ -259,279 +204,350 @@ class __private_channel extends Entity {
     // pushing both here would render each attachment twice in the chat.
     if (!copy_only && this.hub.get(Attr.id) != this.uid) {
       for (let media of attachment) {
-        tempattachment.push({ nid: media, hub_id: this.hub.get(Attr.id) });
+        tempattachment.push({ nid: media, hub_id: this.hub.get(Attr.id) })
       }
     }
     return tempattachment;
   }
 
   /**
-   *
-   * @param {*} thread_id
-   * @param {*} uid
-   * @returns
+   * Folder-scoped posts: split staged attachments (/__chat__/__upload__/)
+   * into device uploads (client asked to promote them into the folder via
+   * folder_attachment) and workspace copies (link-only, purged after send).
+   * Staging is writable by every hub member, so each node must be anchored
+   * to the hub's real chat_upload_id parent AND owned by the caller —
+   * a client-supplied id alone authorizes nothing.
+   */
+  async _classify_staged_attachment(attachment, folder_attachment) {
+    const res = { device: [], workspace: [] };
+    let mfs_home = await this.db.call_proc('mfs_home');
+    const staging_id = mfs_home && mfs_home.chat_upload_id;
+    if (!staging_id) return res;
+    const wanted = new Set(toArray(folder_attachment).map(String));
+    for (let nid of toArray(attachment)) {
+      let rows = await this.db.await_query(
+        'SELECT id, parent_id, owner_id, origin_id, category FROM media WHERE id=?', `${nid}`
+      );
+      let node = toArray(rows)[0];
+      // Anchor on the actual staging parent — not a file_path substring,
+      // which a user-created folder literally named __chat__ could spoof.
+      if (!node || `${node.parent_id}` !== `${staging_id}`) continue;
+      if (['folder', 'hub'].includes(node.category)) continue;
+      if (`${node.owner_id}` !== `${this.uid}` && `${node.origin_id}` !== `${this.uid}`) {
+        this.warn('channel.post: staged attachment not owned by caller', nid);
+        continue;
+      }
+      if (wanted.has(`${nid}`)) {
+        res.device.push(`${nid}`);
+      } else {
+        res.workspace.push(`${nid}`);
+      }
+    }
+    return res;
+  }
+
+  /**
+   * Move staged device uploads into the scoped folder so the original lands
+   * in the folder's Files tab, exactly like a direct upload would have.
+   * Same-hub moves keep the node id (mfs_move_all only updates parent_id);
+   * a cross-hub move re-creates the node, so remap old id -> des_id.
+   */
+  async _promote_staged_to_folder(deviceNids, folderNid) {
+    const hub_id = this.hub.get(Attr.id);
+    const src = deviceNids.map((nid) => ({ nid, hub_id }));
+    let data = await this.db.call_proc('mfs_move_all', stringify(src), this.uid, folderNid, hub_id);
+    data = toArray(data);
+    const remap = {};
+    for (let node of data) {
+      if (node.action === 'move' && node.des_id) {
+        await move_node(
+          { nid: node.nid, mfs_root: node.src_mfs_root },
+          { nid: node.des_id, hub_id, mfs_root: node.des_mfs_root }
+        );
+        remap[`${node.nid}`] = `${node.des_id}`;
+      }
+      // 'show'/'same' rows = same-hub move: parent updated in place, no
+      // physical relocation, id unchanged.
+    }
+    return remap;
+  }
+
+  /**
+   * Promotion is confirmed by the node actually sitting under the folder —
+   * not by the SP returning without error.
+   */
+  async _confirm_promoted(nids, folderNid) {
+    const confirmed = [];
+    for (let nid of toArray(nids)) {
+      try {
+        let rows = await this.db.await_query(
+          'SELECT id FROM media WHERE id=? AND parent_id=?', `${nid}`, `${folderNid}`
+        );
+        if (!isEmpty(toArray(rows))) confirmed.push(`${nid}`);
+      } catch (e) {
+        this.warn('channel.post: promotion confirm failed', nid, e && e.message);
+      }
+    }
+    return confirmed;
+  }
+
+  /**
+   * Staged workspace copies are duplicates (the original never left the
+   * desk) — delete them only AFTER the message and its attachment records
+   * are committed, so a failed post can still be retried from staging.
+   */
+  async _purge_staged_copies(nids) {
+    if (isEmpty(nids)) return;
+    let mfs_home = await this.db.call_proc('mfs_home');
+    if (!mfs_home || !mfs_home.home_dir) return;
+    for (let nid of nids) {
+      try {
+        await this.db.await_proc('mfs_attachment_remove', nid);
+        await remove_node({
+          nid,
+          hub_id: this.hub.get(Attr.id),
+          mfs_root: `${mfs_home.home_dir}/__storage__/`,
+        });
+      } catch (e) {
+        this.warn('channel.post: failed to purge staged copy', nid, e && e.message);
+      }
+    }
+  }
+
+  /**
+   * Folder windows live-append nodes from "media.new" payloads
+   * (window/utils handleWsEvent) — the chat broadcast alone never reaches
+   * the Files tab. Mirrors media.sendNodeAttributes.
+   */
+  async _notify_folder_new_nodes(nids, folderNid) {
+    if (isEmpty(nids)) return;
+    const hub_id = this.hub.get(Attr.id);
+    let recipients = toArray(await this.yp.await_proc('entity_sockets', { hub_id }));
+    if (isEmpty(recipients)) return;
+    for (let nid of nids) {
+      const nodes = {};
+      for (let r of recipients) {
+        if (!r || !r.uid) continue;
+        let attr = nodes[r.uid] ||
+          (await this.db.await_proc('mfs_access_node', r.uid, nid));
+        nodes[r.uid] = attr;
+        if (isEmpty(attr) || !attr.nid) continue;
+        try {
+          await RedisStore.sendData(this.payload(attr, { service: 'media.new' }), r);
+        } catch (e) {
+          this.warn('channel.post: media.new notify failed', nid, e && e.message);
+        }
+      }
+    }
+  }
+
+  /**
+   * 
+   * @param {*} thread_id 
+   * @param {*} uid 
+   * @returns 
    */
   async threadInfo(thread_id, uid) {
-    let thread = {};
-    let data = await this.yp.await_proc(
-      "forward_proc",
-      uid,
-      "channel_get",
-      `'${thread_id}'`,
-    );
+    let thread = {}
+    let data = await this.yp.await_proc('forward_proc', uid, 'channel_get', `'${thread_id}'`)
 
     if (isEmpty(data)) {
-      thread.message = "DELETED";
-      thread.message_id = data.message_id;
+      thread.message = 'DELETED'
+      thread.message_id = data.message_id
       return thread;
     }
 
-    thread.message = data.message;
-    thread.message_id = data.message_id;
-    thread.is_attachment = 0;
+    thread.message = data.message
+    thread.message_id = data.message_id
+    thread.is_attachment = 0
     if (!isEmpty(data.attachment)) {
-      thread.is_attachment = 1;
+      thread.is_attachment = 1
     }
-    thread.author_id = data.author_id;
-    thread.entity = await this.yp.await_proc(
-      "forward_proc",
-      this.uid,
-      "shareroom_contact_get",
-      `'${data.author_id}'`,
-    );
+    thread.author_id = data.author_id
+    thread.entity = await this.yp.await_proc('forward_proc', this.uid, 'shareroom_contact_get', `'${data.author_id}'`)
 
     return thread;
   }
 
   /**
-   *
+   * 
    */
   async list_tickets() {
-    let status = this.input.use(Attr.status) || ["new"];
+    let status = this.input.use(Attr.status) || ['new'];
     const page = this.input.use(Attr.page) || 1;
     const search_ticket_id = this.input.use(Attr.ticket_id);
 
     let filter = {};
     let tickets = [];
-    filter.status = status;
+    filter.status = status
     if (!isEmpty(search_ticket_id)) {
-      filter.search_ticket_id = search_ticket_id;
+      filter.search_ticket_id = search_ticket_id
     }
 
     let sbox = await this._get_wicket(this.uid);
-    let data = await this.yp.await_proc(
-      "forward_proc",
-      sbox.hub_id,
-      "ticket_list",
-      `'${this.uid}','${stringify(filter)}','${page}'`,
-    );
+    let data = await this.yp.await_proc('forward_proc', sbox.hub_id, 'ticket_list', `'${this.uid}','${stringify(filter)}','${page}'`)
 
     data = toArray(data);
 
     for (let ticket of data) {
-      ticket.metadata = this.parseJSON(ticket.metadata);
-      tickets.push(ticket);
+      ticket.metadata = this.parseJSON(ticket.metadata)
+      tickets.push(ticket)
     }
-    this.output.data(tickets);
+    this.output.data(tickets)
   }
 
   /**
-   *
-   * @returns
+   * 
+   * @returns 
    */
   async update_ticket() {
     const ticket_id = this.input.need(Attr.ticket_id);
     let status = this.input.use(Attr.status);
     let res = {};
     let metadata = {};
-    let support_domain_id = Cache.getSysConf("support_domain");
-    let my_org = await this.yp.await_proc("my_organisation", this.uid);
+    let support_domain_id = Cache.getSysConf('support_domain');
+    let my_org = await this.yp.await_proc('my_organisation', this.uid)
 
     if (my_org.domain_id != support_domain_id) {
-      res.status = "INVALID_DOMAIN";
+      res.status = 'INVALID_DOMAIN'
       return this.output.data(res);
     }
 
-    if (!isEmpty(status)) {
-      metadata.status = status;
-    }
-    let ticket = await this.yp.await_proc("ticket_detail", ticket_id);
+    if (!isEmpty(status)) { metadata.status = status }
+    let ticket = await this.yp.await_proc('ticket_detail', ticket_id);
     if (isEmpty(ticket)) {
-      res.status = "INVALID_TICKET";
+      res.status = 'INVALID_TICKET'
       return this.output.data(res);
     }
-    ticket = await this.yp.call_proc(
-      "ticket_update_metadata",
-      ticket_id,
-      metadata,
-    );
-    ticket.metadata = this.parseJSON(ticket.metadata);
+    ticket = await this.yp.call_proc('ticket_update_metadata', ticket_id, metadata);
+    ticket.metadata = this.parseJSON(ticket.metadata)
 
-    let recipients = await this.yp.await_proc("user_sockets", ticket.uid);
+    let recipients = await this.yp.await_proc('user_sockets', ticket.uid);
     await RedisStore.sendData(this.payload(ticket), recipients);
 
-    let support = await this.yp.call_proc(
-      "member_list_all",
-      "all",
-      Cache.getSysConf("support_domain"),
-    );
+    let support = await this.yp.call_proc('member_list_all', 'all', Cache.getSysConf('support_domain'));
     support = toArray(support);
 
     for (let member of support) {
-      let recipients = await this.yp.await_proc(
-        "user_sockets",
-        member.drumate_id,
-      );
+      let recipients = await this.yp.await_proc('user_sockets', member.drumate_id);
       await RedisStore.sendData(this.payload(ticket), recipients);
     }
     this.output.data(ticket);
   }
 
   /**
-   *
+   * 
    */
   async show_ticket() {
     const page = this.input.use(Attr.page) || 1;
     const ticket_id = this.input.need(Attr.ticket_id);
 
-    let ticket = await this.yp.await_proc("ticket_detail", ticket_id);
-    let sbox = await this.yp.await_proc(
-      "forward_proc",
-      ticket.uid,
-      "mfs_wicket_home",
-      `'${ticket.uid}'`,
-    );
-    if (sbox[5]) {
-      /** Created by desk_create_hub */
-      sbox = { ...sbox[5] };
+    let ticket = await this.yp.await_proc('ticket_detail', ticket_id);
+    let sbox = await this.yp.await_proc('forward_proc', ticket.uid, 'mfs_wicket_home', `'${ticket.uid}'`);
+    if (sbox[5]) { /** Created by desk_create_hub */
+      sbox = { ...sbox[5] }
     }
 
-    let data = await this.yp.await_proc(
-      "forward_proc",
-      sbox.hub_id,
-      "ticket_show",
-      `${ticket_id},'${this.uid}','${page}'`,
-    );
+    let data = await this.yp.await_proc('forward_proc', sbox.hub_id, 'ticket_show', `${ticket_id},'${this.uid}','${page}'`)
     data = toArray(data);
 
     let messages = [];
     for (let message of data) {
       if (message.is_seen == 1 && message.is_notify == 1) {
-        let support = await this.yp.call_proc(
-          "member_list_all",
-          this.uid,
-          Cache.getSysConf("support_domain"),
-        );
+        let support = await this.yp.call_proc('member_list_all', this.uid, Cache.getSysConf('support_domain'));
         support = toArray(support);
         for (let member of support) {
           message.service = "channel.acknowledge";
-          let recipients = await this.yp.await_proc(
-            "user_sockets",
-            member.drumate_id,
-          );
+          let recipients = await this.yp.await_proc('user_sockets', member.drumate_id);
           await RedisStore.sendData(this.payload(message), recipients);
         }
 
-        let recipients = await this.yp.await_proc("user_sockets", this.uid);
+        let recipients = await this.yp.await_proc('user_sockets', this.uid);
         await RedisStore.sendData(this.payload(message), recipients);
       }
-      message.entity = { id: this.uid };
+      message.entity = { id: this.uid }
       if (message.author_id != this.uid) {
-        message.entity = await this.yp.await_proc(
-          "forward_proc",
-          this.uid,
-          "shareroom_contact_get",
-          `'${message.author_id}'`,
-        );
+        message.entity = await this.yp.await_proc('forward_proc', this.uid, 'shareroom_contact_get', `'${message.author_id}'`)
       }
-      message.metadata = this.parseJSON(message.metadata);
+      message.metadata = this.parseJSON(message.metadata)
       if (message.is_ticket == 1) {
-        message.metadata.category_display = [];
+        message.metadata.category_display = []
         for (let category of message.metadata.category) {
           switch (category) {
             case "tech":
-              message.metadata.category_display.push("Tech Bug");
+              message.metadata.category_display.push("Tech Bug")
               break;
             case "design":
-              message.metadata.category_display.push("Design Bug");
+              message.metadata.category_display.push("Design Bug")
               break;
             case "notunderstand":
-              message.metadata.category_display.push("Could't Understand");
+              message.metadata.category_display.push("Could't Understand")
               break;
             case "enhancement":
-              message.metadata.category_display.push("Enhancement");
+              message.metadata.category_display.push("Enhancement")
               break;
           }
         }
-        message.metadata.where_display = [];
+        message.metadata.where_display = []
         for (let where of message.metadata.where) {
           switch (where) {
             case "desktop":
-              message.metadata.where_display.push("Desktop");
+              message.metadata.where_display.push("Desktop")
               break;
             case "chat":
-              message.metadata.where_display.push("Chat");
+              message.metadata.where_display.push("Chat")
               break;
             case "contactmanager":
-              message.metadata.where_display.push("Contact Manager");
+              message.metadata.where_display.push("Contact Manager")
               break;
             case "teamroom":
-              message.metadata.where_display.push("Team Room");
+              message.metadata.where_display.push("Team Room")
               break;
             case "sharebox":
-              message.metadata.where_display.push("Share Box");
+              message.metadata.where_display.push("Share Box")
               break;
             case "profile":
-              message.metadata.where_display.push("Profile");
+              message.metadata.where_display.push("Profile")
               break;
             case "others":
-              message.metadata.where_display.push("Others");
+              message.metadata.where_display.push("Others")
               break;
           }
         }
       }
       if (!isEmpty(message.thread_id)) {
-        message.thread = await this.threadInfo(message.thread_id, sbox.hub_id);
+        message.thread = await this.threadInfo(message.thread_id, sbox.hub_id)
       }
-      messages.push(message);
+      messages.push(message)
     }
     this.output.list(messages);
   }
 
   /**
-   *
-   * @param {*} hub_id
-   * @param {*} ticket_id
-   * @returns
+   * 
+   * @param {*} hub_id 
+   * @param {*} ticket_id 
+   * @returns 
    */
   async autoreply(hub_id, ticket_id) {
-    let reply = {};
+    let reply = {}
     let input = {};
     let metadata = {};
     let message_id = await this.yp.await_func("uniqueId");
-    await this.yp.await_proc(
-      "forward_proc",
-      hub_id,
-      "map_ticket_add",
-      `'${message_id}','${ticket_id}'`,
-    );
-    input.author_id = "autoreply";
-    input.uid = "autoreply";
-    input.message_id = message_id;
-    input.metadata = metadata;
-    input.metadata.message_type = "ticket_auto_reply";
+    await this.yp.await_proc('forward_proc', hub_id, 'map_ticket_add', `'${message_id}','${ticket_id}'`)
+    input.author_id = 'autoreply'
+    input.uid = 'autoreply'
+    input.message_id = message_id
+    input.metadata = metadata
+    input.metadata.message_type = 'ticket_auto_reply'
     let message = Cache.message("_ticket_auto_reply", this.client_language());
-    let data = await this.yp.await_proc(
-      "forward_proc",
-      hub_id,
-      "channel_post_message",
-      `'${stringify(input)}','${message}'`,
-    );
+    let data = await this.yp.await_proc('forward_proc', hub_id, 'channel_post_message', `'${stringify(input)}','${message}'`)
     return this.output.sanitize(data);
   }
 
+
   /**
-   *
+   * 
    */
   async send_ticket() {
     let attachment = this.input.use(Attr.attachment, []);
@@ -545,343 +561,263 @@ class __private_channel extends Entity {
       let message_id = await this.yp.await_func("uniqueId");
       let sbox = await this._get_wicket(this.uid);
       if (!isEmpty(attachment)) {
-        let desdir = await this.yp.await_proc(
-          "forward_proc",
-          sbox.hub_id,
-          "mfs_make_dir",
-          `'${sbox.ticket_id}','${stringify([message_id])}',1`,
-        );
-        attachment = await this.move_attachemnt(
-          sbox,
-          desdir,
-          attachment,
-          message_id,
-        );
+        let desdir = await this.yp.await_proc('forward_proc', sbox.hub_id, 'mfs_make_dir', `'${sbox.ticket_id}','${stringify([message_id])}',1`)
+        attachment = await this.move_attachemnt(sbox, desdir, attachment, message_id)
       }
-      metadata.status = "new";
-      if (!isEmpty(attachment)) {
-        metadata.attachment = attachment;
-      }
-      if (!isEmpty(category)) {
-        metadata.category = category;
-      }
-      if (!isEmpty(category)) {
-        metadata.alltime = alltime;
-      }
-      if (!isEmpty(where)) {
-        metadata.where = where;
-      }
-      if (!isEmpty(message)) {
-        message = message.replace(/'/gi, "''");
-      }
+      metadata.status = 'new'
+      if (!isEmpty(attachment)) { metadata.attachment = attachment }
+      if (!isEmpty(category)) { metadata.category = category }
+      if (!isEmpty(category)) { metadata.alltime = alltime }
+      if (!isEmpty(where)) { metadata.where = where }
+      if (!isEmpty(message)) { message = message.replace(/'/gi, "''"); }
       metadata.message = message;
 
-      let ticket = await this.yp.await_proc(
-        "ticket_add",
-        message_id,
-        this.uid,
-        metadata,
-      );
+      let ticket = await this.yp.await_proc('ticket_add', message_id, this.uid, metadata);
       metadata.ticket_id = ticket.ticket_id;
 
-      await this.yp.await_proc(
-        "forward_proc",
-        sbox.hub_id,
-        "map_ticket_add",
-        `'${message_id}','${ticket.ticket_id}'`,
-      );
-      input.author_id = this.uid;
-      input.uid = this.uid;
-      input.message_id = message_id;
-      input.metadata = metadata;
-      input.metadata.message_type = "ticket";
+
+      await this.yp.await_proc('forward_proc', sbox.hub_id, 'map_ticket_add', `'${message_id}','${ticket.ticket_id}'`)
+      input.author_id = this.uid
+      input.uid = this.uid
+      input.message_id = message_id
+      input.metadata = metadata
+      input.metadata.message_type = 'ticket'
       input.ticket_id = ticket.ticket_id;
-      if (!isEmpty(attachment)) {
-        input.attachment = attachment;
-      }
-      let data = await this.yp.await_proc(
-        "forward_proc",
-        sbox.hub_id,
-        "channel_post_message",
-        `'${stringify(input)}','${message}'`,
-      );
-      data.is_attachment = 0;
+      if (!isEmpty(attachment)) { input.attachment = attachment }
+      let data = await this.yp.await_proc('forward_proc', sbox.hub_id, 'channel_post_message', `'${stringify(input)}','${message}'`)
+      data.is_attachment = 0
       if (!isEmpty(input.attachment)) {
-        await this.yp.await_proc(
-          "forward_proc",
-          sbox.hub_id,
-          "channel_post_attachment",
-          `'${message_id}','${sbox.hub_id}','${stringify(input.attachment)}'`,
-        );
-        data.is_attachment = 1;
+        await this.yp.await_proc('forward_proc', sbox.hub_id, 'channel_post_attachment', `'${message_id}','${sbox.hub_id}','${stringify(input.attachment)}'`)
+        data.is_attachment = 1
       }
       data.ticket_id = ticket.ticket_id;
-      let profile = this.user.get("profile") || {};
+      let profile = this.user.get('profile') || {};
       data.lastname = profile.lastname;
       data.firstname = profile.firstname;
-      let my_org = await this.yp.await_proc("my_organisation", this.uid);
-      data.org_name = my_org.name;
+      let my_org = await this.yp.await_proc('my_organisation', this.uid)
+      data.org_name = my_org.name
       data.metadata = metadata;
 
-      let auto = await this.autoreply(sbox.hub_id, ticket.ticket_id);
-      auto.service = "channel.post";
+      let auto = await this.autoreply(sbox.hub_id, ticket.ticket_id)
+      auto.service = "channel.post"
 
-      auto.echoId = this.input.get("echoId");
-      data.echoId = this.input.get("echoId");
+      auto.echoId = this.input.get('echoId');
+      data.echoId = this.input.get('echoId');
       let keys = { entity_id: Attr.hub_id };
-      let recipients = await this.yp.await_proc("user_sockets", ticket.uid);
+      let recipients = await this.yp.await_proc('user_sockets', ticket.uid);
       await RedisStore.sendData(this.payload(data, { keys }), recipients);
       await RedisStore.sendData(this.payload(auto, { keys }), recipients);
-      let support = await this.yp.call_proc(
-        "member_list_all",
-        this.uid,
-        Cache.getSysConf("support_domain"),
-      );
+      let support = await this.yp.call_proc('member_list_all', this.uid, Cache.getSysConf('support_domain'));
       support = toArray(support);
 
       for (let member of support) {
-        let recipients = await this.yp.await_proc(
-          "user_sockets",
-          member.drumate_id,
-        );
+        let recipients = await this.yp.await_proc('user_sockets', member.drumate_id);
         await RedisStore.sendData(this.payload(data, { keys }), recipients);
         await RedisStore.sendData(this.payload(auto, { keys }), recipients);
       }
 
       return data;
-    };
-    f()
-      .then((data = {}) => {
-        this.output.data(data);
-      })
-      .catch(this.fallback);
+    }
+    f().then((data = {}) => {
+      this.output.data(data);
+    }).catch(this.fallback);
   }
 
+
+
   async post_ticket() {
-    let message = this.input.use(Attr.message, "");
+    let message = this.input.use(Attr.message, '');
     const thread_id = this.input.use(Attr.thread_id);
     let attachment = this.input.use(Attr.attachment, []);
     const ticket_id = this.input.need(Attr.ticket_id);
     const f = async () => {
       let input = {};
       let res = {};
-      let ticket = await this.yp.await_proc("ticket_detail", ticket_id);
+      let ticket = await this.yp.await_proc('ticket_detail', ticket_id);
 
       if (isEmpty(ticket)) {
-        res.status = "INVALID_TICKET";
+        res.status = 'INVALID_TICKET'
         return this.output.data(res);
       }
       let message_id = await this.yp.await_func("uniqueId");
       let sbox = await this._get_wicket(ticket.uid);
 
       if (!isEmpty(attachment)) {
-        let desdir = await this.yp.await_proc(
-          "forward_proc",
-          sbox.hub_id,
-          "mfs_make_dir",
-          `'${sbox.ticket_id}','${stringify([message_id])}',1`,
-        );
-        attachment = await this.move_attachemnt(
-          sbox,
-          desdir,
-          attachment,
-          message_id,
-        );
+        let desdir = await this.yp.await_proc('forward_proc', sbox.hub_id, 'mfs_make_dir', `'${sbox.ticket_id}','${stringify([message_id])}',1`)
+        attachment = await this.move_attachemnt(sbox, desdir, attachment, message_id)
       }
 
-      await this.yp.await_proc(
-        "forward_proc",
-        sbox.hub_id,
-        "map_ticket_add",
-        `'${message_id}','${ticket.ticket_id}'`,
-      );
-      input.author_id = this.uid;
-      input.uid = this.uid;
-      input.message_id = message_id;
+      await this.yp.await_proc('forward_proc', sbox.hub_id, 'map_ticket_add', `'${message_id}','${ticket.ticket_id}'`)
+      input.author_id = this.uid
+      input.uid = this.uid
+      input.message_id = message_id
       input.ticket_id = ticket.ticket_id;
-      input.metadata = {};
-      input.metadata.message_type = "ticket";
-      if (!isEmpty(attachment)) {
-        input.attachment = attachment;
-      }
-      if (!isEmpty(message)) {
-        message = message.replace(/'/gi, "''");
-      }
-      if (!isEmpty(thread_id)) {
-        input.thread_id = thread_id;
-      }
-      let data = await this.yp.await_proc(
-        "forward_proc",
-        sbox.hub_id,
-        "channel_post_message",
-        `'${stringify(input)}','${message}'`,
-      );
-      data.is_attachment = 0;
+      input.metadata = {}
+      input.metadata.message_type = 'ticket'
+      if (!isEmpty(attachment)) { input.attachment = attachment }
+      if (!isEmpty(message)) { message = message.replace(/'/gi, "''"); }
+      if (!isEmpty(thread_id)) { input.thread_id = thread_id }
+      let data = await this.yp.await_proc('forward_proc', sbox.hub_id, 'channel_post_message', `'${stringify(input)}','${message}'`)
+      data.is_attachment = 0
       if (!isEmpty(input.attachment)) {
-        await this.yp.await_proc(
-          "forward_proc",
-          sbox.hub_id,
-          "channel_post_attachment",
-          `'${message_id}','${sbox.hub_id}','${stringify(input.attachment)}'`,
-        );
-        data.is_attachment = 1;
+        await this.yp.await_proc('forward_proc', sbox.hub_id, 'channel_post_attachment', `'${message_id}','${sbox.hub_id}','${stringify(input.attachment)}'`)
+        data.is_attachment = 1
         // data.attachment = await this._getAttachmentsInfo(data.attachment, this.hub.get(Attr.id));
       }
 
       if (!isEmpty(thread_id)) {
-        data.thread = await this.threadInfo(thread_id, sbox.hub_id);
+        data.thread = await this.threadInfo(thread_id, sbox.hub_id)
       }
 
       data.ticket_id = ticket.ticket_id;
-      data.echoId = this.input.get("echoId");
+      data.echoId = this.input.get('echoId');
       //await this.notify_user(ticket.uid, data);
       let keys = { entity_id: Attr.hub_id };
-      let recipients = await this.yp.await_proc("user_sockets", ticket.uid);
+      let recipients = await this.yp.await_proc('user_sockets', ticket.uid);
       await RedisStore.sendData(this.payload(data, { keys }), recipients);
 
-      let support = await this.yp.call_proc(
-        "member_list_all",
-        "xxxxxxx",
-        Cache.getSysConf("support_domain"),
-      );
+
+      let support = await this.yp.call_proc('member_list_all', 'xxxxxxx', Cache.getSysConf('support_domain'));
       support = toArray(support);
 
       for (let member of support) {
-        let recipients = await this.yp.await_proc(
-          "user_sockets",
-          member.drumate_id,
-        );
+        let recipients = await this.yp.await_proc('user_sockets', member.drumate_id);
         await RedisStore.sendData(this.payload(data, { keys }), recipients);
+
       }
 
       return data;
-    };
-    f()
-      .then((data = {}) => {
-        this.output.data(data);
-      })
-      .catch(this.fallback);
+
+    }
+    f().then((data = {}) => {
+      this.output.data(data);
+    }).catch(this.fallback);
   }
 
+
   /**
-   *
+   * 
    */
   async post() {
-    let message = this.input.use(Attr.message, "");
+    let message = this.input.use(Attr.message, '');
     const thread_id = this.input.use(Attr.thread_id);
     let attachment = this.input.use(Attr.attachment, []);
+    let folder_attachment = this.input.use('folder_attachment', []);
     let exclude = this.input.need(Attr.socket_id);
     if (exclude) exclude = [exclude];
     let input = {};
-    let message_id = await this.db.await_proc("message_id");
+
+    attachment = toArray(attachment).map(String);
+    folder_attachment = toArray(folder_attachment).map(String);
+    // Client-supplied ids flow into proc-call strings below — hard-reject
+    // anything that is not a plain node id before any interpolation.
+    const ID_RE = /^[0-9a-zA-Z_-]{1,32}$/;
+    for (let id of [...attachment, ...folder_attachment]) {
+      if (!ID_RE.test(id)) {
+        this.warn('channel.post: malformed attachment id', id);
+        return this.output.data({ status: 'INVALID_ATTACHMENT' });
+      }
+    }
+
+    let message_id = await this.db.await_proc('message_id');
     let sbox;
-    message_id = message_id.id;
+    message_id = message_id.id
 
     if (this.hub.get(Attr.id) == this.uid) {
       sbox = await this._get_wicket(this.uid);
-    } else {
-      sbox = await this.db.call_proc("mfs_home");
+    }
+    else {
+      sbox = await this.db.call_proc('mfs_home')
     }
     const nid = this.input.use(Attr.nid);
-    // Folder-scoped posts upload into the folder; copy (not move) so the
-    // originals remain visible in the folder's Files tab.
+    // Folder-scoped posts: device uploads sit in the hub's chat staging
+    // until the message is sent. Promote them into the scoped folder first
+    // (the original lands in the Files tab), then copy (not move) every
+    // attachment into the sbox so the message keeps its own copy.
     const copy_only = !isEmpty(nid);
-    if (!isEmpty(attachment)) {
-      let desdir = await this.yp.await_proc(
-        "forward_proc",
-        sbox.hub_id,
-        "mfs_make_dir",
-        `'${sbox.chat_id}','${stringify([message_id])}',1`,
-      );
-      attachment = await this.move_attachemnt(
-        sbox,
-        desdir,
-        attachment,
-        message_id,
-        copy_only,
-      );
+    let staged = { device: [], workspace: [] };
+    let promoted = [];
+    if (copy_only && !isEmpty(attachment)) {
+      staged = await this._classify_staged_attachment(attachment, folder_attachment);
+      if (!isEmpty(staged.device)) {
+        // Moving a file INTO the folder is a write — channel.post itself is
+        // only read-gated, so check the destination node explicitly.
+        // privilege check matches ui _K.permission.write: privilege & perm > 0
+        const MFS_PERM_WRITE = 0b0001000;
+        let folder = await this.db.await_proc('mfs_access_node', this.uid, nid);
+        if (!isEmpty(folder) && (Number(folder.privilege) & MFS_PERM_WRITE)) {
+          const remap = await this._promote_staged_to_folder(staged.device, nid);
+          attachment = attachment.map((n) => remap[n] || n);
+          promoted = staged.device.map((n) => remap[n] || n);
+          // A device nid the SP did not confirm stays in staging: its sbox
+          // copy below is independent, so purge it like a workspace copy
+          // rather than leaving a silent orphan.
+          const confirmed = new Set(await this._confirm_promoted(promoted, nid));
+          const failed = [];
+          promoted = promoted.filter((n) => {
+            if (confirmed.has(`${n}`)) return true;
+            failed.push(`${n}`);
+            return false;
+          });
+          if (!isEmpty(failed)) {
+            this.warn('channel.post: promotion unconfirmed, purging from staging', failed);
+            staged.workspace.push(...failed);
+          }
+        } else {
+          this.warn('channel.post: caller lacks write on folder, staged uploads stay sbox-only', nid);
+          // Demote: keep them in the message (sbox copy) but never in the
+          // folder; their staging copies get purged like workspace ones.
+          staged.workspace.push(...staged.device);
+          staged.device = [];
+        }
+      }
     }
-    input.author_id = this.uid;
-    input.uid = this.uid;
+    if (!isEmpty(attachment)) {
+      let desdir = await this.yp.await_proc('forward_proc', sbox.hub_id, 'mfs_make_dir', `'${sbox.chat_id}','${stringify([message_id])}',1`)
+      attachment = await this.move_attachemnt(sbox, desdir, attachment, message_id, copy_only)
+    }
+    input.author_id = this.uid
+    input.uid = this.uid
 
-    if (!isEmpty(attachment)) {
-      input.attachment = attachment;
-    }
-    if (!isEmpty(message)) {
-      message = message.replace(/'/gi, "''");
-    }
-    if (!isEmpty(thread_id)) {
-      input.thread_id = thread_id;
-    }
-    if (!isEmpty(nid)) {
-      input.metadata = { _scope_nid: `${nid}` };
-    }
-    input.message_id = message_id;
-    let data = await this.yp.await_proc(
-      "forward_proc",
-      this.hub.get(Attr.id),
-      "channel_post_message",
-      `'${stringify(input)}','${message}'`,
+    if (!isEmpty(attachment)) { input.attachment = attachment }
+    if (!isEmpty(message)) { message = message.replace(/'/gi, "''"); }
+    if (!isEmpty(thread_id)) { input.thread_id = thread_id }
+    if (!isEmpty(nid)) { input.metadata = { _scope_nid: `${nid}` }; }
+    input.message_id = message_id
+    let data = await this.yp.await_proc('forward_proc', this.hub.get(Attr.id),
+      'channel_post_message', `'${stringify(input)}','${message}'`
     );
-    data.is_attachment = 0;
+    data.is_attachment = 0
     if (!isEmpty(input.attachment)) {
-      await this.yp.await_proc(
-        "forward_proc",
-        this.hub.get(Attr.id),
-        "channel_post_attachment",
-        `'${message_id}','${this.hub.get(Attr.id)}','${stringify(input.attachment)}'`,
+      await this.yp.await_proc('forward_proc', this.hub.get(Attr.id),
+        'channel_post_attachment', `'${message_id}','${this.hub.get(Attr.id)}','${stringify(input.attachment)}'`
       );
-      data.is_attachment = 1;
+      data.is_attachment = 1
     }
+    // Only after the message and its attachment records are committed:
+    // remove the now-redundant staging copies and surface the promoted
+    // files in everyone's open folder window.
+    await this._purge_staged_copies(staged.workspace);
+    await this._notify_folder_new_nodes(promoted, nid);
 
     if (!isEmpty(thread_id)) {
-      data.thread = await this.threadInfo(thread_id, this.hub.get(Attr.id));
+      data.thread = await this.threadInfo(thread_id, this.hub.get(Attr.id))
     }
 
-    let profile = this.user.get("profile") || {};
+
+    let profile = this.user.get('profile') || {};
     data.firstname = this.user.attributes.firstname;
     data.lastname = profile.lastname;
     data.hub_id = this.hub.get(Attr.id);
     if (nid) data.nid = nid;
-    data.echoId = this.input.get("echoId");
+    data.echoId = this.input.get('echoId');
     const meetingMatch = /^\[\[MEETING:\s*(start|end)\s*:/.exec(data.message);
     if (meetingMatch) data.message_type = `meeting.${meetingMatch[1]}`;
     let hub_id = this.hub.get(Attr.id);
-    let recipients = await this.yp.await_proc("entity_sockets", {
-      exclude,
-      hub_id,
-    });
+    let recipients = await this.yp.await_proc('entity_sockets', { exclude, hub_id });
     await RedisStore.sendData(this.payload(data), recipients);
 
-    this.output.data(data);
-  }
-
-  /**
-   * Ephemeral typing indicator. Broadcasts the caller's typing state to all
-   * other hub participants over WebSocket. Nothing is persisted.
-   */
-  async typing() {
-    let exclude = this.input.need(Attr.socket_id);
-    if (exclude) exclude = [exclude];
-    let hub_id = this.hub.get(Attr.id);
-    let profile = this.user.get("profile") || {};
-    let data = {
-      author_id: this.uid,
-      uid: this.uid,
-      firstname: this.user.attributes.firstname,
-      lastname: profile.lastname,
-      hub_id,
-      state: this.input.use("state", 1),
-    };
-    let recipients = await this.yp.await_proc("entity_sockets", {
-      exclude,
-      hub_id,
-    });
-    await RedisStore.sendData(
-      this.payload(data, { service: "channel.typing" }),
-      recipients,
-    );
-    this.output.data({ ok: 1 });
+    this.output.data(data)
   }
 
   /**
@@ -890,46 +826,34 @@ class __private_channel extends Entity {
    * message_id is generated server-side via message_id SP.
    */
   async write() {
-    let message = this.input.use(Attr.message, "");
+    let message = this.input.use(Attr.message, '');
     const thread_id = this.input.use(Attr.thread_id);
     let attachment = this.input.use(Attr.attachment, []);
     const is_forward = this.input.use(Attr.is_forward, 0);
-    const mention_ids = this.input.use("mention_ids", null);
+    const mention_ids = this.input.use('mention_ids', null);
     let exclude = this.input.need(Attr.socket_id);
     if (exclude) exclude = [exclude];
 
-    let message_id = await this.db.await_proc("message_id");
+    let message_id = await this.db.await_proc('message_id');
     message_id = message_id.id;
 
-    let sbox = await this.db.call_proc("mfs_home");
+    let sbox = await this.db.call_proc('mfs_home');
     if (!isEmpty(attachment)) {
-      let desdir = await this.yp.await_proc(
-        "forward_proc",
-        sbox.hub_id,
-        "mfs_make_dir",
-        `'${sbox.chat_id}','${stringify([message_id])}',1`,
-      );
-      attachment = await this.move_attachemnt(
-        sbox,
-        desdir,
-        attachment,
-        message_id,
-      );
+      let desdir = await this.yp.await_proc('forward_proc', sbox.hub_id, 'mfs_make_dir', `'${sbox.chat_id}','${stringify([message_id])}',1`);
+      attachment = await this.move_attachemnt(sbox, desdir, attachment, message_id);
     }
 
-    if (!isEmpty(message)) {
-      message = message.replace(/'/gi, "''");
-    }
+    if (!isEmpty(message)) { message = message.replace(/'/gi, "''"); }
 
     let data = await this.db.await_proc(
-      "channel_write",
+      'channel_write',
       this.uid,
       message_id,
       message,
       thread_id || null,
       !isEmpty(attachment) ? stringify(attachment) : null,
       is_forward,
-      !isEmpty(mention_ids) ? stringify(mention_ids) : null,
+      !isEmpty(mention_ids) ? stringify(mention_ids) : null
     );
 
     data.is_attachment = !isEmpty(attachment) ? 1 : 0;
@@ -939,83 +863,59 @@ class __private_channel extends Entity {
     }
 
     data.hub_id = this.hub.get(Attr.id);
-    data.echoId = this.input.get("echoId");
+    data.echoId = this.input.get('echoId');
 
     let hub_id = this.hub.get(Attr.id);
-    let recipients = await this.yp.await_proc("entity_sockets", {
-      exclude,
-      hub_id,
-    });
+    let recipients = await this.yp.await_proc('entity_sockets', { exclude, hub_id });
     await RedisStore.sendData(this.payload(data), recipients);
 
     if (!isEmpty(mention_ids)) {
       try {
-        const hubRecipientUids = toArray(recipients).map((r) => r.uid);
+        const hubRecipientUids = toArray(recipients).map(r => r.uid);
         const extraMentionIds = mention_ids.filter(
-          (id) => id !== this.uid && !hubRecipientUids.includes(id),
+          id => id !== this.uid && !hubRecipientUids.includes(id)
         );
         if (extraMentionIds.length) {
-          const mentionRecipients = await this.yp.await_proc(
-            "user_sockets",
-            extraMentionIds,
-          );
+          const mentionRecipients = await this.yp.await_proc('user_sockets', extraMentionIds);
           if (!isEmpty(mentionRecipients)) {
             await RedisStore.sendData(this.payload(data), mentionRecipients);
           }
         }
       } catch (e) {
-        this.warn(
-          "[channel.write] mention notification failed:",
-          e && e.message,
-        );
+        this.warn('[channel.write] mention notification failed:', e && e.message);
       }
     }
 
     // Track chat_initiated
     try {
-      const track = await this.db.await_proc(
-        "share_track_add",
-        "chat_initiated",
-        this.uid,
-        null,
-      );
+      const track = await this.db.await_proc('share_track_add', 'chat_initiated', this.uid, null);
       const row = toArray(track)[0] || {};
       if (row.inserted) {
-        const trackRecipients = await this.yp.await_proc("entity_sockets", {
-          hub_id,
-        });
+        const trackRecipients = await this.yp.await_proc('entity_sockets', { hub_id });
         await RedisStore.sendData(
           this.payload(
-            {
-              event: "chat_initiated",
-              actor_id: this.uid,
-              firstname: row.firstname,
-              lastname: row.lastname,
-            },
-            { service: "share.track_event" },
+            { event: 'chat_initiated', actor_id: this.uid, firstname: row.firstname, lastname: row.lastname },
+            { service: 'share.track_event' }
           ),
-          trackRecipients,
+          trackRecipients
         );
       }
     } catch (e) {
-      this.warn(
-        "[channel.write] chat_initiated tracking failed:",
-        e && e.message,
-      );
+      this.warn('[channel.write] chat_initiated tracking failed:', e && e.message);
     }
 
     this.output.data(data);
   }
 
   /**
-   * Retrieve paginated notifications for the current user across all hubs.
-   * Supports type filter (all / mention / share) and unread-only toggle.
-   */
+  * Retrieve paginated notifications for the current user across all hubs.
+  * Supports type filter (all / mention / share) and unread-only toggle.
+  */
   async list_notifications() {
-    const VALID_TYPES = ["all", "mention", "share"];
-    let type = this.input.use(Attr.type, "all");
-    if (!VALID_TYPES.includes(type)) type = "all";
-    const unread_only = this.input.use("unread_only", 0) ? 1 : 0;
+    const VALID_TYPES = ['all', 'mention', 'share'];
+    let type = this.input.use(Attr.type, 'all');
+    if (!VALID_TYPES.includes(type)) type = 'all';
+    const unread_only = this.input.use('unread_only', 0) ? 1 : 0;
     const page = this.input.use(Attr.page, 1);
 
     // Get all active hubs for the current user via their drumate media table.
@@ -1029,14 +929,11 @@ class __private_channel extends Entity {
            FROM media m
            INNER JOIN yp.entity e ON e.id = m.id
            LEFT JOIN yp.hub h ON h.id = m.id
-           WHERE m.category = 'hub' AND m.status = 'active'`,
-        ),
+           WHERE m.category = 'hub' AND m.status = 'active'`
+        )
       );
     } catch (e) {
-      this.warn(
-        "[channel.list_notifications] hub list query failed:",
-        e && e.message,
-      );
+      this.warn('[channel.list_notifications] hub list query failed:', e && e.message);
     }
 
     // Query channel_list_notifications per hub and aggregate results
@@ -1050,26 +947,23 @@ class __private_channel extends Entity {
             this.uid,
             type,
             unread_only,
-            1,
-          ),
+            1
+          )
         );
         // Tag each row with hub context for renderer
         for (const row of rows) {
           row.hub_id = hub.id;
-          row.category = "teamchat";
-          row.hub_name = hub.name || "";
+          row.category = 'teamchat';
+          row.hub_name = hub.name || '';
           all_notifications.push(row);
         }
       } catch (e) {
-        this.warn(
-          `[channel.list_notifications] hub ${hub.id} query failed:`,
-          e && e.message,
-        );
+        this.warn(`[channel.list_notifications] hub ${hub.id} query failed:`, e && e.message);
       }
     }
 
     // Include P2P mentions from yp.contact_activity for mention/all tabs
-    if (type === "mention" || type === "all") {
+    if (type === 'mention' || type === 'all') {
       try {
         const p2pMentions = toArray(
           await this.yp.await_query(
@@ -1086,22 +980,19 @@ class __private_channel extends Entity {
             LEFT JOIN yp.drumate d ON d.id = ca.uid
             WHERE ca.target_uid = ? AND ca.event = 'p2p_mention' AND ca.dismissed_at IS NULL
             ORDER BY ca.timestamp DESC LIMIT 45`,
-            this.uid,
-          ),
+            this.uid
+          )
         );
         for (const row of p2pMentions) {
           if (unread_only && row.is_read) continue;
           // Use contact_invite category so the UI dismisses via contact_activity_dismiss
           // (sets dismissed_at). The mention_ids field makes the skeleton render it as
           // a mention ("X mentioned you") despite the contact_invite category.
-          row.category = "contact_invite";
+          row.category = 'contact_invite';
           all_notifications.push(row);
         }
       } catch (e) {
-        this.warn(
-          "[channel.list_notifications] p2p mention query failed:",
-          e && e.message,
-        );
+        this.warn('[channel.list_notifications] p2p mention query failed:', e && e.message);
       }
     }
 
@@ -1116,19 +1007,20 @@ class __private_channel extends Entity {
   }
 
   // ========================
-  //
+  // 
   // ========================
   read() {
     const id = this.input.use(Attr.id);
-    this.db.call_proc("channel_read_messages", id, this.uid, this.output.data);
+    this.db.call_proc('channel_read_messages', id, this.uid, this.output.data);
   }
 
+
   pages_to_read() {
-    this.db.call_proc("pages_to_read", this.uid, this.output.data);
+    this.db.call_proc('pages_to_read', this.uid, this.output.data);
   }
 
   /**
-   *
+   * 
    */
   async acknowledge() {
     const message_id = this.input.use(Attr.message_id);
@@ -1136,17 +1028,10 @@ class __private_channel extends Entity {
     if (exclude) exclude = [exclude];
 
     let res = {};
-    res = await this.db.await_proc("acknowledge_message", message_id, this.uid);
-    // Persist the reader into metadata._seen_ for every message up to message_id
-    // (read receipts). acknowledge_message only advances the read_channel cursor,
-    // so without this the reader never appears in _seen_ on a fresh load — they
-    // would only flicker in via the live broadcast below.
-    if (message_id) {
-      await this.db.await_proc("channel_read_messages", message_id, this.uid);
-    }
-    let message = await this.db.await_proc("channel_get", message_id);
+    res = await this.db.await_proc('acknowledge_message', message_id, this.uid);
+    let message = await this.db.await_proc('channel_get', message_id);
     message.key_id = this.hub.get(Attr.id);
-    let recipients = await this.yp.await_proc("entity_sockets", {
+    let recipients = await this.yp.await_proc('entity_sockets', {
       hub_id: message.key_id,
       exclude,
     });
@@ -1154,163 +1039,124 @@ class __private_channel extends Entity {
     this.output.data(res);
   }
 
+
+
   /**
-   *
+   * 
    */
   async acknowledge_ticket() {
     const message_id = this.input.use(Attr.message_id);
     const ticket_id = this.input.need(Attr.ticket_id);
     const f = async () => {
-      let ticket = await this.yp.await_proc("ticket_detail", ticket_id);
-      let sbox = await this.yp.await_proc(
-        "forward_proc",
-        ticket.uid,
-        "mfs_wicket_home",
-        `'${ticket.uid}'`,
-      );
+      let ticket = await this.yp.await_proc('ticket_detail', ticket_id);
+      let sbox = await this.yp.await_proc('forward_proc', ticket.uid, 'mfs_wicket_home', `'${ticket.uid}'`);
 
       let res = {};
-      res = await this.yp.await_proc(
-        "forward_proc",
-        sbox.hub_id,
-        "acknowledge_message",
-        `'${message_id}','${this.uid}'`,
-      );
-      let message = await this.yp.await_proc(
-        "forward_proc",
-        sbox.hub_id,
-        "channel_get",
-        `'${message_id}'`,
-      );
+      res = await this.yp.await_proc('forward_proc', sbox.hub_id, 'acknowledge_message', `'${message_id}','${this.uid}'`);
+      let message = await this.yp.await_proc('forward_proc', sbox.hub_id, 'channel_get', `'${message_id}'`);
 
-      let support = await this.yp.call_proc(
-        "member_list_all",
-        this.uid,
-        Cache.getSysConf("support_domain"),
-      );
-      support = toArray(support);
+      let support = await this.yp.call_proc('member_list_all', this.uid, Cache.getSysConf('support_domain'));
+      support = toArray(support)
       for (let member of support) {
         message.service = "channel.acknowledge";
         let service = message.service;
-        let recipients = await this.yp.await_proc(
-          "user_sockets",
-          member.drumate_id,
-        );
-        await RedisStore.sendData(
-          this.payload(message, { service }),
-          recipients,
-        );
+        let recipients = await this.yp.await_proc('user_sockets', member.drumate_id);
+        await RedisStore.sendData(this.payload(message, { service }), recipients);
       }
 
-      let recipients = await this.yp.await_proc("user_sockets", this.uid);
+      let recipients = await this.yp.await_proc('user_sockets', this.uid);
       await RedisStore.sendData(this.payload(message), recipients);
-      return this.output.data(res);
-    };
-    f()
-      .then((r) => {
-        this.output.data(r);
-      })
-      .catch(this.fallback);
+      return this.output.data(res)
+
+    }
+    f().then((r) => {
+      this.output.data(r);
+    }).catch(this.fallback);
   }
 
+
   // ========================
-  //
+  // 
   // ========================
   async clear_notifications() {
     //await this.notify_user(this.uid, {});
-    let recipients = await this.yp.await_proc("user_sockets", this.uid);
+    let recipients = await this.yp.await_proc('user_sockets', this.uid);
     await RedisStore.sendData(this.payload({}), recipients);
-    let data = await this.db.await_proc(
-      "channel_clear_notifications",
-      this.uid,
-    );
+    let data = await this.db.await_proc('channel_clear_notifications', this.uid);
     this.output.data(data);
   }
 
   /**
-   * To create a RTC session Offer
+   * To create a RTC session Offer 
    * see : https://webrtc.org/getting-started/firebase-rtc-codelab
    * @params {object} as specified by https://www.w3.org/TR/webrtc/#rtcpeerconnection-interface
    */
   async createRTCOffer() {
-    const offer = this.input.need("offer");
+    const offer = this.input.need('offer');
     const data = {
       callerId: this.uid,
-      roomId: Crypto.randomBytes(32).toString("base64"),
-    };
-    let recipients = await this.yp.await_proc("user_sockets", this.uid);
+      roomId: Crypto.randomBytes(32).toString("base64")
+    }
+    let recipients = await this.yp.await_proc('user_sockets', this.uid);
     await RedisStore.sendData(this.payload(data), recipients);
     this.output.data(data);
   }
 
   /**
-   *
+   * 
    */
   async delete() {
-    let option = this.input.need(Attr.option);
-    let messages = this.input.need(Attr.messages);
+    let option = this.input.need(Attr.option)
+    let messages = this.input.need(Attr.messages)
+
 
     let res = {};
     let data = {};
     let temp_result = [];
 
-    if (option != "me" && option != "all") {
-      res.status = "INVALID_OPTION";
+    if (option != 'me' && option != 'all') {
+      res.status = 'INVALID_OPTION'
       return this.output.data(res);
     }
     let invalid_messageid = 0;
     let invalid_option = 0;
     for (let message_id of messages) {
-      data = await this.db.await_proc("channel_get", message_id);
+      data = await this.db.await_proc('channel_get', message_id);
       if (isEmpty(data)) {
         invalid_messageid = invalid_messageid + 1;
       }
       if (!isEmpty(data)) {
-        if (option == "all" && data.author_id != this.uid) {
+        if (option == 'all' && data.author_id != this.uid) {
           invalid_option = invalid_option + 1;
         }
       }
     }
 
     if (invalid_messageid > 0) {
-      res.status = "INVALID_MESSAGES";
+      res.status = 'INVALID_MESSAGES'
       return this.output.data(res);
     }
 
     if (invalid_option > 0) {
-      res.status = "INVALID_OPTION";
+      res.status = 'INVALID_OPTION'
       return this.output.data(res);
     }
-    let result;
-    if (option == "all") {
-      result = await this.db.await_proc(
-        "channel_delete_hub_all",
-        this.uid,
-        option,
-        stringify(messages),
-      );
+    let result
+    if (option == 'all') {
+      result = await this.db.await_proc('channel_delete_hub_all', this.uid, option, stringify(messages));
     } else {
-      result = await this.db.await_proc(
-        "channel_delete_hub_me",
-        this.uid,
-        option,
-        stringify(messages),
-      );
+      result = await this.db.await_proc('channel_delete_hub_me', this.uid, option, stringify(messages));
     }
     data = result.shift() || [];
     data = toArray(data);
     for (let message of data) {
+
       if (!isEmpty(message.delete_attachment)) {
-        message.delete_attachment = this.parseJSON(message.delete_attachment);
+        message.delete_attachment = this.parseJSON(message.delete_attachment)
         for (let tempattach of message.delete_attachment) {
           let { nid, hub_id } = this.parseJSON(tempattach) || {};
           if (!nid || !hub_id) continue;
-          let { home_dir } = await this.yp.await_proc(
-            "forward_proc",
-            hub_id,
-            "mfs_home",
-            ``,
-          );
+          let { home_dir } = await this.yp.await_proc('forward_proc', hub_id, 'mfs_home', ``)
           let src = { nid, hub_id, home_dir };
           await remove_node(src);
         }
@@ -1318,19 +1164,16 @@ class __private_channel extends Entity {
 
       temp_result.push(message);
 
-      if (option == "all") {
-        let recipients = await this.yp.await_proc(
-          "entity_sockets",
-          this.hub.get(Attr.id),
-        );
+      if (option == 'all') {
+        let recipients = await this.yp.await_proc('entity_sockets', this.hub.get(Attr.id));
         await RedisStore.sendData(this.payload(message), recipients);
       }
     }
-    data = result.shift();
+    data = result.shift()
     data = toArray(data);
     let service = "channel.roominfo";
     for (let msg of data) {
-      let recipients = await this.yp.await_proc("user_sockets", msg.uid);
+      let recipients = await this.yp.await_proc('user_sockets', msg.uid);
       await RedisStore.sendData(this.payload(msg, { service }), recipients);
     }
     this.output.list(temp_result);
@@ -1341,16 +1184,16 @@ class __private_channel extends Entity {
    * Stores message_id + hub_id in notification_bookmark table (user drumate DB).
    */
   async bookmark_add() {
-    const message_id = this.input.need("message_id");
-    const hub_id = this.input.need("hub_id");
+    const message_id = this.input.need('message_id');
+    const hub_id = this.input.need('hub_id');
 
-    const user_db = await this.yp.await_func("get_db_name", this.uid);
-    if (!user_db) return this.exception.server("USER_DB_NOT_FOUND");
+    const user_db = await this.yp.await_func('get_db_name', this.uid);
+    if (!user_db) return this.exception.server('USER_DB_NOT_FOUND');
 
     const data = await this.yp.await_proc(
       `${user_db}.notification_bookmark_add`,
       message_id,
-      hub_id,
+      hub_id
     );
     this.output.data(data);
   }
@@ -1359,14 +1202,14 @@ class __private_channel extends Entity {
    * Unpin (remove) a previously bookmarked notification.
    */
   async bookmark_remove() {
-    const message_id = this.input.need("message_id");
+    const message_id = this.input.need('message_id');
 
-    const user_db = await this.yp.await_func("get_db_name", this.uid);
-    if (!user_db) return this.exception.server("USER_DB_NOT_FOUND");
+    const user_db = await this.yp.await_func('get_db_name', this.uid);
+    if (!user_db) return this.exception.server('USER_DB_NOT_FOUND');
 
     const data = await this.yp.await_proc(
       `${user_db}.notification_bookmark_remove`,
-      message_id,
+      message_id
     );
     this.output.data(data);
   }
@@ -1377,12 +1220,12 @@ class __private_channel extends Entity {
   async bookmark_list() {
     const page = this.input.use(Attr.page, 1);
 
-    const user_db = await this.yp.await_func("get_db_name", this.uid);
-    if (!user_db) return this.exception.server("USER_DB_NOT_FOUND");
+    const user_db = await this.yp.await_func('get_db_name', this.uid);
+    if (!user_db) return this.exception.server('USER_DB_NOT_FOUND');
 
     const data = await this.yp.await_proc(
       `${user_db}.notification_bookmark_list`,
-      page,
+      page
     );
     this.output.list(data);
   }
@@ -1398,14 +1241,14 @@ class __private_channel extends Entity {
    * Returns: { hub_id, home_id, db_name, is_new }
    */
   async dm_init() {
-    const recipient_id = this.input.need("recipient_id");
+    const recipient_id = this.input.need('recipient_id');
     if (!recipient_id || recipient_id === this.uid) {
-      return this.exception.user("Invalid recipient_id.");
+      return this.exception.user('Invalid recipient_id.');
     }
 
     // Get user's drumate DB explicitly
-    const user_db = await this.yp.await_func("get_db_name", this.uid);
-    if (!user_db) return this.exception.server("USER_DB_NOT_FOUND");
+    const user_db = await this.yp.await_func('get_db_name', this.uid);
+    if (!user_db) return this.exception.server('USER_DB_NOT_FOUND');
 
     // Deterministic filename
     const [uid_a, uid_b] = [this.uid, recipient_id].sort();
@@ -1421,8 +1264,8 @@ class __private_channel extends Entity {
            AND m.user_filename = ?
            AND m.status = 'active'
          LIMIT 1`,
-        dm_filename,
-      ),
+        dm_filename
+      )
     )[0];
 
     if (existing && existing.hub_id) {
@@ -1435,34 +1278,21 @@ class __private_channel extends Entity {
     const owner_id = this.uid;
 
     // Sanitise filename for hostname
-    let hostname = dm_filename.replace(
-      /[ \.,;:!&~#'|@*\$><\?\(\)\[\]\{\}\"\/]/g,
-      "",
-    );
-    hostname = await this.yp.await_func("strip_accents", hostname);
-    hostname = hostname.replace(/\-$/, "").trim().toLowerCase();
+    let hostname = dm_filename.replace(/[ \.,;:!&~#'|@*\$><\?\(\)\[\]\{\}\"\/]/g, '');
+    hostname = await this.yp.await_func('strip_accents', hostname);
+    hostname = hostname.replace(/\-$/, '').trim().toLowerCase();
     hostname = new URL(`http://${hostname}`).hostname;
 
-    const args = {
-      hostname,
-      area: "private",
-      filename: dm_filename,
-      owner_id,
-      domain,
-    };
+    const args = { hostname, area: 'private', filename: dm_filename, owner_id, domain };
 
     // Call desk_create_hub in user's drumate DB
-    const rows = await this.yp.await_proc(
-      `${user_db}.desk_create_hub`,
-      args,
-      {},
-    );
+    const rows = await this.yp.await_proc(`${user_db}.desk_create_hub`, args, {});
 
     let hub_id, hub_db, home_id;
     for (const r of toArray(rows)) {
       if (r && r.failed) {
-        this.warn("[dm_init] desk_create_hub failed", rows);
-        return this.exception.server("DM_HUB_CREATION_FAILED");
+        this.warn('[dm_init] desk_create_hub failed', rows);
+        return this.exception.server('DM_HUB_CREATION_FAILED');
       }
       if (r.db_name && r.filesize != null && r.actual_home_id) {
         hub_db = r.db_name;
@@ -1475,7 +1305,7 @@ class __private_channel extends Entity {
     }
 
     if (!hub_id || !hub_db) {
-      return this.exception.server("DM_HUB_CREATION_FAILED");
+      return this.exception.server('DM_HUB_CREATION_FAILED');
     }
 
     // 3. Add recipient as member with Edit+Chat privilege
@@ -1484,21 +1314,21 @@ class __private_channel extends Entity {
       await this.yp.await_proc(`${hub_db}.add_member`, recipient_id, 7, 0);
     } catch (e) {
       // Non-fatal: hub created, recipient can be added later
-      this.warn("[dm_init] add_member failed:", e && e.message);
+      this.warn('[dm_init] add_member failed:', e && e.message);
     }
 
     // 4. Notify recipient via WebSocket
     try {
-      const recipients = await this.yp.await_proc("user_sockets", recipient_id);
+      const recipients = await this.yp.await_proc('user_sockets', recipient_id);
       await RedisStore.sendData(
         this.payload(
-          { hub_id, home_id, db_name: hub_db, event: "dm.new" },
-          { service: "channel.dm_init" },
+          { hub_id, home_id, db_name: hub_db, event: 'dm.new' },
+          { service: 'channel.dm_init' }
         ),
-        recipients,
+        recipients
       );
     } catch (e) {
-      this.warn("[dm_init] notify failed:", e && e.message);
+      this.warn('[dm_init] notify failed:', e && e.message);
     }
 
     this.output.data({ hub_id, home_id, db_name: hub_db, is_new: 1 });
@@ -1527,8 +1357,8 @@ class __private_channel extends Entity {
          WHERE m.category = 'hub'
            AND m.user_filename LIKE '_inbox_%'
            AND m.status = 'active'
-         ORDER BY m.upload_time DESC`,
-      ),
+         ORDER BY m.upload_time DESC`
+      )
     );
 
     if (!hubs.length) {
@@ -1543,10 +1373,9 @@ class __private_channel extends Entity {
 
       // Derive other_uid from filename: _inbox_{uid_a}_{uid_b}
       // Current user is one of them; the other is the recipient
-      const parts = hub.filename.split("_").filter(Boolean);
+      const parts = hub.filename.split('_').filter(Boolean);
       // parts: ['inbox', uid_a, uid_b]
-      const other_uid =
-        parts.find((p) => p !== "inbox" && p !== this.uid) || null;
+      const other_uid = parts.find(p => p !== 'inbox' && p !== this.uid) || null;
 
       let last_message = null;
       let last_message_time = 0;
@@ -1557,21 +1386,13 @@ class __private_channel extends Entity {
 
         // Last message
         const lastMsgs = toArray(
-          await this.yp.await_proc(
-            `${db_name}.channel_list_messages`,
-            this.uid,
-            "date",
-            "desc",
-            1,
-          ),
+          await this.yp.await_proc(`${db_name}.channel_list_messages`, this.uid, 'date', 'desc', 1)
         );
         if (lastMsgs.length) {
           const lm = lastMsgs[0];
-          last_message = lm.message
-            ? String(lm.message).substring(0, 100)
-            : null;
+          last_message = lm.message ? String(lm.message).substring(0, 100) : null;
           last_message_time = lm.ctime || 0;
-          if (!last_message && lm.is_attachment) last_message = "[File]";
+          if (!last_message && lm.is_attachment) last_message = '[File]';
         }
 
         // Unread count
@@ -1585,27 +1406,22 @@ class __private_channel extends Entity {
                  SELECT 1 FROM ${db_name}.read_channel rc
                  WHERE rc.message_id = c.message_id AND rc.uid = ?
                )`,
-            this.uid,
-            this.uid,
-          ),
+            this.uid, this.uid
+          )
         )[0];
-        unread_count = unreadRow ? unreadRow.cnt || 0 : 0;
+        unread_count = unreadRow ? (unreadRow.cnt || 0) : 0;
+
       } catch (e) {
-        this.warn(
-          `[list_conversations] hub ${hub.hub_id} query failed:`,
-          e && e.message,
-        );
+        this.warn(`[list_conversations] hub ${hub.hub_id} query failed:`, e && e.message);
       }
 
       // Get other user's profile
       let other_user = { id: other_uid };
       if (other_uid) {
         try {
-          other_user = (await this.yp.await_proc("get_user", other_uid)) || {
-            id: other_uid,
-          };
+          other_user = await this.yp.await_proc('get_user', other_uid) || { id: other_uid };
         } catch (e) {
-          this.warn("[list_conversations] get_user failed:", e && e.message);
+          this.warn('[list_conversations] get_user failed:', e && e.message);
         }
       }
 
@@ -1633,8 +1449,8 @@ class __private_channel extends Entity {
    * Params: file_nid (required) — media node ID of the file to search in attachment JSON arrays.
    */
   async list_by_file() {
-    const file_nid = this.input.need("file_nid");
-    const data = await this.db.await_proc("channel_list_by_file", file_nid);
+    const file_nid = this.input.need('file_nid');
+    const data = await this.db.await_proc('channel_list_by_file', file_nid);
     this.output.list(data);
   }
 
@@ -1645,22 +1461,16 @@ class __private_channel extends Entity {
    * Params: file_nid (required) — media node ID to find in attachment array OR mention pattern.
    */
   async list_thread_by_file() {
-    const file_nid = this.input.need("file_nid");
+    const file_nid = this.input.need('file_nid');
     const hub_id = this.hub.get(Attr.id);
     const pattern = `mention:${hub_id}:${file_nid}`;
 
-    const attachHits = await this.db.await_proc(
-      "channel_list_by_file",
-      file_nid,
-    );
+    const attachHits = await this.db.await_proc('channel_list_by_file', file_nid);
     let mentionHits = [];
     try {
-      mentionHits = await this.db.await_proc("channel_search", pattern);
+      mentionHits = await this.db.await_proc('channel_search', pattern);
     } catch (e) {
-      console.warn(
-        "[list_thread_by_file] channel_search failed (continuing with attach-only):",
-        e && e.message,
-      );
+      console.warn('[list_thread_by_file] channel_search failed (continuing with attach-only):', e && e.message);
     }
 
     const attachArr = toArray(attachHits);
@@ -1671,10 +1481,7 @@ class __private_channel extends Entity {
     // render attachment, mention_ids, thread_id, status, metadata. Skip ids
     // already present in attachHits to avoid duplicate work.
     const attachIds = new Set(
-      attachArr
-        .map((r) => r && r.message_id)
-        .filter(Boolean)
-        .map(String),
+      attachArr.map(r => r && r.message_id).filter(Boolean).map(String)
     );
     const mentionOnlyIds = [];
     for (const r of mentionArr) {
@@ -1685,33 +1492,29 @@ class __private_channel extends Entity {
     let mentionRows = [];
     for (const mid of mentionOnlyIds) {
       try {
-        const full = await this.db.await_proc("channel_get", mid);
+        const full = await this.db.await_proc('channel_get', mid);
         const row = Array.isArray(full) ? full[0] : full;
         if (row && row.message_id) {
           mentionRows.push(row);
           continue;
         }
         // Fallback: synthesize minimal shape from channel_search projection
-        const src = mentionArr.find((r) => String(r.id) === mid) || {};
+        const src = mentionArr.find(r => String(r.id) === mid) || {};
         mentionRows.push({
           sys_id: 0,
-          author_id: src.author_id || "",
-          message: src.preview || "",
+          author_id: src.author_id || '',
+          message: src.preview || '',
           message_id: mid,
           thread_id: null,
-          attachment: "[]",
+          attachment: '[]',
           is_forward: 0,
           mention_ids: [],
-          status: "active",
+          status: 'active',
           ctime: src.ctime || 0,
           metadata: null,
         });
       } catch (e) {
-        console.warn(
-          "[list_thread_by_file] channel_get failed for",
-          mid,
-          e && e.message,
-        );
+        console.warn('[list_thread_by_file] channel_get failed for', mid, e && e.message);
       }
     }
 
@@ -1722,9 +1525,8 @@ class __private_channel extends Entity {
         byId.set(String(key), row);
       }
     }
-    const merged = Array.from(byId.values()).sort(
-      (a, b) => (b.ctime || 0) - (a.ctime || 0),
-    );
+    const merged = Array.from(byId.values())
+      .sort((a, b) => (b.ctime || 0) - (a.ctime || 0));
 
     // Enrich each row to match channel.messages contract:
     // - message.entity = shareroom_contact_get(author_id) — kept as-is
@@ -1742,18 +1544,13 @@ class __private_channel extends Entity {
         } else {
           try {
             message.entity = await this.yp.await_proc(
-              "forward_proc",
-              this.uid,
-              "shareroom_contact_get",
-              `'${message.author_id}'`,
+              'forward_proc', this.uid, 'shareroom_contact_get',
+              `'${message.author_id}'`
             );
             contactCache[key] = message.entity;
           } catch (e) {
-            console.warn(
-              "[list_thread_by_file] shareroom_contact_get failed for",
-              message.author_id,
-              e && e.message,
-            );
+            console.warn('[list_thread_by_file] shareroom_contact_get failed for',
+              message.author_id, e && e.message);
           }
         }
       }
@@ -1763,30 +1560,20 @@ class __private_channel extends Entity {
         let profile = profileCache[key];
         if (!profile) {
           try {
-            const raw = await this.yp.await_proc(
-              "drumate_get",
-              message.author_id,
-            );
-            profile = Array.isArray(raw) ? raw[0] || {} : raw || {};
+            const raw = await this.yp.await_proc('drumate_get', message.author_id);
+            profile = Array.isArray(raw) ? (raw[0] || {}) : (raw || {});
             profileCache[key] = profile;
           } catch (e) {
-            console.warn(
-              "[list_thread_by_file] drumate_get failed for",
-              message.author_id,
-              e && e.message,
-            );
+            console.warn('[list_thread_by_file] drumate_get failed for',
+              message.author_id, e && e.message);
             profile = {};
             profileCache[key] = profile;
           }
         }
-        if (!message.firstname && profile.firstname)
-          message.firstname = profile.firstname;
-        if (!message.lastname && profile.lastname)
-          message.lastname = profile.lastname;
-        if (!message.surname && profile.surname)
-          message.surname = profile.surname;
-        if (!message.fullname && profile.fullname)
-          message.fullname = profile.fullname;
+        if (!message.firstname && profile.firstname) message.firstname = profile.firstname;
+        if (!message.lastname && profile.lastname) message.lastname = profile.lastname;
+        if (!message.surname && profile.surname) message.surname = profile.surname;
+        if (!message.fullname && profile.fullname) message.fullname = profile.fullname;
         if (!message.email && profile.email) message.email = profile.email;
       }
 
@@ -1794,11 +1581,8 @@ class __private_channel extends Entity {
         try {
           message.thread = await this.threadInfo(message.thread_id, hub_id);
         } catch (e) {
-          console.warn(
-            "[list_thread_by_file] threadInfo failed for",
-            message.thread_id,
-            e && e.message,
-          );
+          console.warn('[list_thread_by_file] threadInfo failed for',
+            message.thread_id, e && e.message);
         }
       }
     }
@@ -1806,5 +1590,8 @@ class __private_channel extends Entity {
     this.output.list(merged);
   }
 }
+
+
+
 
 module.exports = __private_channel;

--- a/service/private/chat.js
+++ b/service/private/chat.js
@@ -1056,6 +1056,17 @@ class privateChat extends Entity {
       res.status = "INVALID_ATTACHMENT";
       return this.output.data(res);
     }
+    // The chat staging folder is writable by every hub member; the ACL doc
+    // promises owner-only removal — enforce it so one member cannot delete
+    // another member's pending attachment.
+    let owners = await this.db.await_query(
+      "SELECT owner_id, origin_id FROM media WHERE id=?", `${nid}`
+    );
+    let owner = toArray(owners)[0] || {};
+    if (`${owner.owner_id}` !== `${this.uid}` && `${owner.origin_id}` !== `${this.uid}`) {
+      res.status = "INVALID_ATTACHMENT";
+      return this.output.data(res);
+    }
 
     await this.db.await_proc("mfs_attachment_remove", nid);
     let mfs_home = await this.db.await_proc("mfs_home");


### PR DESCRIPTION
## Summary

Folder-scoped chat clients now upload device attachments to hub chat staging (/__chat__/__upload__/) instead of directly into the folder. channel.post gains a folder_attachment param to move listed staged nids into the scoped folder at send time, then run the existing copy-to-sbox flow unchanged. Old clients without folder_attachment keep existing copy-only behaviour.

## Security Hardening

- Validate every client-supplied attachment id against strict id format before any proc-call interpolation
- Classification anchors on parent_id == chat_upload_id (not file_path substring) and requires caller ownership
- Moving into folder is a write: caller must hold write permission on destination, otherwise demoted to sbox-only
- Promotion is separate mfs_move_all call; same-hub moves keep nid, cross-hub moves remap from des_id
- Each promoted nid confirmed by parent check before trusted
- Staged workspace copies purged only after channel_post_message AND channel_post_attachment succeed (retry-safe)
- remove_attachment now enforces owner-only removal (ACL doc promise)

## Deployment Note

This PR must be deployed BEFORE the companion ui-team PR: `fix(chat): keep folder-chat attachments out of the folder until send`

## Backward Compatibility

Old clients sending no folder_attachment parameter keep existing copy-only behaviour.