### PR TITLE
Secure share v2 (test) → preview (server)

### DIFF
--- a/acl/secure_share.json
+++ b/acl/secure_share.json
@@ -142,6 +142,13 @@
         "src": "read"
       }
     },
+    "list_open_notifications": {
+      "doc": "List recent share-open events across the current user's secure shares (creator), deduped per recipient, for the activity notification panel. Read-only; the SP filters by creator_id and notify_on_open.",
+      "scope": "hub",
+      "permission": {
+        "src": "read"
+      }
+    },
     "revoke": {
       "doc": "Revoke a secure share token (soft delete — sets revoked_at timestamp). Broadcasts a secure_share_revoked event via Redis to all hub socket connections so the recipient loses access instantly.",
       "scope": "hub",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.54",
+  "version": "2.9.55",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.54",
+      "version": "2.9.55",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.51",
+  "version": "2.9.52",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.51",
+      "version": "2.9.52",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.50",
+  "version": "2.9.51",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.50",
+      "version": "2.9.51",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.53",
+  "version": "2.9.54",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.53",
+      "version": "2.9.54",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.47",
+  "version": "2.9.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.47",
+      "version": "2.9.48",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.46",
+  "version": "2.9.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.46",
+      "version": "2.9.47",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.49",
+  "version": "2.9.50",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.49",
+      "version": "2.9.50",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.48",
+  "version": "2.9.49",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.48",
+      "version": "2.9.49",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.45",
+  "version": "2.9.46",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.45",
+      "version": "2.9.46",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.52",
+  "version": "2.9.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.52",
+      "version": "2.9.53",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.46",
+  "version": "2.9.47",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.48",
+  "version": "2.9.49",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.45",
+  "version": "2.9.46",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.49",
+  "version": "2.9.50",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.51",
+  "version": "2.9.52",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.52",
+  "version": "2.9.53",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.50",
+  "version": "2.9.51",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.53",
+  "version": "2.9.54",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.54",
+  "version": "2.9.55",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.47",
+  "version": "2.9.48",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -696,9 +696,12 @@ class __dmz extends Mfs {
       return this.output.data({ status: 'INVALID_TOKEN' });
     }
 
-    if (row.hub_id) {
+    // Notify ONLY the share creator (their desk activity panel), not the whole hub.
+    // A hub-wide broadcast (entity_sockets) carries requester_email + the free-form
+    // message to every other recipient who has the share open — a privacy leak.
+    if (row.creator_id) {
       try {
-        const recipients = await this.yp.await_proc('entity_sockets', { hub_id: row.hub_id });
+        const recipients = await this.yp.await_proc('user_sockets', row.creator_id);
         await RedisStore.sendData(
           this.payload(
             {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -462,10 +462,15 @@ class __dmz extends Mfs {
         // download). The SP returns all approved grants for this recipient, latest
         // first; older deployments returned only the latest, and the union is
         // correct for both. can_view carries no extra capability, so it is skipped.
+        // granted_level is now a SET (comma-list) — a single approval may grant
+        // several levels at once (multi-select request). Split and union each.
         for (const g of grantRows) {
-          const lvl = g && g.granted_level;
-          if (!lvl || lvl === 'can_view') continue;
-          if (caps.indexOf(lvl) === -1) caps.push(lvl);
+          const raw = g && g.granted_level;
+          if (!raw) continue;
+          for (const lvl of String(raw).split(',').map(s => s.trim()).filter(Boolean)) {
+            if (lvl === 'can_view') continue;
+            if (caps.indexOf(lvl) === -1) caps.push(lvl);
+          }
         }
         // permission_level is a legacy single-value display field — reflect the
         // latest approved grant (first row); the capabilities array above is the
@@ -697,13 +702,20 @@ class __dmz extends Mfs {
     const VALID_LEVELS = ['can_download', 'can_chat', 'can_edit'];
     const token          = this.input.need(Attr.token);
     const rawEmail       = (this.input.get(Attr.email) || '').toLowerCase().trim();
-    const requestedLevel = (this.input.get('requested_level') || '').trim();
-    const message        = (this.input.get('message') || '').trim() || null;
+    // Multi-level: the recipient may request several permissions at once (e.g.
+    // chat + edit). Accept a comma-list, normalise (dedupe, drop blanks), and
+    // require every level to be valid. Stored into the requested_level SET column.
+    const requestedLevels = Array.from(new Set(
+      (this.input.get('requested_level') || '')
+        .split(',').map(s => s.trim()).filter(Boolean)
+    ));
+    const requestedLevel  = requestedLevels.join(',');
+    const message         = (this.input.get('message') || '').trim() || null;
 
     if (!rawEmail || !rawEmail.includes('@')) {
       return this.output.data({ status: 'INVALID_EMAIL' });
     }
-    if (!VALID_LEVELS.includes(requestedLevel)) {
+    if (!requestedLevels.length || requestedLevels.some(l => !VALID_LEVELS.includes(l))) {
       return this.output.data({ status: 'INVALID_LEVEL' });
     }
 

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -418,8 +418,10 @@ class __dmz extends Mfs {
       caps = [info.permission_level];
     }
 
-    // If the guest previously had an approved access request, that grant
-    // REPLACES the base set (the sender deliberately chose what to grant).
+    // If the guest previously had an approved access request, that grant ADDS to
+    // the share's base capabilities — it does NOT replace them. The Request Access
+    // popup grants one level at a time, so a chat-only share whose recipient is
+    // later approved for download must end up with chat AND download.
     // The grant is keyed by requester_email. The email gate provides submittedEmail,
     // but a PUBLIC share has no gate — so a logged-in recipient who requested access
     // (the Request Access popup prefills their account email as requester_email) had
@@ -452,12 +454,24 @@ class __dmz extends Mfs {
     }
     if (grantEmail) {
       try {
-        const grantRow = toArray(
+        const grantRows = toArray(
           await this.yp.await_proc('secure_share_get_access_grant', token, grantEmail)
-        )[0] || {};
-        if (grantRow.granted_level) {
-          info.permission_level = grantRow.granted_level;
-          caps = (grantRow.granted_level === 'can_view') ? [] : [grantRow.granted_level];
+        );
+        // UNION every approved grant onto the share's base caps (do not overwrite —
+        // that dropped the chat cap when a chat-share recipient was approved for
+        // download). The SP returns all approved grants for this recipient, latest
+        // first; older deployments returned only the latest, and the union is
+        // correct for both. can_view carries no extra capability, so it is skipped.
+        for (const g of grantRows) {
+          const lvl = g && g.granted_level;
+          if (!lvl || lvl === 'can_view') continue;
+          if (caps.indexOf(lvl) === -1) caps.push(lvl);
+        }
+        // permission_level is a legacy single-value display field — reflect the
+        // latest approved grant (first row); the capabilities array above is the
+        // authoritative set the recipient UI gates on.
+        if (grantRows[0] && grantRows[0].granted_level) {
+          info.permission_level = grantRows[0].granted_level;
         }
       } catch (e) {
         this.warn('[dmz.login] secure_share_get_access_grant failed:', e && e.message);

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -173,7 +173,11 @@ class __dmz extends Mfs {
         const secureRes = await this.yp.await_proc('secure_share_info', token);
         if (!isEmpty(secureRes) && !secureRes.failed) {
           res = secureRes;
+          // Never expose secrets/recipient lists to an unauthenticated info probe
+          // (mirrors _loginSecureShare's safeInfo): allowed_emails would otherwise let
+          // a viewer enumerate the allow-list before passing the gate.
           delete res.password_hash;
+          delete res.allowed_emails;
         }
       } catch (e) {
         this.warn('[dmz.info] secure_share_info lookup failed:', e && e.message);
@@ -184,7 +188,20 @@ class __dmz extends Mfs {
       res = res || {};
       res.status = 'WRONG_TICKET';
     } else if (res.is_secure) {
-      res.status = res.validity === 'TICKET_OK' ? 'REQUIRED_EMAIL' : res.validity;
+      // Report the share's ACTUAL gate, not a blanket REQUIRED_EMAIL. A revoked/
+      // expired share keeps its validity; a valid one is email-gated only if it
+      // requires email (or a legacy single recipient), else password-gated, else
+      // public (TICKET_OK). The only caller (sharebox revoke poller) acts solely on
+      // TICKET_REVOKED/TICKET_EXPIRED, so this is safe for it.
+      if (res.validity !== 'TICKET_OK') {
+        res.status = res.validity;
+      } else if (res.require_email || res.recipient_email) {
+        res.status = 'REQUIRED_EMAIL';
+      } else if (res.require_password) {
+        res.status = 'REQUIRED_PASSWORD';
+      } else {
+        res.status = 'TICKET_OK';
+      }
     } else if (res.require_password) {
       res.status = 'REQUIRED_PASSWORD';
     }

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -312,7 +312,6 @@ class __dmz extends Mfs {
 
     // Valid access — log it and notify sender in real time
     const actor_id = (guest_id === user.id) ? null : (user.id || null);
-    this.warn('[SS-DBG] open-enter token=' + token + ' actor=' + actor_id + ' sock=' + (this.input.get(Attr.socket_id) || 'MISSING') + ' email=' + (submittedEmail || 'none') + ' auth=' + isAuthenticated + ' member=' + (this.input.get('is_member') || '?'));
     try {
       const track = await this.yp.await_proc('secure_share_access_log', token, actor_id, this.input.get(Attr.socket_id));
       // v2: also record a per-visit access event (entered_at / last_seen_at) backing
@@ -327,13 +326,11 @@ class __dmz extends Mfs {
         this.warn('[dmz.login] secure_share access_event failed:', e && e.message);
       }
       const row   = toArray(track)[0] || {};
-      this.warn('[SS-DBG] after-log hub=' + (row.hub_id || 'NONE') + ' notify=' + info.notify_on_open);
       // The access counter always updates above; the SENDER notification only
       // fires when the share has notify_on_open enabled (default 1; legacy rows
       // without the field keep notifying). info comes from secure_share_info.
       if (row.hub_id && info.notify_on_open != 0) {
         const recipients = await this.yp.await_proc('entity_sockets', { hub_id: row.hub_id });
-        this.warn('[SS-DBG] broadcast recipients=' + (Array.isArray(recipients) ? recipients.length : 'NONE'));
         await RedisStore.sendData(
           this.payload(
             {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -426,21 +426,29 @@ class __dmz extends Mfs {
     // no email to match on refresh, and the approved grant was never applied → the
     // download/chat stayed gated even after approval. Fall back to the account email.
     let grantEmail = submittedEmail;
-    // Explicit grant-lookup email replayed by the recipient UI from localStorage
-    // (the email they sent the Request Access with). Used ONLY to match an approved
-    // grant — never the email gate (the gate uses submittedEmail) — so it cannot let
-    // anyone bypass a restricted share; it only resolves a grant already issued to
-    // that exact email. Lets anonymous (incognito) recipients keep access after a
-    // refresh, where there is no account email to key on.
-    if (!grantEmail) {
-      const ge = (this.input.get('grant_email') || '').toLowerCase().trim();
-      if (ge) grantEmail = ge;
-    }
+    // Authenticated viewers: key the grant lookup to their OWN account email, and
+    // NEVER a client-supplied grant_email. Otherwise one signed-in account could
+    // replay another requester's approved email (the response event even carries
+    // requester_email) to claim that grant. Account email takes precedence; the
+    // client value is ignored for an authenticated session.
     if (!grantEmail && isAuthenticated && user.profile) {
       try {
         const p = typeof user.profile === 'string' ? JSON.parse(user.profile) : user.profile;
         grantEmail = (p.email || '').toLowerCase().trim();
       } catch (e) { /* ignore */ }
+    }
+    // ANONYMOUS (incognito) viewers only: fall back to the email they requested with,
+    // replayed by the UI from localStorage, so they keep access after a refresh (no
+    // account email to key on). It only resolves a grant already issued to that exact
+    // email and never affects the email gate (which uses submittedEmail).
+    // ⚠ KNOWN RESIDUAL: on a PUBLIC link this is replayable — a determined anonymous
+    // viewer who learns another requester's approved email could claim that grant.
+    // Fully closing it needs the anonymous guest-identity fix (see
+    // secure-share-enforcement-gap.md). Guarded to !isAuthenticated so it can never
+    // override an authenticated session's own account email.
+    if (!grantEmail && !isAuthenticated) {
+      const ge = (this.input.get('grant_email') || '').toLowerCase().trim();
+      if (ge) grantEmail = ge;
     }
     if (grantEmail) {
       try {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -312,6 +312,7 @@ class __dmz extends Mfs {
 
     // Valid access — log it and notify sender in real time
     const actor_id = (guest_id === user.id) ? null : (user.id || null);
+    this.warn('[SS-DBG] open-enter token=' + token + ' actor=' + actor_id + ' sock=' + (this.input.get(Attr.socket_id) || 'MISSING') + ' email=' + (submittedEmail || 'none') + ' auth=' + isAuthenticated + ' member=' + (this.input.get('is_member') || '?'));
     try {
       const track = await this.yp.await_proc('secure_share_access_log', token, actor_id, this.input.get(Attr.socket_id));
       // v2: also record a per-visit access event (entered_at / last_seen_at) backing
@@ -326,11 +327,13 @@ class __dmz extends Mfs {
         this.warn('[dmz.login] secure_share access_event failed:', e && e.message);
       }
       const row   = toArray(track)[0] || {};
+      this.warn('[SS-DBG] after-log hub=' + (row.hub_id || 'NONE') + ' notify=' + info.notify_on_open);
       // The access counter always updates above; the SENDER notification only
       // fires when the share has notify_on_open enabled (default 1; legacy rows
       // without the field keep notifying). info comes from secure_share_info.
       if (row.hub_id && info.notify_on_open != 0) {
         const recipients = await this.yp.await_proc('entity_sockets', { hub_id: row.hub_id });
+        this.warn('[SS-DBG] broadcast recipients=' + (Array.isArray(recipients) ? recipients.length : 'NONE'));
         await RedisStore.sendData(
           this.payload(
             {

--- a/service/lib/secure-share-write-guard.js
+++ b/service/lib/secure-share-write-guard.js
@@ -1,0 +1,92 @@
+// ==================================================================== *
+//   Secure-share write guard
+//   Shared by media.js write handlers (upload, make_dir) to enforce a secure-
+//   share recipient's capability set SERVER-SIDE.
+//
+//   The DMZ guest session is cookie-bound to the share CREATOR (so hub
+//   endpoints like media.show_node_by resolve), which means this.uid carries
+//   the creator's FULL privilege — the normal write ACL therefore always passes
+//   for a recipient, regardless of the share's level. This guard re-derives the
+//   RECIPIENT's effective write capability (base share caps UNION approved
+//   access grants) directly from the share token, mirroring the login logic in
+//   dmz.js::_loginSecureShare. Keep the two in sync.
+// ==================================================================== *
+const { toArray } = require("@drumee/server-essentials");
+
+function parseCaps(raw) {
+  if (Array.isArray(raw)) return raw.slice();
+  if (typeof raw === "string" && raw.trim()) {
+    try {
+      const p = JSON.parse(raw);
+      if (Array.isArray(p)) return p;
+    } catch (e) {
+      /* ignore malformed JSON */
+    }
+  }
+  return [];
+}
+
+/**
+ * Decide whether a secure-share recipient may perform a write (upload / mkdir).
+ *
+ * @param {*} yp              yellow-page DB handle (await_proc)
+ * @param {string} token      the share token sent with the write request
+ * @param {string} recipientEmail  resolved by the caller — account email for an
+ *                            authenticated viewer, replayed grant_email for an
+ *                            anonymous one (mirrors _loginSecureShare keying)
+ * @returns {Promise<null|boolean>}
+ *   null  → NOT a secure-share write (no token, or token is not a secure share,
+ *           e.g. a legacy DMZ folder link) → caller proceeds with normal ACL.
+ *   true  → secure-share recipient HAS can_edit (base or approved grant) → allow.
+ *   false → secure-share recipient lacks can_edit → caller must deny.
+ */
+async function secureShareWriteVerdict(yp, token, recipientEmail) {
+  if (!token) return null;
+
+  let info;
+  try {
+    info = toArray(await yp.await_proc("secure_share_info", token))[0];
+  } catch (e) {
+    // DB error: we cannot classify the token. Fail OPEN so a transient hiccup
+    // never blocks normal/legacy writes — the client-side gate still applies.
+    return null;
+  }
+  // Not a secure share (failed=1 / no creator) → legacy or invalid token; this
+  // guard does not apply, so existing behaviour is left untouched.
+  if (!info || info.failed || !info.creator_id) return null;
+  // Revoked or expired share → no write. secure_share_info exposes this only as
+  // a computed `validity` string (there is no revoked_at output column).
+  if (info.validity && info.validity !== "TICKET_OK") return false;
+
+  let caps = parseCaps(info.capabilities);
+  if (!caps.length && info.permission_level && info.permission_level !== "can_view") {
+    caps = [info.permission_level];
+  }
+  if (caps.indexOf("can_edit") !== -1) return true;
+
+  // No base edit grant — check this recipient's APPROVED access requests. The
+  // grant union is keyed by the recipient email the caller resolved, exactly as
+  // _loginSecureShare does (can_edit can be requested + approved, so a view-only
+  // base share may legitimately have an edit-upgraded recipient).
+  const email = (recipientEmail || "").toLowerCase().trim();
+  if (email) {
+    try {
+      const grants = toArray(
+        await yp.await_proc("secure_share_get_access_grant", token, email)
+      );
+      for (const g of grants) {
+        const raw = g && g.granted_level;
+        if (!raw) continue;
+        for (const lvl of String(raw).split(",").map((s) => s.trim())) {
+          if (lvl === "can_edit") return true;
+        }
+      }
+    } catch (e) {
+      // Grant lookup failed on a CONFIRMED secure share → fall through to deny
+      // (fail closed).
+    }
+  }
+  return false;
+}
+
+module.exports = { secureShareWriteVerdict };

--- a/service/media.js
+++ b/service/media.js
@@ -21,10 +21,12 @@ const {
 } = require("@drumee/server-essentials");
 const indexQueue = require("../offline/queues/indexQueue");
 const { writeAudit } = require("./private/_audit");
+const { secureShareWriteVerdict } = require("./lib/secure-share-write-guard");
 const { DENIED } = Events;
 const {
   BATCH_FILE,
   CARD,
+  ID_NOBODY,
   DIRNAME,
   DOWNLOAD_FOLDER,
   FAILED_CREATE_FILE,
@@ -116,10 +118,66 @@ class __media extends Mfs {
   }
 
   /**
+   * Server-side enforcement of a secure-share recipient's WRITE capability.
+   *
+   * A DMZ secure-share guest session is cookie-bound to the share CREATOR (so
+   * hub endpoints resolve), which means this.uid carries the creator's FULL
+   * privilege and the normal write ACL always passes — even for a view-only
+   * recipient. This re-derives the RECIPIENT's effective write capability from
+   * the share token (base caps UNION approved access grants, mirroring
+   * dmz.js::_loginSecureShare) and denies when can_edit is absent.
+   *
+   * Non-secure-share writes are never affected: with no token, or a legacy DMZ
+   * token, the verdict is null and the caller proceeds with the normal ACL.
+   *
+   * Side-effect free — the caller rejects with the primitive appropriate to its
+   * phase (pre_upload is an ACL checker → trigger(DENIED); make_dir is a service
+   * method → exception.forbiden()).
+   *
+   * @returns {Promise<boolean>} true → may proceed; false → caller must reject
+   */
+  async _secureShareWriteAllowed() {
+    const token = this.input.get(Attr.token);
+    if (!token) return true;
+
+    // Resolve the recipient email exactly as _loginSecureShare does: an
+    // AUTHENTICATED viewer is keyed to their OWN account email (never a
+    // client-supplied value); an ANONYMOUS viewer to the grant_email the UI
+    // replays. The account email always wins so a signed-in session can't claim
+    // another requester's approved grant.
+    let email = "";
+    try {
+      const cookie = this.input.get(Attr.cookie) || {};
+      const regsid = cookie.regsid;
+      if (regsid) {
+        const guest_id = Cache.getSysConf("guest_id");
+        const u = await this.yp.await_proc("cookie_retrieve_user", regsid);
+        if (u && u.id && ![ID_NOBODY, guest_id].includes(u.id) && u.profile) {
+          const p = typeof u.profile === "string" ? JSON.parse(u.profile) : u.profile;
+          email = ((p && p.email) || "").toLowerCase().trim();
+        }
+      }
+    } catch (e) {
+      // fall through to the anonymous path
+    }
+    if (!email) {
+      email = (this.input.get("grant_email") || "").toLowerCase().trim();
+    }
+
+    const verdict = await secureShareWriteVerdict(this.yp, token, email);
+    if (verdict === false) {
+      this.warn("[secure-share] write denied: recipient lacks can_edit");
+      return false;
+    }
+    return true;
+  }
+
+  /**
    *
    * @returns
    */
   async make_dir() {
+    if (!(await this._secureShareWriteAllowed())) return this.exception.forbiden();
     const parent = this.source_granted();
     const pid = parent.id || this.home_id;
     let ownpath = decodeURI(this.input.get(Attr.ownpath));
@@ -315,6 +373,11 @@ class __media extends Mfs {
   async pre_upload() {
     let json_str;
 
+    if (!(await this._secureShareWriteAllowed())) {
+      this.warn("Secure-share upload denied: recipient lacks can_edit");
+      this.trigger(DENIED);
+      return;
+    }
     if (this.session.isAnonymous()) {
       const token = this.input.use(Attr.token);
       if (isEmpty(token) && isEmpty(this.input.sid())) {

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -183,6 +183,16 @@ class __secure_share extends Mfs {
    */
   async list_open_notifications() {
     const rows = toArray(await this.yp.await_proc('secure_share_list_open_notifications', this.uid));
+    // TEMP DIAGNOSTIC (debug-level → not alerting). Compares the SP output (filtered)
+    // against the raw access events for this creator, to see if a logged-in open is
+    // recorded but filtered, or never recorded. Remove after diagnosing.
+    try {
+      const raw = toArray(await this.yp.await_query(
+        "SELECT e.actor_id, e.recipient_email, e.socket_id, e.last_seen_at, t.creator_id, t.notify_on_open " +
+        "FROM secure_share_access_event e JOIN secure_share_token t ON t.id = e.token_id " +
+        "WHERE t.creator_id = ? ORDER BY e.last_seen_at DESC LIMIT 10", this.uid));
+      this.debug('[SS-OPEN-DBG] creator=' + this.uid + ' SP_returned=' + rows.length + ' RAW=' + JSON.stringify(raw));
+    } catch (e) { this.debug('[SS-OPEN-DBG] raw query failed: ' + (e && e.message)); }
     for (const r of rows) {
       if (!r || !r.hub_id || !r.node_id) continue;
       try {

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -65,6 +65,15 @@ class __secure_share extends Mfs {
     // which emails are accepted. Sent as integer 1/0 (SP reads it via JSON_VALUE).
     const requireEmail = this.input.get('require_email') ? 1 : 0;
 
+    // Defense-in-depth (the sender UI also blocks this): "require email to view"
+    // must restrict to at least one allowed email/domain. With an empty allow-list
+    // the gate would accept ANY email — a cosmetic, non-real gate. Reject the create
+    // rather than publish an any-email link (per Lexis 2026-06-14). Existing shares
+    // are unaffected (create-time only).
+    if (requireEmail && !allowedEmails) {
+      return this.output.data({ status: 'REQUIRE_EMAIL_NEEDS_ALLOWED' });
+    }
+
     // Notify the sender in real time when a recipient opens the share. Defaults
     // to ON (1) when the field is omitted, preserving the previous always-notify
     // behaviour. Coerced to integer 1/0 to avoid the JSON-bool→TINYINT trap.

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -189,8 +189,10 @@ class __secure_share extends Mfs {
       const svcOpt = { service: 'share.track_event' };
 
       try {
-        // Broadcast to hub members (sender's window refreshes its list)
-        const recipients = await this.yp.await_proc('entity_sockets', { hub_id });
+        // Broadcast to the SHARE's hub (row.hub_id), not the revoker's current
+        // workspace (this.hub) — same fix as respond_to_access_request, so the
+        // sender's list refreshes even when revoking from a different/global context.
+        const recipients = await this.yp.await_proc('entity_sockets', { hub_id: row.hub_id || hub_id });
         await RedisStore.sendData(this.payload(eventData, svcOpt), recipients);
       } catch (e) {
         this.warn('[secure_share.revoke] hub broadcast failed:', e && e.message);

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -183,16 +183,6 @@ class __secure_share extends Mfs {
    */
   async list_open_notifications() {
     const rows = toArray(await this.yp.await_proc('secure_share_list_open_notifications', this.uid));
-    // TEMP DIAGNOSTIC (debug-level → not alerting). Compares the SP output (filtered)
-    // against the raw access events for this creator, to see if a logged-in open is
-    // recorded but filtered, or never recorded. Remove after diagnosing.
-    try {
-      const raw = toArray(await this.yp.await_query(
-        "SELECT e.actor_id, e.recipient_email, e.socket_id, e.last_seen_at, t.creator_id, t.notify_on_open " +
-        "FROM secure_share_access_event e JOIN secure_share_token t ON t.id = e.token_id " +
-        "WHERE t.creator_id = ? ORDER BY e.last_seen_at DESC LIMIT 10", this.uid));
-      this.debug('[SS-OPEN-DBG] creator=' + this.uid + ' SP_returned=' + rows.length + ' RAW=' + JSON.stringify(raw));
-    } catch (e) { this.debug('[SS-OPEN-DBG] raw query failed: ' + (e && e.message)); }
     for (const r of rows) {
       if (!r || !r.hub_id || !r.node_id) continue;
       try {

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -176,6 +176,26 @@ class __secure_share extends Mfs {
   }
 
   /**
+   * List recent share-open events across the current user's secure shares, for the
+   * activity notification panel ("{who} opened {folder}"). The SP filters by
+   * creator_id + notify_on_open and dedupes per recipient. Read-only; mirrors
+   * list_requests' node-name enrichment so the panel can show the shared folder.
+   */
+  async list_open_notifications() {
+    const rows = toArray(await this.yp.await_proc('secure_share_list_open_notifications', this.uid));
+    for (const r of rows) {
+      if (!r || !r.hub_id || !r.node_id) continue;
+      try {
+        const a = toArray(
+          await this.yp.await_proc('forward_proc', r.hub_id, 'mfs_node_attr', `'${r.node_id}'`)
+        )[0] || {};
+        if (a.filename) r.node_name = a.filename;
+      } catch (e) { /* keep fallback */ }
+    }
+    this.output.list(rows);
+  }
+
+  /**
    * Revoke a secure share token (soft delete).
    * Broadcasts a real-time event so the recipient loses access immediately.
    */

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -251,6 +251,15 @@ class __secure_share extends Mfs {
     let   email  = (this.input.get(Attr.email) || '').toLowerCase().trim();
     let   uid    = (this.input.get(Attr.uid) || '').trim() || null;
 
+    // Only the secure-share CREATOR may revoke a recipient. secure_share_list is
+    // creator-scoped (filters by this.uid), so a non-empty result means the caller
+    // owns a share on this node. Otherwise deny — a workspace contributor with mere
+    // write access on the node must not be able to strip another user's grant.
+    const owned = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
+    if (!owned.length) {
+      return this.output.data({ status: 'FORBIDDEN' });
+    }
+
     // Resolve the uid from the email when the row didn't carry one (signed-in
     // recipients have actor_id; anonymous public viewers do not).
     if (!uid && email) {

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -371,7 +371,14 @@ class __secure_share extends Mfs {
       can_edit       : row.granted_level === 'can_edit' ? 1 : 0,
     };
     try {
-      const hub_id = this.hub.get(Attr.id);
+      // Target the SHARE's hub (row.hub_id from the request), NOT the approver's
+      // current workspace context (this.hub) — the sender often approves from the
+      // global activity panel while in a different/no workspace, so this.hub did
+      // not match the share's hub, and the broadcast reached neither the guest
+      // (whose DMZ socket is bound into the share's hub via the creator) nor the
+      // sender → the approval never arrived real-time. Fall back to this.hub only
+      // if the row somehow lacks it.
+      const hub_id = row.hub_id || this.hub.get(Attr.id);
       const targets = await this.yp.await_proc('entity_sockets', { hub_id });
       // Include the recipient's last-known socket too, in case it isn't in the hub set.
       if (row.guest_socket_id) targets.push({ socket_id: row.guest_socket_id });

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -351,12 +351,17 @@ class __secure_share extends Mfs {
 
     const requestId    = this.input.need('request_id');
     const action       = (this.input.get('action') || '').trim();
-    const grantedLevel = (this.input.get('granted_level') || '').trim() || null;
+    // Multi-level: the sender may grant several levels at once (multi-select
+    // request). Normalise the comma-list, dedupe, and require every level valid.
+    const grantedLevels = Array.from(new Set(
+      (this.input.get('granted_level') || '').split(',').map(s => s.trim()).filter(Boolean)
+    ));
+    const grantedLevel = grantedLevels.join(',') || null;
 
     if (!VALID_ACTIONS.includes(action)) {
       return this.output.data({ status: 'INVALID_ACTION' });
     }
-    if (action === 'approve' && (!grantedLevel || !VALID_LEVELS.includes(grantedLevel))) {
+    if (action === 'approve' && (!grantedLevels.length || grantedLevels.some(l => !VALID_LEVELS.includes(l)))) {
       return this.output.data({ status: 'INVALID_LEVEL' });
     }
 
@@ -389,17 +394,22 @@ class __secure_share extends Mfs {
     // reaches every viewer of the share). Broadcast to entity_sockets(hub_id): the
     // guest's DMZ socket is included there (cookie_touch passes socket_id for exactly
     // this), which is reliable — unlike the single, often-stale active_socket_id.
+    // granted_level is a SET (comma-list) — split it and union the privilege so a
+    // multi-level grant (e.g. chat + edit) carries every cap to the recipient.
+    const grantedSet = String(row.granted_level || '').split(',').map(s => s.trim()).filter(Boolean);
+    let grantedPriv = 3;
+    for (const lvl of grantedSet) grantedPriv |= (LEVEL_TO_PRIVILEGE[lvl] || 0);
     const respondedPayload = {
       event          : 'secure_share_access_responded',
       request_id     : row.id,
       action,
       requester_email: (row.requester_email || '').toLowerCase().trim(),
       granted_level  : row.granted_level,
-      privilege      : LEVEL_TO_PRIVILEGE[row.granted_level] || 3,
-      capabilities   : (row.granted_level && row.granted_level !== 'can_view') ? [row.granted_level] : [],
-      can_download   : row.granted_level === 'can_download' ? 1 : 0,
-      can_chat       : row.granted_level === 'can_chat' ? 1 : 0,
-      can_edit       : row.granted_level === 'can_edit' ? 1 : 0,
+      privilege      : grantedPriv,
+      capabilities   : grantedSet.filter(l => l !== 'can_view'),
+      can_download   : grantedSet.includes('can_download') ? 1 : 0,
+      can_chat       : grantedSet.includes('can_chat') ? 1 : 0,
+      can_edit       : grantedSet.includes('can_edit') ? 1 : 0,
     };
     try {
       // Target the SHARE's hub (row.hub_id from the request), NOT the approver's
@@ -438,7 +448,10 @@ class __secure_share extends Mfs {
    */
   async _grantHubMembership(row) {
     const LEVEL_TO_PRIVILEGE = { can_view: 3, can_download: 7, can_chat: 3, can_edit: 15 };
-    const privilege = LEVEL_TO_PRIVILEGE[row.granted_level] || 3;
+    // granted_level is a SET (comma-list) — union the cumulative privilege masks
+    // over every granted level so a multi-level grant gets the combined privilege.
+    const privilege = String(row.granted_level || '').split(',').map(s => s.trim()).filter(Boolean)
+      .reduce((p, lvl) => p | (LEVEL_TO_PRIVILEGE[lvl] || 0), 3);
     const hub_id    = row.hub_id;
     const email     = (row.requester_email || '').toLowerCase().trim();
     if (!hub_id || !email) return;


### PR DESCRIPTION
Promotes the **secure share v2** server work from `test` to `preview`. All changes here are secure-share-only (`dmz.js`, `media.js`, `secure_share.js`, `secure-share-write-guard.js`, `acl/secure_share.json`).

### Included
- Recipient login/caps: union approved grants onto base caps; reliable `is_authenticated`/`is_member`/`is_owner`; strip secrets from `dmz.info`; require allowed-emails when email-required is on.
- Access requests: multi-level (SET) parse/validate/grant/union; approval + revoke broadcast to the **share's** hub (`row.hub_id`).
- Notifications: `list_open_notifications` endpoint.
- **KAN-81**: server-side write guard (`secure-share-write-guard.js` + `media.js`) blocks `make_dir`/`pre_upload` for recipients below the share's `can_edit` — at every nesting level (token-based).

### Known limitations (architectural fix pending with Somanos)
- Recipient session is cookie-bound to the **creator** (enforcement-gap). Write is guarded; read-side (download bytes) is UI-gated only.
- **Nested sub-folders**: the nested folder opens as the full desk folder window under the creator session — a view-only recipient can download / invite / manage-access / chat / call there (upload + create-folder ARE blocked). Depth-unbounded. Complete fix = capped-principal session → Need clarification.