### PR TITLE
Secure Share v2 — capped-principal recipient model + viewer hardening

### DIFF
--- a/acl/google_drive.json
+++ b/acl/google_drive.json
@@ -28,11 +28,17 @@
       "returns": { "type": "object", "properties": { "configured": { "type": "integer" }, "email": { "type": "string" } } }
     },
     "sa_check": {
-      "doc": "Validate a pasted Drive folder link/id for the share-to-SA import: the SA must see it AND its owner must be the caller's linked Google email (blocks importing folders shared to the SA by other people). Returns { ok, folder_id, name }. Errors: SA_NOT_CONFIGURED, SA_BAD_LINK, SA_NOT_SHARED, SA_NOT_A_FOLDER, SA_NOT_OWNER, SA_NEEDS_GOOGLE.",
+      "doc": "Validate a pasted Drive folder OR file link/id for the share-to-SA import. Share-gated: only requires the SA can SEE the item (the user shared it with the SA email) — NO owner check, so an item owned by any account can be imported. Returns { ok, folder_id, name, is_folder }. Errors: SA_NOT_CONFIGURED, SA_BAD_LINK, SA_NOT_SHARED.",
       "scope": "hub",
       "permission": { "src": "owner" },
-      "params": { "folder": { "type": "string", "required": true, "description": "Drive folder URL or bare folder id" } },
-      "returns": { "type": "object", "properties": { "ok": { "type": "integer" }, "folder_id": { "type": "string" }, "name": { "type": "string" } } }
+      "params": { "folder": { "type": "string", "required": true, "description": "Drive folder/file URL or bare id" } },
+      "returns": { "type": "object", "properties": { "ok": { "type": "integer" }, "folder_id": { "type": "string" }, "name": { "type": "string" }, "is_folder": { "type": "integer" } } }
+    },
+    "disconnect": {
+      "doc": "Forget the Drive connection: best-effort revoke the refresh_token at Google, then NULL the tokens on the Drive-scoped oauth_accounts row (kept, not deleted, so Google sign-in still works). After this get_state.ok is false. Returns { ok: true }.",
+      "scope": "hub",
+      "permission": { "src": "owner" },
+      "returns": { "type": "object", "properties": { "ok": { "type": "boolean" } } }
     },
     "list": {
       "doc": "Browse one Google Drive folder for the in-app migration picker tree. Read-only, My Drive only. Returns { files: [{ id, name, is_folder, mime_type, size }], next_page_token }.",
@@ -84,7 +90,7 @@
       "doc": "Consolidated popup-open state so the FE can reconnect to an in-flight migration (or show a just-finished result once) instead of defaulting to the Start screen. Returns { ok (has drive scope), scope_kind ('readonly' keeps the legacy whole-Drive tree UI, 'file' switches to the Google Picker), picker (1 when api_key+project_number are configured), job (shaped getUserJob snapshot or null), seen_job_id (last dismissed result) }.",
       "scope": "hub",
       "permission": { "src": "owner" },
-      "returns": { "type": "object", "properties": { "ok": { "type": "boolean" }, "scope_kind": { "type": "string" }, "picker": { "type": "integer" }, "sa": { "type": "integer" }, "sa_email": { "type": "string" }, "job": { "type": "object" }, "seen_job_id": { "type": "string" } } }
+      "returns": { "type": "object", "properties": { "ok": { "type": "boolean" }, "email": { "type": "string" }, "scope_kind": { "type": "string" }, "picker": { "type": "integer" }, "sa": { "type": "integer" }, "sa_email": { "type": "string" }, "job": { "type": "object" }, "seen_job_id": { "type": "string" } } }
     },
     "ack_result": {
       "doc": "Mark a finished migration result as seen (profile.gdrive_seen_job=job_id) so reopening the popup won't show that result again.",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.55",
+  "version": "2.9.56",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.55",
+      "version": "2.9.56",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.57",
+  "version": "2.9.58",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.57",
+      "version": "2.9.58",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.56",
+  "version": "2.9.57",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.56",
+      "version": "2.9.57",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.58",
+  "version": "2.9.59",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.58",
+      "version": "2.9.59",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.58",
+  "version": "2.9.59",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.56",
+  "version": "2.9.57",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.55",
+  "version": "2.9.56",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.57",
+  "version": "2.9.58",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -548,9 +548,11 @@ class __dmz extends Mfs {
     // read-level (3), separated from view by the media.js download guard.
     //
     // Scope is deliberately tight to avoid regressions:
-    //   - authenticated viewers of a RESTRICTED (email/password-gated) share only;
-    //     PUBLIC + ANONYMOUS recipients keep creator-binding (capped guest
-    //     principal for those is the sequenced follow-up).
+    //   - any AUTHENTICATED recipient (PUBLIC or restricted share). Per the standard
+    //     share-link model, a logged-in viewer gets the link's caps and must request
+    //     access to elevate (they are already signed in → the request-access flow).
+    //     ANONYMOUS viewers stay creator-bound until the capped guest principal lands
+    //     (then they too are capped to the link's level; elevating requires login).
     //   - FOLDER shares only (no info.file_nid): a single-file share has no
     //     descendants and a different byte path — left on creator-binding.
     //   - member/owner already hold standing ACL → bind to self, NO extra grant.
@@ -560,8 +562,7 @@ class __dmz extends Mfs {
     // at the top of this method).
     // ---------------------------------------------------------------------
     let bindUid = info.creator_id;
-    const isRestrictedShare = emailGateActive || !!info.require_password;
-    if (isAuthenticated && user.id && isRestrictedShare && !info.file_nid && info.node_id) {
+    if (isAuthenticated && user.id && !info.file_nid && info.node_id) {
       if (memberPriv > 0 || String(user.id) === String(info.creator_id)) {
         // Member or owner — already has standing access; operate as themselves.
         bindUid = user.id;

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -268,25 +268,44 @@ class __dmz extends Mfs {
     let submittedEmail = (this.input.get(Attr.email) || '').toLowerCase().trim();
 
     if (emailGateActive) {
-      // Auto-grant logged-in Drumee members whose account email matches the share
-      if (!submittedEmail && user.id && ![ID_NOBODY, guest_id].includes(user.id)) {
+      const isOwnerViewer = isAuthenticated && String(user.id) === String(info.creator_id);
+      if (isOwnerViewer) {
+        // The creator previewing their OWN share is not a recipient — skip the
+        // recipient email gate (their own account need not be on the allow-list).
+        // Mirrors the pre-existing is_owner handling in the response below; without
+        // this the strict check below would lock an owner out of their own share.
+      } else if (isAuthenticated) {
+        // Restricted share opened by a LOGGED-IN (non-owner) viewer: gate STRICTLY
+        // on the VERIFIED account email. A signed-in user must NOT type a different
+        // invited address to get in — the only identity that counts is the one they
+        // authenticated as (product rule: "only the invited email; sign in / sign
+        // up as that address"). Using the account email (never the client-supplied
+        // value) also closes the soft-gate bypass where a def@ session could submit
+        // abc@ to pass (the typed email was never ownership-verified). A logged-in
+        // viewer whose own account is not on the allow-list is refused here; if they
+        // are a workspace member they still reach the content via their own desk.
+        let accountEmail = '';
         try {
           const p = typeof user.profile === 'string' ? JSON.parse(user.profile) : (user.profile || {});
-          const accountEmail = (p.email || '').toLowerCase().trim();
-          if (accountEmail && _emailMatchesAllowed(accountEmail, info)) {
-            submittedEmail = accountEmail;
-          }
+          accountEmail = (p.email || '').toLowerCase().trim();
         } catch (e) {
-          this.warn('[dmz.login] secure_share auto-grant parse failed:', e && e.message);
+          this.warn('[dmz.login] secure_share account email parse failed:', e && e.message);
         }
-      }
-
-      if (!submittedEmail) {
-        return this.output.data({ ...safeInfo, status: 'REQUIRED_EMAIL', is_secure: 1 });
-      }
-
-      if (!_emailMatchesAllowed(submittedEmail, info)) {
-        return this.output.data({ status: 'EMAIL_MISMATCH', is_secure: 1 });
+        if (!accountEmail || !_emailMatchesAllowed(accountEmail, info)) {
+          return this.output.data({ status: 'EMAIL_MISMATCH', is_secure: 1 });
+        }
+        submittedEmail = accountEmail;
+      } else {
+        // ANONYMOUS viewer: existing typed-email gate (soft — no ownership proof).
+        // Verified-identity enforcement for anonymous recipients arrives with the
+        // capped guest-principal follow-up; left unchanged here to avoid a flow
+        // regression.
+        if (!submittedEmail) {
+          return this.output.data({ ...safeInfo, status: 'REQUIRED_EMAIL', is_secure: 1 });
+        }
+        if (!_emailMatchesAllowed(submittedEmail, info)) {
+          return this.output.data({ status: 'EMAIL_MISMATCH', is_secure: 1 });
+        }
       }
     }
 
@@ -349,23 +368,11 @@ class __dmz extends Mfs {
       this.warn('[dmz.login] secure_share access_log failed:', e && e.message);
     }
 
-    // Associate session with share creator so hub endpoints (media.show_node_by) work —
-    // mirrors the cookie_touch done for normal DMZ tokens at login line 330.
-    // socket_id must be passed so entity_sockets() includes this guest socket in
-    // hub broadcasts (e.g. secure_share_revoked) — same pattern as session.dmz_login.
-    // Safe: page.js ensures the hub cookie always has its own independent session id,
-    // so this UPDATE never touches the authenticated user's regsid row.
-    if (info.creator_id) {
-      try {
-        await this.yp.await_proc('cookie_touch', {
-          sid       : this.input.sid(),
-          uid       : info.creator_id,
-          socket_id : this.input.get(Attr.socket_id)
-        });
-      } catch (e) {
-        this.warn('[dmz.login] secure_share cookie_touch failed:', e && e.message);
-      }
-    }
+    // NOTE: the session cookie_touch (principal binding) is DEFERRED to after the
+    // capability set + member privilege are resolved below, so a logged-in recipient
+    // can be bound to their OWN capped principal instead of the share creator. See
+    // the binding block near the end of this method. Nothing between here and there
+    // depends on the bound session (all DB calls pass explicit hub_id/uid args).
 
     // Hub-level expiry display fields (same as normal login)
     let rows = await this.yp.await_proc('forward_proc', info.hub_id, 'dmz_settings', ``);
@@ -493,12 +500,13 @@ class __dmz extends Mfs {
     // their own link); a member who wants full access uses their own desk. Uses the
     // real recipient uid (resolved above), not the creator-bound session.
     let is_member = 0;
+    let memberPriv = 0;
     if (isAuthenticated && user.id) {
       try {
         const accessRows = await this.yp.await_proc(
           'forward_proc', info.hub_id, 'mfs_access_node', `'${user.id}','${info.nid}'`
         );
-        const memberPriv = parseInt((toArray(accessRows)[0] || {}).privilege, 10) || 0;
+        memberPriv = parseInt((toArray(accessRows)[0] || {}).privilege, 10) || 0;
         if (memberPriv > 0) is_member = 1;
       } catch (e) {
         this.warn('[dmz.login] secure_share member access check failed:', e && e.message);
@@ -519,6 +527,78 @@ class __dmz extends Mfs {
     for (const c of caps) privilege |= (CAP_PRIVILEGE[c] || 0);
 
     const hasCap = (c) => (caps.indexOf(c) !== -1 ? 1 : 0);
+
+    // ---------------------------------------------------------------------
+    // Bind the share session to its operating principal.
+    //
+    // Historically this bound the session to the share CREATOR so the
+    // authenticated media stack could resolve the shared node — but that made the
+    // recipient operate with the creator's FULL privilege (the enforcement gap:
+    // nested folders exposed owner capabilities; write/invite/call/manage all ran
+    // as the owner). Instead, for a LOGGED-IN recipient of a RESTRICTED FOLDER
+    // share, bind to the recipient's OWN uid and give them a node-scoped grant at
+    // the share's CAPPED privilege. The central ACL then enforces exactly the
+    // share's level at every depth (grants inherit to descendants), and grantPriv
+    // <= 15 means admin(16)/owner(32) ops (invite, manage-access, call) are denied
+    // automatically.
+    //
+    // grantPriv uses the STORED cumulative scale (lib/privilege.js): read=3,
+    // write=7, delete/modify=15. can_chat needs write(7) — chat.post asks 'write';
+    // can_edit needs delete(15) — move/rename/trash ask 'delete'. Download is
+    // read-level (3), separated from view by the media.js download guard.
+    //
+    // Scope is deliberately tight to avoid regressions:
+    //   - authenticated viewers of a RESTRICTED (email/password-gated) share only;
+    //     PUBLIC + ANONYMOUS recipients keep creator-binding (capped guest
+    //     principal for those is the sequenced follow-up).
+    //   - FOLDER shares only (no info.file_nid): a single-file share has no
+    //     descendants and a different byte path — left on creator-binding.
+    //   - member/owner already hold standing ACL → bind to self, NO extra grant.
+    //   - a non-member gets the node-scoped grant; if the grant FAILS we keep the
+    //     creator binding so the share still WORKS (degrade, never break access).
+    // The share is guaranteed valid here (TICKET_REVOKED/EXPIRED/LOCKED returned
+    // at the top of this method).
+    // ---------------------------------------------------------------------
+    let bindUid = info.creator_id;
+    const isRestrictedShare = emailGateActive || !!info.require_password;
+    if (isAuthenticated && user.id && isRestrictedShare && !info.file_nid && info.node_id) {
+      if (memberPriv > 0 || String(user.id) === String(info.creator_id)) {
+        // Member or owner — already has standing access; operate as themselves.
+        bindUid = user.id;
+      } else {
+        // Non-member recipient — grant capped node access, then bind to their uid.
+        let grantPriv = 0b0000011;                                    // read / view / download
+        if (caps.indexOf('can_chat') !== -1) grantPriv = 0b0000111;   // write — chat.post
+        if (caps.indexOf('can_edit') !== -1) grantPriv = 0b0001111;   // delete/modify — edit
+        try {
+          const db_name = await this.yp.await_func('get_db_name', info.hub_id);
+          if (db_name) {
+            await this.yp.await_proc(
+              `${db_name}.permission_grant`,
+              info.node_id, user.id, 0, grantPriv, 'system', 'Secure share access'
+            );
+            bindUid = user.id;            // rebind ONLY after the grant succeeds
+          }
+        } catch (e) {
+          this.warn('[dmz.login] secure_share node grant failed; keeping creator binding:', e && e.message);
+        }
+      }
+    }
+    // socket_id must be passed so entity_sockets() includes this guest socket in
+    // hub broadcasts (e.g. secure_share_revoked). page.js ensures the hub cookie
+    // has its own independent session id, so this never touches the authenticated
+    // user's regsid row.
+    if (bindUid) {
+      try {
+        await this.yp.await_proc('cookie_touch', {
+          sid       : this.input.sid(),
+          uid       : bindUid,
+          socket_id : this.input.get(Attr.socket_id)
+        });
+      } catch (e) {
+        this.warn('[dmz.login] secure_share cookie_touch failed:', e && e.message);
+      }
+    }
 
     return this.output.data({
       ...user,

--- a/service/lib/secure-share-write-guard.js
+++ b/service/lib/secure-share-write-guard.js
@@ -111,4 +111,64 @@ async function secureShareWriteVerdict(yp, token, recipientEmail) {
   return secureShareCapVerdict(yp, token, recipientEmail, ["can_edit"]);
 }
 
-module.exports = { secureShareWriteVerdict, secureShareCapVerdict };
+/**
+ * Resolve the privilege bitmask a secure-share recipient is capped to, for capping
+ * the per-node privilege returned by a folder LISTING (mfs_show_node_by). Used so a
+ * recipient who is still creator-bound (an anonymous viewer) does not see the
+ * creator's full per-node privilege in nested folders — the listing display is
+ * clamped to the share's level at every depth. (Logged-in recipients are rebound to
+ * their own capped uid, so their listing privilege is already capped and this is a
+ * no-op for them.) This is a DISPLAY cap only — server-side write enforcement is the
+ * separate token guards / capped-principal binding.
+ *
+ * Uses the CLIENT cumulative scale (matches dmz.js::_loginSecureShare CAP_PRIVILEGE
+ * and the node `privilege` field): view/read=3, +download=7, +edit=15. can_chat adds
+ * no bit (chat is gated by the can_chat flag, not the privilege bitmask).
+ *
+ * @returns {Promise<null|number>} null → NOT a secure share (no token / legacy /
+ *   invalid) → caller must NOT cap; otherwise the cumulative privilege bitmask.
+ */
+async function secureShareCapPrivilege(yp, token, recipientEmail) {
+  if (!token) return null;
+  let info;
+  try {
+    info = toArray(await yp.await_proc("secure_share_info", token))[0];
+  } catch (e) {
+    return null; // cannot classify → do not cap (transient); behaviour unchanged
+  }
+  if (!info || info.failed || !info.creator_id) return null;
+  // Revoked/expired/locked → the listing should not be serving content anyway; don't
+  // touch the privilege here (DMZ login already gates validity). null = no cap.
+  if (info.validity && info.validity !== "TICKET_OK") return null;
+
+  let caps = parseCaps(info.capabilities);
+  if (!caps.length && info.permission_level && info.permission_level !== "can_view") {
+    caps = [info.permission_level];
+  }
+  // Union this recipient's approved access grants (a view-only base share may have
+  // an upgraded recipient). Keyed by the resolved recipient email; anonymous → none.
+  const email = (recipientEmail || "").toLowerCase().trim();
+  if (email) {
+    try {
+      const grants = toArray(
+        await yp.await_proc("secure_share_get_access_grant", token, email)
+      );
+      for (const g of grants) {
+        const raw = g && g.granted_level;
+        if (!raw) continue;
+        for (const lvl of String(raw).split(",").map((s) => s.trim()).filter(Boolean)) {
+          if (caps.indexOf(lvl) === -1) caps.push(lvl);
+        }
+      }
+    } catch (e) {
+      /* base caps only */
+    }
+  }
+
+  let capPriv = 0b0000011; // view / read baseline
+  if (caps.indexOf("can_download") !== -1) capPriv |= 0b0000111; // + download
+  if (caps.indexOf("can_edit") !== -1) capPriv |= 0b0001111;     // + edit/modify
+  return capPriv;
+}
+
+module.exports = { secureShareWriteVerdict, secureShareCapVerdict, secureShareCapPrivilege };

--- a/service/lib/secure-share-write-guard.js
+++ b/service/lib/secure-share-write-guard.js
@@ -27,47 +27,60 @@ function parseCaps(raw) {
 }
 
 /**
- * Decide whether a secure-share recipient may perform a write (upload / mkdir).
+ * Decide whether a secure-share recipient holds ANY of the required capabilities.
  *
- * @param {*} yp              yellow-page DB handle (await_proc)
- * @param {string} token      the share token sent with the write request
- * @param {string} recipientEmail  resolved by the caller — account email for an
- *                            authenticated viewer, replayed grant_email for an
- *                            anonymous one (mirrors _loginSecureShare keying)
+ * The recipient's effective capability set is the share's base caps UNION their
+ * approved access grants, keyed by the resolved recipient email — identical to
+ * the login derivation in dmz.js::_loginSecureShare. Keep the three in sync.
+ *
+ * Used by every per-operation guard that the coarse node-privilege bitmask cannot
+ * isolate on its own (e.g. download — which the ACL treats as read-level, so a
+ * view-only recipient would otherwise be able to fetch bytes; and upload/mkdir).
+ *
+ * @param {*} yp                 yellow-page DB handle (await_proc)
+ * @param {string} token         the share token sent with the request
+ * @param {string} recipientEmail account email for an authenticated viewer, or the
+ *                               replayed grant_email for an anonymous one
+ * @param {string[]} requiredCaps capabilities that authorize the op; the recipient
+ *                               passes if they hold ANY one (e.g. download is
+ *                               allowed by can_download OR can_edit)
  * @returns {Promise<null|boolean>}
- *   null  → NOT a secure-share write (no token, or token is not a secure share,
- *           e.g. a legacy DMZ folder link) → caller proceeds with normal ACL.
- *   true  → secure-share recipient HAS can_edit (base or approved grant) → allow.
- *   false → secure-share recipient lacks can_edit → caller must deny.
+ *   null  → NOT a secure-share request (no token, or a legacy/non-secure token) →
+ *           caller proceeds with the normal ACL, untouched.
+ *   true  → recipient holds one of requiredCaps → allow.
+ *   false → recipient holds none of requiredCaps (or the share is revoked/expired)
+ *           → caller must deny.
  */
-async function secureShareWriteVerdict(yp, token, recipientEmail) {
+async function secureShareCapVerdict(yp, token, recipientEmail, requiredCaps) {
   if (!token) return null;
+  const req = Array.isArray(requiredCaps) ? requiredCaps : [requiredCaps];
 
   let info;
   try {
     info = toArray(await yp.await_proc("secure_share_info", token))[0];
   } catch (e) {
     // DB error: we cannot classify the token. Fail OPEN so a transient hiccup
-    // never blocks normal/legacy writes — the client-side gate still applies.
+    // never blocks normal/legacy ops — the rebind + client gate still apply.
     return null;
   }
   // Not a secure share (failed=1 / no creator) → legacy or invalid token; this
   // guard does not apply, so existing behaviour is left untouched.
   if (!info || info.failed || !info.creator_id) return null;
-  // Revoked or expired share → no write. secure_share_info exposes this only as
-  // a computed `validity` string (there is no revoked_at output column).
+  // Revoked or expired share → deny. secure_share_info exposes this only as a
+  // computed `validity` string (there is no revoked_at output column).
   if (info.validity && info.validity !== "TICKET_OK") return false;
 
   let caps = parseCaps(info.capabilities);
   if (!caps.length && info.permission_level && info.permission_level !== "can_view") {
     caps = [info.permission_level];
   }
-  if (caps.indexOf("can_edit") !== -1) return true;
+  const satisfies = (list) => req.some((c) => list.indexOf(c) !== -1);
+  // Base caps already satisfy → allow without the extra grant lookup (preserves
+  // the original short-circuit for the common case).
+  if (satisfies(caps)) return true;
 
-  // No base edit grant — check this recipient's APPROVED access requests. The
-  // grant union is keyed by the recipient email the caller resolved, exactly as
-  // _loginSecureShare does (can_edit can be requested + approved, so a view-only
-  // base share may legitimately have an edit-upgraded recipient).
+  // Not satisfied by the base caps — check this recipient's APPROVED access
+  // grants (a view-only base share may have a recipient upgraded to download/edit).
   const email = (recipientEmail || "").toLowerCase().trim();
   if (email) {
     try {
@@ -77,8 +90,8 @@ async function secureShareWriteVerdict(yp, token, recipientEmail) {
       for (const g of grants) {
         const raw = g && g.granted_level;
         if (!raw) continue;
-        for (const lvl of String(raw).split(",").map((s) => s.trim())) {
-          if (lvl === "can_edit") return true;
+        for (const lvl of String(raw).split(",").map((s) => s.trim()).filter(Boolean)) {
+          if (req.indexOf(lvl) !== -1) return true;
         }
       }
     } catch (e) {
@@ -89,4 +102,13 @@ async function secureShareWriteVerdict(yp, token, recipientEmail) {
   return false;
 }
 
-module.exports = { secureShareWriteVerdict };
+/**
+ * Backward-compatible write verdict (upload / mkdir): write requires can_edit.
+ * Thin wrapper over secureShareCapVerdict so existing callers are unchanged.
+ * @returns {Promise<null|boolean>} see secureShareCapVerdict.
+ */
+async function secureShareWriteVerdict(yp, token, recipientEmail) {
+  return secureShareCapVerdict(yp, token, recipientEmail, ["can_edit"]);
+}
+
+module.exports = { secureShareWriteVerdict, secureShareCapVerdict };

--- a/service/media.js
+++ b/service/media.js
@@ -21,7 +21,7 @@ const {
 } = require("@drumee/server-essentials");
 const indexQueue = require("../offline/queues/indexQueue");
 const { writeAudit } = require("./private/_audit");
-const { secureShareWriteVerdict, secureShareCapVerdict } = require("./lib/secure-share-write-guard");
+const { secureShareWriteVerdict, secureShareCapVerdict, secureShareCapPrivilege } = require("./lib/secure-share-write-guard");
 const { DENIED } = Events;
 const {
   BATCH_FILE,
@@ -178,6 +178,39 @@ class __media extends Mfs {
    */
   async _secureShareWriteAllowed() {
     return this._secureShareCapAllowed(["can_edit"]);
+  }
+
+  /**
+   * For a folder LISTING served while still creator-bound (an anonymous secure-share
+   * viewer), resolve the privilege bitmask the per-node `privilege` must be clamped
+   * to, so nested folders display at the share's level instead of the creator's full
+   * privilege. Returns null when NOT a secure-share request (no token / legacy) → the
+   * caller must leave the listing untouched. Logged-in recipients are rebound to their
+   * own capped uid, so their listing privilege is already capped → this is a no-op for
+   * them. DISPLAY cap only. Recipient email resolved exactly as the write guard does.
+   */
+  async _secureShareCapPrivilege() {
+    const token = this.input.get(Attr.token);
+    if (!token) return null;
+    let email = "";
+    try {
+      const cookie = this.input.get(Attr.cookie) || {};
+      const regsid = cookie.regsid;
+      if (regsid) {
+        const guest_id = Cache.getSysConf("guest_id");
+        const u = await this.yp.await_proc("cookie_retrieve_user", regsid);
+        if (u && u.id && ![ID_NOBODY, guest_id].includes(u.id) && u.profile) {
+          const p = typeof u.profile === "string" ? JSON.parse(u.profile) : u.profile;
+          email = ((p && p.email) || "").toLowerCase().trim();
+        }
+      }
+    } catch (e) {
+      // fall through to the anonymous path
+    }
+    if (!email) {
+      email = (this.input.get("grant_email") || "").toLowerCase().trim();
+    }
+    return secureShareCapPrivilege(this.yp, token, email);
   }
 
   /**
@@ -1312,6 +1345,18 @@ class __media extends Mfs {
     if (file_nid) {
       data = toArray(data).filter(item => item && item.nid === file_nid);
     }
+    // Secure-share listing: clamp each node's displayed privilege to the share's caps
+    // so an anonymous (still creator-bound) recipient does not see the creator's full
+    // privilege in nested folders. No token (normal desk listing) → capPriv null →
+    // data untouched. Logged-in recipients are already capped via their own grant, so
+    // the AND is a no-op for them. DISPLAY clamp only.
+    const capPriv = await this._secureShareCapPrivilege();
+    if (capPriv != null) {
+      data = toArray(data).map((n) => {
+        if (n && n.privilege != null) n.privilege = n.privilege & capPriv;
+        return n;
+      });
+    }
     this.output.list(data);
   }
 
@@ -1350,6 +1395,15 @@ class __media extends Mfs {
         file.filesize = nodes[0].total_size;
       }
       tree.push(file);
+    }
+    // Secure-share listing: clamp displayed per-node privilege to the share caps
+    // (same as show_node_by). Gated on the token → normal listings untouched.
+    const capPriv = await this._secureShareCapPrivilege();
+    if (capPriv != null) {
+      tree = tree.map((n) => {
+        if (n && n.privilege != null) n.privilege = n.privilege & capPriv;
+        return n;
+      });
     }
     this.output.data(tree);
   }

--- a/service/media.js
+++ b/service/media.js
@@ -21,7 +21,7 @@ const {
 } = require("@drumee/server-essentials");
 const indexQueue = require("../offline/queues/indexQueue");
 const { writeAudit } = require("./private/_audit");
-const { secureShareWriteVerdict } = require("./lib/secure-share-write-guard");
+const { secureShareWriteVerdict, secureShareCapVerdict } = require("./lib/secure-share-write-guard");
 const { DENIED } = Events;
 const {
   BATCH_FILE,
@@ -136,7 +136,7 @@ class __media extends Mfs {
    *
    * @returns {Promise<boolean>} true → may proceed; false → caller must reject
    */
-  async _secureShareWriteAllowed() {
+  async _secureShareCapAllowed(requiredCaps) {
     const token = this.input.get(Attr.token);
     if (!token) return true;
 
@@ -164,12 +164,20 @@ class __media extends Mfs {
       email = (this.input.get("grant_email") || "").toLowerCase().trim();
     }
 
-    const verdict = await secureShareWriteVerdict(this.yp, token, email);
+    const verdict = await secureShareCapVerdict(this.yp, token, email, requiredCaps);
     if (verdict === false) {
-      this.warn("[secure-share] write denied: recipient lacks can_edit");
+      this.warn(`[secure-share] denied: recipient lacks ${[].concat(requiredCaps).join(" / ")}`);
       return false;
     }
     return true;
+  }
+
+  /**
+   * Write (upload / mkdir) requires can_edit. Backward-compatible wrapper kept so
+   * the existing pre_upload / make_dir callers stay byte-identical.
+   */
+  async _secureShareWriteAllowed() {
+    return this._secureShareCapAllowed(["can_edit"]);
   }
 
   /**
@@ -1752,6 +1760,14 @@ class __media extends Mfs {
    * @returns 
    */
   async download(id, vcf) {
+    // Secure-share recipient: an explicit download (folder/file zip) requires
+    // can_download (or can_edit). A view-only recipient is blocked here, while
+    // inline PREVIEW/stream paths (thumb/preview/slide/video/orig-render/...) are
+    // untouched so viewing still works. No token (normal/legacy request) → the
+    // guard returns null → normal ACL applies, behaviour unchanged.
+    if (!(await this._secureShareCapAllowed(["can_download", "can_edit"]))) {
+      return this.exception.forbiden();
+    }
     let node = this.source_granted();
     let nid = node.id;
     let socket_id = this.input.need(Attr.socket_id);
@@ -1839,6 +1855,12 @@ class __media extends Mfs {
    * @returns 
    */
   async zip() {
+    // Defense-in-depth for the download guard: download() above stages the archive,
+    // this serves its bytes. A view-only secure-share recipient must not retrieve a
+    // previously-staged zip (no token → null → normal ACL, unchanged).
+    if (!(await this._secureShareCapAllowed(["can_download", "can_edit"]))) {
+      return this.exception.forbiden();
+    }
     const id = this.input.need(Attr.id);
     const zipname = this.input.need("zipname") || `index`;
     // Use this.uid to match the path used by create_small_zip() and

--- a/service/private/desk.js
+++ b/service/private/desk.js
@@ -329,8 +329,8 @@ class __private_desk extends Media {
     try {
       const hubs = toArray(
         await this.yp.await_query(
-          `SELECT id, db_name FROM entity
-           WHERE owner_id = ? AND type = 'hub' AND status = 'active'`,
+          `SELECT e.id, e.db_name FROM entity e JOIN hub h ON h.id = e.id
+           WHERE h.owner_id = ? AND e.type = 'hub' AND e.status = 'active'`,
           this.uid
         )
       );

--- a/service/private/google_drive.js
+++ b/service/private/google_drive.js
@@ -107,57 +107,89 @@ class GoogleDrive extends ExtImport {
     return access_token;
   }
 
-  /** Accepts a Drive folder URL or a bare id; returns the id or null. */
+  /**
+   * Accepts a Drive folder OR file/Docs link (or a bare id); returns the id.
+   * Folder: …/folders/ID · file: …/file/d/ID · Google Docs/Sheets/Slides:
+   * …/document|spreadsheets|presentation/d/ID (all match /d/ID) · ?id=ID.
+   */
   _parseFolderId(input) {
     const s = String(input || '').trim();
-    const m = s.match(/\/folders\/([A-Za-z0-9_-]{10,})/) || s.match(/[?&]id=([A-Za-z0-9_-]{10,})/);
+    const m = s.match(/\/folders\/([A-Za-z0-9_-]{10,})/)
+      || s.match(/\/d\/([A-Za-z0-9_-]{10,})/)
+      || s.match(/[?&]id=([A-Za-z0-9_-]{10,})/);
     if (m) return m[1];
     if (/^[A-Za-z0-9_-]{10,}$/.test(s)) return s;
     return null;
   }
 
   /**
-   * The folder must be visible to the SA AND owned by the caller's linked
-   * Google account. Without the owner check, anyone could import ANY folder
-   * ever shared with the SA by someone else (cross-user data leak).
+   * Share-gated verification (product decision: no owner check). The item just
+   * has to be VISIBLE to the SA — i.e. the user shared it with the SA email.
+   * That share + the pasted link IS the access grant, so a folder OR a file
+   * owned by ANY account can be imported (not only the connected one).
+   * Returns { id, name, is_folder }.
    */
-  async _saVerifyFolder(folder_id) {
-    const rowE = toArray(await this.yp.await_query(
-      'SELECT email FROM oauth_accounts WHERE user_id=? AND provider=? AND email IS NOT NULL ORDER BY (scope LIKE "%drive.%") DESC, mtime DESC LIMIT 1',
-      this.uid, 'google'
-    ))[0];
-    const userEmail = rowE && rowE.email;
-    if (!userEmail) throw new Error('SA_NEEDS_GOOGLE');
+  async _saVerifyShared(item_id) {
     const token = await this._saToken();
     let res;
     try {
-      res = await axios.get(`https://www.googleapis.com/drive/v3/files/${encodeURIComponent(folder_id)}`, {
+      res = await axios.get(`https://www.googleapis.com/drive/v3/files/${encodeURIComponent(item_id)}`, {
         headers: { Authorization: `Bearer ${token}` },
-        params: { fields: 'id,name,mimeType,owners(emailAddress)', supportsAllDrives: true },
+        params: { fields: 'id,name,mimeType', supportsAllDrives: true },
       });
     } catch (e) {
-      // 404 for the SA = the share hasn't reached it (or wrong id).
+      // 404/403 for the SA = the share hasn't reached it (or wrong id).
       throw new Error('SA_NOT_SHARED');
     }
     const f = res.data || {};
-    if (f.mimeType !== 'application/vnd.google-apps.folder') throw new Error('SA_NOT_A_FOLDER');
-    const owners = (f.owners || []).map((o) => (o.emailAddress || '').toLowerCase());
-    if (!owners.includes(String(userEmail).toLowerCase())) throw new Error('SA_NOT_OWNER');
-    return { id: f.id, name: f.name };
+    if (!f.id) throw new Error('SA_NOT_SHARED');
+    return {
+      id: f.id,
+      name: f.name,
+      is_folder: f.mimeType === 'application/vnd.google-apps.folder',
+    };
   }
 
-  /** FE setup card: the email the user must share their folder with. */
+  /** FE setup card: the email the user must share their folder/file with. */
   async sa_info() {
     const sa = googleDriveServiceAccount();
     this.output.data({ configured: sa ? 1 : 0, email: sa ? sa.client_email : null });
   }
 
-  /** Validate a pasted folder link/id before starting; returns its name. */
+  /** Validate a pasted folder/file link/id before starting; returns its name. */
   async sa_check() {
-    const folder_id = this._parseFolderId(this.input.need('folder'));
-    if (!folder_id) throw new Error('SA_BAD_LINK');
-    const f = await this._saVerifyFolder(folder_id);
-    this.output.data({ ok: 1, folder_id: f.id, name: f.name });
+    const item_id = this._parseFolderId(this.input.need('folder'));
+    if (!item_id) throw new Error('SA_BAD_LINK');
+    const f = await this._saVerifyShared(item_id);
+    this.output.data({ ok: 1, folder_id: f.id, name: f.name, is_folder: f.is_folder ? 1 : 0 });
+  }
+
+  /**
+   * Forget the Drive connection: best-effort revoke at Google, then clear the
+   * tokens on the Drive-scoped row WITHOUT deleting it (keeps Google sign-in
+   * intact — login re-OAuths and doesn't rely on the stored refresh_token).
+   * After this get_state.ok is false → the FE returns to the connect screen,
+   * where Connect can pick a different account.
+   */
+  async disconnect() {
+    const row = toArray(await this.yp.await_query(
+      'SELECT refresh_token FROM oauth_accounts WHERE user_id=? AND provider=? AND scope LIKE "%drive.%" ORDER BY mtime DESC LIMIT 1',
+      this.uid, 'google'
+    ))[0];
+    if (row && row.refresh_token) {
+      try {
+        await axios.post(
+          'https://oauth2.googleapis.com/revoke',
+          new URLSearchParams({ token: row.refresh_token }).toString(),
+          { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } }
+        );
+      } catch (_) { /* token may already be invalid — ignore */ }
+    }
+    await this.yp.await_query(
+      'UPDATE oauth_accounts SET refresh_token=NULL, access_token=NULL WHERE user_id=? AND provider=? AND scope LIKE "%drive.%"',
+      this.uid, 'google'
+    );
+    this.output.data({ ok: true });
   }
 
   /**
@@ -261,14 +293,16 @@ class GoogleDrive extends ExtImport {
     let mode = this.input.use('mode', 'all') === 'selected' ? 'selected' : 'all';
     let selections = this.input.use('selections', null);
     if (auth_kind === 'sa') {
-      // Whole-folder import via share-to-SA: re-validate server-side (never
-      // trust the FE's sa_check) and shape it as a single-folder selection —
+      // Share-to-SA import: re-validate server-side (never trust the FE's
+      // sa_check) and shape it as a single-item selection — folder OR file —
       // the importer path is identical, only the token source differs.
-      const folder_id = this._parseFolderId(this.input.need('sa_folder'));
-      if (!folder_id) throw new Error('SA_BAD_LINK');
-      const f = await this._saVerifyFolder(folder_id);
+      const item_id = this._parseFolderId(this.input.need('sa_folder'));
+      if (!item_id) throw new Error('SA_BAD_LINK');
+      const f = await this._saVerifyShared(item_id);
       mode = 'selected';
-      selections = JSON.stringify({ folder_ids: [f.id], file_ids: [] });
+      selections = f.is_folder
+        ? JSON.stringify({ folder_ids: [f.id], file_ids: [] })
+        : JSON.stringify({ folder_ids: [], file_ids: [f.id] });
     }
     // The input layer may deliver the object as a JSON string — normalize.
     if (typeof selections === 'string') {
@@ -419,11 +453,14 @@ class GoogleDrive extends ExtImport {
       // A user can hold SEVERAL google rows (login client vs Drive connect —
       // different provider_user_id). Always pick the one carrying the Drive
       // grant, never whichever the DB returns first.
-      'SELECT scope, refresh_token FROM oauth_accounts WHERE user_id=? AND provider=? ORDER BY (scope LIKE "%drive.%") DESC, mtime DESC LIMIT 1',
+      'SELECT scope, refresh_token, email FROM oauth_accounts WHERE user_id=? AND provider=? ORDER BY (scope LIKE "%drive.%") DESC, mtime DESC LIMIT 1',
       this.uid, 'google'
     ))[0];
     const scope = (scopeRow && scopeRow.scope) || '';
     const ok = !!(scopeRow && scopeRow.refresh_token && DRIVE_SCOPE_RE.test(scope));
+    // The Google account currently connected — shown on the ready screen so
+    // the user can confirm which Drive they're importing from / disconnect.
+    const email = ok ? ((scopeRow && scopeRow.email) || null) : null;
     // FE branches its picker UI on this: 'readonly' keeps the legacy in-app
     // tree (whole-Drive capable), 'file' switches to the Google Picker.
     const scope_kind = scope.includes('drive.readonly')
@@ -443,7 +480,7 @@ class GoogleDrive extends ExtImport {
     const snap = await getUserJob(this.uid);
     const job = snap ? this._shapeStatus(snap) : null;
     const seen_job_id = await this._getSeenJob();
-    this.output.data({ ok, scope_kind, picker, sa, sa_email, job, seen_job_id });
+    this.output.data({ ok, email, scope_kind, picker, sa, sa_email, job, seen_job_id });
   }
 
   /** Read profile.gdrive_seen_job (id of the last result the user dismissed). */

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -244,10 +244,15 @@ class __secure_share extends Mfs {
       // capped-principal binding (dmz.js::_loginSecureShare) issued to authenticated
       // recipients of this share — otherwise a revoked recipient keeps standing ACL
       // on the shared node. Enumerate this share's recipients from the access-event
-      // log (creator-scoped, and restricted-shares only — exactly the population that
-      // received grants) and drop each one's node-scoped grant. permission_revoke
-      // deletes only the (node_id, uid) row, so a recipient who is ALSO a real
-      // workspace member keeps their '*' membership untouched. Best-effort.
+      // log and drop each one's node-scoped grant. permission_revoke deletes only
+      // the (node_id, uid) row, so a recipient who is ALSO a real workspace member
+      // keeps their '*' membership untouched. Best-effort.
+      // KNOWN RESIDUAL: secure_share_list_access_events excludes PUBLIC shares, so a
+      // logged-in recipient of a PUBLIC share (also rebound + granted) is NOT
+      // enumerated here — their node grant survives revoke. Low-severity (the content
+      // was public; the grant is invisible to their desk, only crafted-API reachable).
+      // To be closed by an all-shares cleanup bundled with the capped-guest-principal
+      // schema (a token-scoped recipient enumeration).
       if (row.node_id && row.hub_id) {
         try {
           const db_name = await this.yp.await_func('get_db_name', row.hub_id);

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -239,6 +239,38 @@ class __secure_share extends Mfs {
           this.warn('[secure_share.revoke] recipient broadcast failed:', e && e.message);
         }
       }
+
+      // Revoking the token must ALSO remove any node-scoped permission grants the
+      // capped-principal binding (dmz.js::_loginSecureShare) issued to authenticated
+      // recipients of this share — otherwise a revoked recipient keeps standing ACL
+      // on the shared node. Enumerate this share's recipients from the access-event
+      // log (creator-scoped, and restricted-shares only — exactly the population that
+      // received grants) and drop each one's node-scoped grant. permission_revoke
+      // deletes only the (node_id, uid) row, so a recipient who is ALSO a real
+      // workspace member keeps their '*' membership untouched. Best-effort.
+      if (row.node_id && row.hub_id) {
+        try {
+          const db_name = await this.yp.await_func('get_db_name', row.hub_id);
+          const events  = toArray(
+            await this.yp.await_proc('secure_share_list_access_events', row.hub_id, row.node_id, this.uid)
+          );
+          if (db_name) {
+            const seen = new Set();
+            for (const ev of events) {
+              const uid = ev && ev.actor_id;
+              if (!uid || uid === 'ffffffffffffffff' || uid === this.uid || seen.has(uid)) continue;
+              seen.add(uid);
+              try {
+                await this.yp.await_proc(`${db_name}.permission_revoke`, row.node_id, uid);
+              } catch (e) {
+                this.warn('[secure_share.revoke] node grant revoke failed:', e && e.message);
+              }
+            }
+          }
+        } catch (e) {
+          this.warn('[secure_share.revoke] grant cleanup failed:', e && e.message);
+        }
+      }
     }
 
     this.output.data(row);
@@ -447,7 +479,15 @@ class __secure_share extends Mfs {
    * @param {object} row  the row returned by secure_share_respond_to_access_request
    */
   async _grantHubMembership(row) {
-    const LEVEL_TO_PRIVILEGE = { can_view: 3, can_download: 7, can_chat: 3, can_edit: 15 };
+    // SERVER-ENFORCEMENT privilege (lib/privilege.js STORED cumulative scale) — this
+    // is the value written to the permission table that user_permission/ACL enforce,
+    // NOT the client-UI scale used for the broadcast payload in respond_to_access_request.
+    // download is read-level (3): downloading is a 'read' op, so it needs no write bit
+    // (keeping it at 3 stops a download-only recipient from chatting / passing the
+    // upload ACL). can_chat needs write (7) because chat.post asks 'write' — granting
+    // only 3 is why signed-in recipients previously could not post. can_edit needs
+    // delete/modify (15) for move/rename/trash. Matches dmz.js::_loginSecureShare grantPriv.
+    const LEVEL_TO_PRIVILEGE = { can_view: 3, can_download: 3, can_chat: 7, can_edit: 15 };
     // granted_level is a SET (comma-list) — union the cumulative privilege masks
     // over every granted level so a multi-level grant gets the combined privilege.
     const privilege = String(row.granted_level || '').split(',').map(s => s.trim()).filter(Boolean)


### PR DESCRIPTION
## Secure Share v2 — capped-principal recipient model + viewer hardening (test → preview)

Promotes the secure-share recipient-enforcement work. Replaces the creator-bound DMZ recipient session (the live enforcement gap) with a **capped principal**, so the central ACL enforces the share's caps at every folder depth.

### Server changes (v2.9.56 → v2.9.59)
- **Capped-principal rebind** (`dmz.js`): a logged-in recipient of a restricted **or public** share binds to their **own uid** + a node-scoped grant at the share's caps (view=3 / chat=7 / edit=15), instead of the creator. Closes invite/manage/call/upload-as-owner at every depth. Members/owner/file-shares/anonymous keep creator-binding; fail-safe if the grant errors.
- **Verified-identity email gate** (`dmz.js`): a logged-in recipient is gated on their **account email** (not a typed value) — closes the typed-email bypass; owner previewing bypasses; anonymous unchanged.
- **Listing privilege clamp** (`media.js` `show_node_by`/`_with_size`): clamps each node's displayed privilege to the share caps when a share token is present, so an anonymous (creator-bound) recipient doesn't see the creator's full privilege in nested folders. Gated on the token → normal listings untouched.
- **Download guard** (`media.js` `download`/`zip` + `secure-share-write-guard`): explicit download requires `can_download`; inline preview unaffected.
- **Revoke cleanup** (`secure_share.js`): revoking a share now drops the recipients' node-scoped grants (restricted shares; public-share residual documented in code).
- **Fix** (`desk.js`): cross-hub message search joined `owner_id` on `entity` (it's on `hub`) → `ER_BAD_FIELD_ERROR`; corrected via a hub join (was spamming the alert bot).
- No schema change (reuses existing SPs).

### KNOWN LIMITATION (documented, pre-existing — not a regression)
**Anonymous** recipients' sessions remain creator-bound, so a hand-crafted API call (not via the UI) can still act as the creator. The recipient **UI is fully capped**; this only affects crafted requests by an anonymous viewer. Complete close = a **capped guest principal** (new identity infrastructure on the central directory) — an architectural follow-up to be designed/applied with Somanos/Liam.

### Note for the reviewer
This is a branch promotion and also carries one unrelated teammate commit on `test`: `c4f7ba4` (Google Drive integration). Please confirm it's preview-ready before merging. All secure-share commits here were diff-reviewed at push.
