### PR TITLE
chore: gitignore BMad generated dirs (_bmad, _bmad-output)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ package-lock.json
 /package-lock.json
 .dev-tools.rc
 .claude/
+
+# BMad (bmad-method) — generated, do not commit
+_bmad/
+_bmad-output/


### PR DESCRIPTION
## What
Add `.gitignore` entries for the BMad Method (`bmad-method`) local install:

- `_bmad/` — generated framework/core + `bmm` module
- `_bmad-output/` — generated planning/implementation artifacts

`.claude/skills/` (44 BMad skills) is already covered by the existing `.claude/` ignore rule.

## Why
`npx bmad-method install` was run locally; these generated directories must not be committed to the repo.

## Notes
⚠️ The `guard-preview-source` workflow requires PRs into `preview` to originate from the `test` branch. This PR comes from a feature branch, so that check will fail **by design** — merging requires an admin override (or re-routing through `test`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
