### PR TITLE
Promote secure-share Mode 1 (test->preview)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.60",
+  "version": "2.9.61",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.60",
+      "version": "2.9.61",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.60",
+  "version": "2.9.61",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -303,6 +303,14 @@ class __dmz extends Mfs {
         if (!submittedEmail) {
           return this.output.data({ ...safeInfo, status: 'REQUIRED_EMAIL', is_secure: 1 });
         }
+        // "Require email to view" with no allow-list (Mode 1) accepts ANY email, so the
+        // submitted value must at least be a real email format — _emailMatchesAllowed
+        // returns true for any string when there is no list. The recipient UI already
+        // validates the format; this is the server-side guard against a crafted call.
+        // (List/legacy shares implicitly enforce format via the exact/domain match below.)
+        if (!submittedEmail.isEmail()) {
+          return this.output.data({ status: 'EMAIL_MISMATCH', is_secure: 1 });
+        }
         if (!_emailMatchesAllowed(submittedEmail, info)) {
           return this.output.data({ status: 'EMAIL_MISMATCH', is_secure: 1 });
         }

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -60,19 +60,14 @@ class __secure_share extends Mfs {
       : undefined;
     // undefined → key omitted from JSON.stringify → SP reads SQL NULL → public share
 
-    // v2: require_email is decoupled from allowed_emails. When set, viewers must
-    // enter any email to access; an optional allowed_emails list further restricts
-    // which emails are accepted. Sent as integer 1/0 (SP reads it via JSON_VALUE).
+    // v2: require_email is decoupled from allowed_emails (per Lexis 2026-06-17).
+    //   - require_email + NO allowed_emails → "require email to view" (Mode 1): the
+    //     gate accepts ANY valid-format email. Recipient identity is captured but not
+    //     restricted; the email FORMAT is validated server-side at the gate
+    //     (dmz.js _loginSecureShare) so a non-real value cannot pass.
+    //   - require_email + allowed_emails → restrict to that list/domain (Mode 2).
+    // Sent as integer 1/0 (SP reads it via JSON_VALUE).
     const requireEmail = this.input.get('require_email') ? 1 : 0;
-
-    // Defense-in-depth (the sender UI also blocks this): "require email to view"
-    // must restrict to at least one allowed email/domain. With an empty allow-list
-    // the gate would accept ANY email — a cosmetic, non-real gate. Reject the create
-    // rather than publish an any-email link (per Lexis 2026-06-14). Existing shares
-    // are unaffected (create-time only).
-    if (requireEmail && !allowedEmails) {
-      return this.output.data({ status: 'REQUIRE_EMAIL_NEEDS_ALLOWED' });
-    }
 
     // Notify the sender in real time when a recipient opens the share. Defaults
     // to ON (1) when the field is omitted, preserving the previous always-notify


### PR DESCRIPTION
Promote secure-share **Mode 1** to preview.

Includes (test→preview, all authored here):
- **fix(secure-share): allow require-email shares without an allow-list (Mode 1)** — "require email to view" with no list now accepts any valid-format email (email capture + open tracking for public links); a filled list still restricts to that list/domain. Adds a server-side email-format check at the anonymous gate.

Known limitation (pre-existing, documented): the DMZ recipient session is creator-bound, so per-recipient caps are UI-gated rather than fully server-enforced — the capped-principal work closes this. Mode 1 links should be kept view-only. Not a regression introduced by this PR.
