### PR TITLE
Promote test → preview: Secure Share (enforcement + recipient fixes)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,10 +12,13 @@ on:
         default: UAT
 
 concurrency:
-  # Repo-wide group: all targets share one working tree in the container,
-  # so deploys must serialize regardless of target/branch.
+  # Repo-wide group: all targets share one working tree (container for UAT/PROD,
+  # stage host for TEST), so deploys must serialize regardless of target/branch.
   group: cd-server-team
   cancel-in-progress: false
+
+permissions:
+  contents: read
 
 jobs:
   deploy:
@@ -41,20 +44,71 @@ jobs:
           else
             TARGET="${{ github.event.inputs.target || 'UAT' }}"
           fi
+          # MODE=stage  -> deploy locally on the runner host (drumee.in), endpoint `main` (native pm2)
+          # MODE=container -> deploy into the prod box (sgp) docker container
           case "$TARGET" in
-            PROD) ENV_FILE=production; EP=main;    PORT=24000; BRANCH=preview ;;
-            TEST) ENV_FILE=test;       EP=test;    PORT=24002; BRANCH=test ;;
-            UAT)  ENV_FILE=deploy;     EP=preview; PORT=24001; BRANCH=preview ;;
+            PROD) ENV_FILE=production; EP=main;    PORT=24000; BRANCH=preview; MODE=container ;;
+            TEST) ENV_FILE=deploy;     EP=main;    PORT=24000; BRANCH=test;    MODE=stage ;;
+            UAT)  ENV_FILE=deploy;     EP=preview; PORT=24001; BRANCH=preview; MODE=container ;;
             *) echo "Unknown target: $TARGET"; exit 1 ;;
           esac
           echo "env_file=$ENV_FILE" >> "$GITHUB_OUTPUT"
           echo "endpoint=$EP"       >> "$GITHUB_OUTPUT"
           echo "port=$PORT"         >> "$GITHUB_OUTPUT"
           echo "branch=$BRANCH"     >> "$GITHUB_OUTPUT"
-          echo "::notice::Target $TARGET -> endpoint $EP (branch $BRANCH)"
+          echo "mode=$MODE"         >> "$GITHUB_OUTPUT"
+          echo "::notice::Target $TARGET -> endpoint $EP (branch $BRANCH, mode $MODE)"
 
+      # ---------------- TEST: deploy to drumee.in (stage) `main` endpoint, native ----------------
+      - name: Deploy to stage main (TEST)
+        id: stage
+        if: steps.target.outputs.mode == 'stage'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO_DIR: /usr/src/drumee/server-team
+        run: |
+          set -euo pipefail
+          AUTH="https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git"
+          [ -d "$REPO_DIR/.git" ] || sudo git init -q "$REPO_DIR"
+          PREV=$(sudo git -C "$REPO_DIR" rev-parse HEAD 2>/dev/null || echo "")
+          echo "prev=$PREV" >> "$GITHUB_OUTPUT"
+          sudo git -C "$REPO_DIR" fetch --depth 1 "$AUTH" test
+          sudo git -C "$REPO_DIR" checkout -f -B test FETCH_HEAD
+          sudo git -C "$REPO_DIR" reset --hard FETCH_HEAD
+          sudo git -C "$REPO_DIR" clean -fd -e .dev-tools.rc || true
+          echo "Deploying $(sudo git -C "$REPO_DIR" rev-parse --short HEAD) to stage main"
+          sudo bash -c "cd '$REPO_DIR' && npm install --no-audit --no-fund"
+          sudo bash -c "cd '$REPO_DIR' && npm run deploy -- deploy"
+          sudo /usr/sbin/drumee start main
+          sudo /usr/sbin/drumee start main/service
+
+      - name: Verify stage main (TEST)
+        if: steps.target.outputs.mode == 'stage'
+        run: |
+          set -euo pipefail
+          sleep 6
+          CODE=$(curl -sk -o /dev/null -w '%{http_code}' --max-time 10 -H 'Host: drumee.in' https://localhost/-/ || echo 000)
+          echo "stage main HTTP: $CODE"
+          [[ "$CODE" =~ ^[2-4][0-9][0-9]$ ]] || { echo "::error::stage main verify failed ($CODE)"; exit 1; }
+          echo "Verified stage main (server-team test)"
+
+      - name: Rollback stage (on failure)
+        if: failure() && steps.target.outputs.mode == 'stage' && steps.stage.outputs.prev != ''
+        env:
+          REPO_DIR: /usr/src/drumee/server-team
+          PREV: ${{ steps.stage.outputs.prev }}
+        run: |
+          set -uo pipefail
+          echo "::warning::Rolling back stage main to ${PREV:0:8}"
+          sudo git -C "$REPO_DIR" reset --hard "$PREV"
+          sudo bash -c "cd '$REPO_DIR' && npm run deploy -- deploy" || true
+          sudo /usr/sbin/drumee start main || true
+          sudo /usr/sbin/drumee start main/service || true
+
+      # ---------------- UAT / PROD: deploy into prod box (sgp) container ----------------
       - name: Fetch and reset working tree
         id: fetch
+        if: steps.target.outputs.mode == 'container'
         env:
           BRANCH: ${{ steps.target.outputs.branch }}
         run: |
@@ -79,6 +133,7 @@ jobs:
           echo "New     : ${NEW:0:8}"
 
       - name: Install dependencies
+        if: steps.target.outputs.mode == 'container'
         run: |
           ssh "$SGP_USER@$SGP_HOST" "sudo docker exec -i $CONTAINER bash -s" <<EOSSH
           set -euo pipefail
@@ -92,6 +147,7 @@ jobs:
           EOSSH
 
       - name: Deploy
+        if: steps.target.outputs.mode == 'container'
         env:
           ENV_FILE: ${{ steps.target.outputs.env_file }}
         run: |
@@ -107,6 +163,7 @@ jobs:
           EOSSH
 
       - name: Start services
+        if: steps.target.outputs.mode == 'container'
         env:
           EP: ${{ steps.target.outputs.endpoint }}
         run: |
@@ -118,6 +175,7 @@ jobs:
           EOSSH
 
       - name: Verify HTTP
+        if: steps.target.outputs.mode == 'container'
         env:
           PORT: ${{ steps.target.outputs.port }}
           EP: ${{ steps.target.outputs.endpoint }}
@@ -135,7 +193,7 @@ jobs:
           EOSSH
 
       - name: Rollback (on failure)
-        if: failure() && steps.fetch.outputs.prev != ''
+        if: failure() && steps.target.outputs.mode == 'container' && steps.fetch.outputs.prev != ''
         env:
           ENV_FILE: ${{ steps.target.outputs.env_file }}
           PREV: ${{ steps.fetch.outputs.prev }}

--- a/acl/channel.json
+++ b/acl/channel.json
@@ -293,6 +293,45 @@
       },
       "errors": []
     },
+    "react": {
+      "doc": "Toggle the caller's emoji reaction on a channel message. Adds the reaction if absent, removes it if already present. Persists per-message in metadata under the _reactions_ key alongside read receipts, so reactions load with the message. Broadcasts the updated reactions map to all other hub participants via WebSocket, excluding the caller's socket.",
+      "scope": "hub",
+      "permission": {
+        "src": "read"
+      },
+      "params": {
+        "message_id": {
+          "type": "string",
+          "required": true,
+          "doc": "ID of the message to react to"
+        },
+        "emoji": {
+          "type": "string",
+          "required": true,
+          "doc": "Single emoji to toggle for the caller"
+        },
+        "socket_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Caller's WebSocket socket ID. Used to exclude the caller from the broadcast recipients."
+        }
+      },
+      "returns": {
+        "type": "object",
+        "doc": "Updated reaction state",
+        "properties": {
+          "message_id": {
+            "type": "string",
+            "doc": "The message that was reacted to"
+          },
+          "reactions": {
+            "type": "object",
+            "doc": "Map of emoji to array of user IDs who reacted with it"
+          }
+        }
+      },
+      "errors": []
+    },
     "post_ticket": {
       "doc": "Post a reply message to an existing support ticket. Supports threaded replies and file attachments. Broadcasts the new message to the ticket owner and all support domain members.",
       "scope": "hub",

--- a/acl/chat.json
+++ b/acl/chat.json
@@ -704,6 +704,46 @@
       ]
     },
 
+    "react": {
+      "doc": "Toggle the caller's emoji reaction on a P2P message. Adds the reaction if absent, removes it if already present. P2P messages are single-write in the author's DB, so reactions to a peer-authored message are toggled cross-DB. Persists per-message in metadata under the _reactions_ key. Notifies the peer and the caller's other sessions via WebSocket.",
+      "scope": "hub",
+      "permission": {
+        "src": "write"
+      },
+      "params": {
+        "message_id": {
+          "type": "string",
+          "required": true,
+          "description": "ID of the message to react to"
+        },
+        "emoji": {
+          "type": "string",
+          "required": true,
+          "description": "Single emoji to toggle for the caller"
+        },
+        "entity_id": {
+          "type": "string",
+          "required": true,
+          "description": "Peer user ID (peer_id). Identifies the conversation and the DB that may own the message. Accepts peer_id as alias."
+        },
+        "peer_id": {
+          "type": "string",
+          "required": false,
+          "description": "Alias for entity_id"
+        },
+        "socket_id": {
+          "type": "string",
+          "required": false,
+          "description": "Caller's WebSocket socket ID, excluded from the caller's sibling-session broadcast"
+        }
+      },
+      "returns": {
+        "type": "object",
+        "description": "Updated reaction state with message_id and the reactions map (emoji to array of user IDs)"
+      },
+      "errors": []
+    },
+
     "share_rooms": {
       "doc": "List group/shared chat rooms. Returns chat rooms for group conversations (not direct contact chats), with optional keyword filtering and pagination.",
       "scope": "hub",

--- a/offline/queues/migrationQueue.js
+++ b/offline/queues/migrationQueue.js
@@ -73,7 +73,15 @@ const migrationQueue = new Queue('drumee:migration', {
       type: 'exponential',
       delay: 10000, // 10s → 20s → 40s
     },
-    timeout: 30 * 60 * 1000, // 30 min — long-running import
+    // No fixed per-job wall. A folder with up to 10,000 files legitimately
+    // runs well past any constant (even parallelized), and a 30-min guillotine
+    // killed such jobs mid-import → Bull re-ran from scratch on each of 3
+    // attempts → permanent failure (never reached 'completed'). Job liveness is
+    // instead guarded by lockDuration/lockRenewTime + stalledInterval/
+    // maxStalledCount above, by a PER-REQUEST axios timeout in the importer (so
+    // a hung Drive socket is reaped without a job-wide guillotine), and by the
+    // Redis cancellation sentinel for user-initiated stops.
+    timeout: 0,
     removeOnComplete: 100,   // keep last 100 for status polling after finish
     // Cap retained failures so Redis doesn't grow unbounded. Keep recent
     // ones (7 days / 200 max) for status polling + debugging; older ones

--- a/offline/workers/gdrive/importer.js
+++ b/offline/workers/gdrive/importer.js
@@ -28,7 +28,9 @@ const fsp = require('fs').promises;
 const { join, extname } = require('path');
 const { createHash } = require('crypto');
 const { google } = require('googleapis');
-const { isCancelled } = require('../../queues/migrationQueue');
+const migrationQueue = require('../../queues/migrationQueue');
+const { isCancelled } = migrationQueue;
+const { withDriveRetry, classifyDriveError } = require('./retry');
 const { googleDriveCredentials, googleDriveServiceAccount } = require('../../../service/lib/google_credentials');
 
 const PROGRESS_BATCH = 5;
@@ -48,6 +50,34 @@ const DRIVE_HTTP_TIMEOUT_MS = 120000;
 // folder where every child fails NOT_GRANTED) can't bloat job.returnvalue,
 // which is JSON-serialized into Redis. The TRUE total is tracked in errorCount.
 const MAX_ERRORS = 200;
+// File-level download concurrency WITHIN one job. The Bull worker already runs
+// 2 jobs at once (gdriveWorker CONCURRENCY), so 2 × this bounds simultaneous
+// Drive downloads — kept conservative (Drive rate-limits aggressively, and the
+// retry layer absorbs the rest). FOLDER creation stays serial; only regular
+// files inside a folder run through the pool.
+const FILE_CONCURRENCY = Math.min(8, Math.max(1, parseInt(process.env.GDRIVE_FILE_CONCURRENCY || '4', 10)));
+// Resume set TTL — mirrors the cancellation sentinel; a job that outlives 1h
+// no longer needs cross-attempt resume state.
+const DONE_TTL_SEC = 3600;
+
+/**
+ * Minimal promise semaphore (no dependency). Returns a `limit(fn)` that runs at
+ * most `max` fns concurrently, queueing the rest. Used to bound file downloads.
+ */
+function makeSemaphore(max) {
+  let active = 0;
+  const queue = [];
+  const pump = () => {
+    if (active >= max || queue.length === 0) return;
+    active += 1;
+    const { fn, resolve, reject } = queue.shift();
+    Promise.resolve().then(fn).then(resolve, reject).finally(() => {
+      active -= 1;
+      pump();
+    });
+  };
+  return (fn) => new Promise((resolve, reject) => { queue.push({ fn, resolve, reject }); pump(); });
+}
 
 class GoogleDriveImporter {
   /**
@@ -66,6 +96,17 @@ class GoogleDriveImporter {
     this._cancelled = false;
     // Token cache populated lazily; refreshed when expires_at - safety < now.
     this._tokenCache = null;          // { access_token, expires_at }
+    // Single-flight guard: collapse N concurrent token refreshes (file pool)
+    // into one in-flight promise so they don't race the cache / oauth row.
+    this._tokenRefreshing = null;
+    // Bounded file-download pool (folder recursion stays serial).
+    this._limit = makeSemaphore(FILE_CONCURRENCY);
+    // Resume set: Drive item.ids already durably imported. Seeded from Redis in
+    // run() so a retry/crash skips finished files instead of re-doing them.
+    this._done = new Set();
+    this._doneKey = null;
+    // Progress is flushed every PROGRESS_BATCH completions across the pool.
+    this._completedSinceUpdate = 0;
     // Per-job scratch dir — wiped on completion to avoid /tmp growing
     // unboundedly across migrations. Set in run() once job.id is known.
     this._scratchDir = null;
@@ -93,6 +134,17 @@ class GoogleDriveImporter {
     // jobs and also walls off cross-job cache leaks.
     this._scratchDir = join('/tmp', `gdrive-job-${this.job.id}`);
     await fsp.mkdir(this._scratchDir, { recursive: true });
+
+    // Seed the resume set: Drive ids durably imported in a PRIOR attempt of this
+    // same job (Bull retry / worker crash-restart). Best-effort — a Redis miss
+    // just means re-importing (still idempotent via node_id_from_path). Keep
+    // processedFiles at 0: the re-walk re-counts as it skips done files, so the
+    // progress numbers stay self-consistent (no double-count of seeded totals).
+    this._doneKey = `gdrive:done:${this.job.id}`;
+    try {
+      const ids = await migrationQueue.client.smembers(this._doneKey);
+      this._done = new Set(ids || []);
+    } catch (_) { this._done = new Set(); }
 
     // Prime the token cache — throws NEEDS_RECONNECT if no refresh_token.
     // Subsequent Drive calls use `_getFreshToken()` which lazily refreshes.
@@ -182,6 +234,11 @@ class GoogleDriveImporter {
       }
     }
 
+    // Terminal completion (success OR user-cancel — both reach here; a thrown /
+    // timed-out attempt does NOT, so the resume set survives for the retry).
+    // Clear the resume set now that this job is done with it.
+    try { await migrationQueue.client.del(this._doneKey); } catch (_) {}
+
     // Bull will use this object as `job.returnvalue` on the 'completed'
     // event. The FE reads it via `get_status`.
     return {
@@ -208,6 +265,22 @@ class GoogleDriveImporter {
     if (this._tokenCache && this._tokenCache.expires_at - TOKEN_SAFETY_SEC > now) {
       return this._tokenCache.access_token;
     }
+    // Single-flight: under the file pool, N tasks can all miss the cache at
+    // once. Each refreshing would race the _tokenCache write AND (OAuth path)
+    // write-skew the shared oauth_accounts row — the exact token-clobber class a
+    // prior fix closed. Share ONE in-flight refresh across all callers; it spans
+    // BOTH the SA jwt.authorize and the OAuth SELECT+refresh+UPDATE branches.
+    if (this._tokenRefreshing) return this._tokenRefreshing;
+    this._tokenRefreshing = this._refreshToken(now)
+      .finally(() => { this._tokenRefreshing = null; });
+    return this._tokenRefreshing;
+  }
+
+  /**
+   * The actual SA/OAuth refresh. Never call directly — always go through
+   * _getFreshToken so concurrent refreshes collapse into one (single-flight).
+   */
+  async _refreshToken(now) {
     // Service-account jobs (whole-folder import via share-to-SA): the SA
     // reads with its OWN auth — no oauth_accounts row involved at all.
     if (this.data.auth_kind === 'sa') {
@@ -298,14 +371,17 @@ class GoogleDriveImporter {
         params.includeItemsFromAllDrives = true;
         params.corpora = 'allDrives';
       }
-      // Re-read token before EACH page so a long pagination doesn't 401
-      // halfway through a 10k-file folder.
-      const accessToken = await this._getFreshToken();
-      const res = await axios.get('https://www.googleapis.com/drive/v3/files', {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        params,
-        timeout: DRIVE_HTTP_TIMEOUT_MS,
-      });
+      // Re-read token before EACH page (inside the retried fn) so a long
+      // pagination doesn't 401 halfway through a 10k-file folder; a 429/5xx on a
+      // page now backs off + retries instead of abandoning the whole folder.
+      const res = await withDriveRetry(async () => {
+        const accessToken = await this._getFreshToken();
+        return axios.get('https://www.googleapis.com/drive/v3/files', {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          params,
+          timeout: DRIVE_HTTP_TIMEOUT_MS,
+        });
+      }, { onAuth: () => { this._tokenCache = null; }, isCancelled: () => this._checkCancelled() });
       items.push(...(res.data.files || []));
       pageToken = res.data.nextPageToken;
     } while (pageToken);
@@ -317,12 +393,14 @@ class GoogleDriveImporter {
    * name/mimeType itself — never trusts client-supplied names.
    */
   async _getMeta(id) {
-    const token = await this._getFreshToken();
-    const res = await axios.get(`https://www.googleapis.com/drive/v3/files/${id}`, {
-      headers: { Authorization: `Bearer ${token}` },
-      params: { fields: 'id, name, mimeType, size' },
-      timeout: DRIVE_HTTP_TIMEOUT_MS,
-    });
+    const res = await withDriveRetry(async () => {
+      const token = await this._getFreshToken();
+      return axios.get(`https://www.googleapis.com/drive/v3/files/${id}`, {
+        headers: { Authorization: `Bearer ${token}` },
+        params: { fields: 'id, name, mimeType, size' },
+        timeout: DRIVE_HTTP_TIMEOUT_MS,
+      });
+    }, { onAuth: () => { this._tokenCache = null; }, isCancelled: () => this._checkCancelled() });
     return res.data;
   }
 
@@ -394,8 +472,11 @@ class GoogleDriveImporter {
    * items, instead of a generic failure.
    */
   _grantCode(e, fallback) {
-    const status = e && e.response && e.response.status;
-    return (status === 403 || status === 404) ? 'NOT_GRANTED' : fallback;
+    // Only a genuine grant gap (403 non-rate / 404) is NOT_GRANTED. A
+    // rate-limited 403 whose retries were exhausted must NOT be mislabeled — it
+    // falls back to LIST_FAILED/IMPORT_FAILED so the FE doesn't tell the user to
+    // re-pick files that were merely throttled.
+    return classifyDriveError(e) === 'fatal_grant' ? 'NOT_GRANTED' : fallback;
   }
 
   async _traverse(opts) {
@@ -420,41 +501,90 @@ class GoogleDriveImporter {
       }
       return true;
     });
+    const FOLDER = 'application/vnd.google-apps.folder';
+    const subFolders = items.filter((i) => i.mimeType === FOLDER);
+    const files = items.filter((i) => i.mimeType !== FOLDER);
     this.totalFolders += 1;
-    this.totalFiles += items.filter((i) => i.mimeType !== 'application/vnd.google-apps.folder').length;
+    this.totalFiles += files.length;
     await this._pushProgress(opts);
 
-    let countSinceUpdate = 0;
-    for (const item of items) {
-      // Cancellation gate before EACH item — keeps the response time
-      // tight; was previously `>= PROGRESS_BATCH` which allowed up to 4
-      // more files to import after the user clicked Cancel.
+    // Folders FIRST, SERIALLY: a child node needs its parent to exist before
+    // creation, and _createFolder idempotency relies on ordered creation —
+    // never parallelize this.
+    for (const folder of subFolders) {
       if (await this._checkCancelled()) return;
-
-      if (item.mimeType === 'application/vnd.google-apps.folder') {
-        const subDestFolder = await this._createFolder(item.name, opts.destFolder, opts.hubDb, opts.userId);
-        await this._traverse({ ...opts, folderId: item.id, destFolder: subDestFolder });
-        // Propagate cancel upward from nested folder.
-        if (this._cancelled) return;
-        continue;
-      }
-
-      try {
-        await this._importItem(item, opts);
-        this.processedFiles += 1;
-        countSinceUpdate++;
-        // Only flush progress every PROGRESS_BATCH files to avoid hammering
-        // Redis for tiny per-file updates.
-        if (countSinceUpdate >= PROGRESS_BATCH) {
-          await this._pushProgress(opts, item.name);
-          countSinceUpdate = 0;
-        }
-      } catch (e) {
-        this._pushError({ file: item.name, code: 'IMPORT_FAILED', reason: e.message });
-        await this._pushProgress(opts);
-      }
+      const subDestFolder = await this._createFolder(folder.name, opts.destFolder, opts.hubDb, opts.userId);
+      await this._traverse({ ...opts, folderId: folder.id, destFolder: subDestFolder });
+      if (this._cancelled) return; // propagate cancel up from a nested folder
     }
-    if (countSinceUpdate > 0) await this._pushProgress(opts);
+
+    // Files: bounded-parallel through the instance semaphore. Downloads overlap;
+    // the per-folder DB create+resolve is race-safe because filenames are unique
+    // within a Drive folder (see _importItem id resolution). _importItemGuarded
+    // never rejects, so allSettled keeps siblings alive when one file fails.
+    const tasks = [];
+    for (const file of files) {
+      if (await this._checkCancelled()) break;       // stop DISPATCHING new work
+      tasks.push(this._limit(() => this._importItemGuarded(file, opts)));
+    }
+    await Promise.allSettled(tasks);                  // keep this frame alive until all settle
+    await this._pushProgress(opts);                   // flush the final partial batch
+    if (this._cancelled) return;
+  }
+
+  /**
+   * Pool task for one file: resume-skip, import, synchronous counter update,
+   * capped error capture, batched progress. NEVER rejects (paired with
+   * Promise.allSettled) so one bad file can't abort its folder's pool.
+   */
+  async _importItemGuarded(item, opts) {
+    if (this._cancelled) return;                      // drain fast once cancelled
+    // Already imported in a prior attempt of this job (keyed by Drive id) —
+    // skip the download + DB work, just account for it.
+    if (this._done.has(item.id)) {
+      this.processedFiles += 1;
+      this._onFileComplete(opts);
+      return;
+    }
+    try {
+      await this._importItem(item, opts);
+      this.processedFiles += 1;                       // synchronous, immediately post-await
+      await this._markDone(item.id);
+      this._onFileComplete(opts, item.name);
+    } catch (e) {
+      // A cancel-induced throw (download aborted mid-backoff) is not a real file
+      // error — don't pollute errors[] with it.
+      if (this._cancelled) return;
+      this._pushError({ file: item.name, code: this._grantCode(e, 'IMPORT_FAILED'), reason: e.message });
+      this._onFileComplete(opts);
+    }
+  }
+
+  /**
+   * Flush progress every PROGRESS_BATCH completions across the pool. The counter
+   * body is synchronous (no await) so concurrent callers can't interleave it;
+   * the progress write is fire-and-forget (it self-catches) to keep tasks short.
+   */
+  _onFileComplete(opts, currentFilename) {
+    this._completedSinceUpdate += 1;
+    if (this._completedSinceUpdate >= PROGRESS_BATCH) {
+      this._completedSinceUpdate = 0;
+      this._pushProgress(opts, currentFilename);
+    }
+  }
+
+  /**
+   * Record a file as durably imported: in-memory (this run's de-dup) + Redis
+   * (cross-attempt resume, TTL-bounded). One pipelined round-trip; best-effort.
+   */
+  async _markDone(itemId) {
+    this._done.add(itemId);
+    try {
+      await migrationQueue.client.multi()
+        .sadd(this._doneKey, itemId)
+        .expire(this._doneKey, DONE_TTL_SEC)
+        .exec();
+    } catch (_) { /* in-memory set still de-dups this run */ }
   }
 
   /**
@@ -562,35 +692,37 @@ class GoogleDriveImporter {
     const source = join(this._scratchDir, cacheKey);
 
     if (!existsSync(source)) {
-      // Always refresh token before the download — long downloads can
-      // outlive the token if we read it at start-of-job.
-      const accessToken = await this._getFreshToken();
-      // Atomic write: stream to `.part`, rename on full success. Without
-      // the rename gate, a mid-stream network drop leaves a truncated
-      // file at `source` that subsequent calls would happily re-use.
+      // Atomic write: stream to `.part`, rename on full success. The whole
+      // download (token fetch + GET + stream) is retried as a unit so a 429/5xx
+      // or a mid-stream ECONNRESET re-streams cleanly: createWriteStream
+      // truncates `.part` on each attempt, the rename runs only after a complete
+      // stream, and the token is re-read inside so a long download can't 401.
       const partFile = `${source}.part`;
-      const dl = await axios.get(downloadUrl, {
-        headers: { Authorization: `Bearer ${accessToken}` },
-        responseType: 'stream',
-        maxRedirects: 5,
-        timeout: DRIVE_HTTP_TIMEOUT_MS,
-      });
-      await new Promise((resolve, reject) => {
-        const out = createWriteStream(partFile);
-        let settled = false;
-        const done = (err) => {
-          if (settled) return;
-          settled = true;
-          if (err) {
-            try { unlinkSync(partFile); } catch (_) {}
-            reject(err);
-          } else resolve();
-        };
-        dl.data.on('error', done);
-        out.on('error', done);
-        out.on('finish', () => done(null));
-        dl.data.pipe(out);
-      });
+      await withDriveRetry(async () => {
+        const accessToken = await this._getFreshToken();
+        const dl = await axios.get(downloadUrl, {
+          headers: { Authorization: `Bearer ${accessToken}` },
+          responseType: 'stream',
+          maxRedirects: 5,
+          timeout: DRIVE_HTTP_TIMEOUT_MS,
+        });
+        await new Promise((resolve, reject) => {
+          const out = createWriteStream(partFile);
+          let settled = false;
+          const done = (err) => {
+            if (settled) return;
+            settled = true;
+            if (err) {
+              try { unlinkSync(partFile); } catch (_) {}
+              reject(err);
+            } else resolve();
+          };
+          dl.data.on('error', done);
+          out.on('error', done);
+          out.on('finish', () => done(null));
+          dl.data.pipe(out);
+        });
+      }, { onAuth: () => { this._tokenCache = null; }, isCancelled: () => this._checkCancelled() });
       // rename is atomic on the same filesystem — readers will only ever
       // see the complete file at `source`.
       await fsp.rename(partFile, source);
@@ -644,14 +776,17 @@ class GoogleDriveImporter {
     // return shape is unreliable in the worker). Match by (pid, name); fall
     // back to the most-recent non-folder child under pid — files are imported
     // sequentially within a job, so that's the one just created.
-    let nodeId = await this._findChildId(opts.hubDb, pid, filenameWithoutExt, false);
-    if (!nodeId) {
-      const rows = await opts.hubDb.await_query(
-        `SELECT id FROM media WHERE parent_id = ? AND category <> 'folder' ORDER BY id DESC LIMIT 1`,
-        pid
-      );
-      nodeId = (toArray(rows)[0] || {}).id || null;
-    }
+    // Resolve by (pid, name). The old "most-recent non-folder child under pid"
+    // fallback is REMOVED: under the file pool it could resolve a DIFFERENT
+    // file's id (wrong node). Name resolution is race-safe for DISTINCT names —
+    // the overwhelming common case in a folder. KNOWN LIMITATION: Google Drive
+    // permits two files with the SAME name in one folder; imported concurrently
+    // they both resolve to the first-created node (one ends up byte-less). The
+    // serial path skipped the 2nd via the path dedup above (when file_path is
+    // present); a future conflict-policy pass (rename/overwrite) is the proper
+    // fix. Accepted here over a per-folder write mutex, which would serialize
+    // every file's DB write and erode the concurrency win for a rare case.
+    const nodeId = await this._findChildId(opts.hubDb, pid, filenameWithoutExt, false);
     if (!nodeId) throw new Error(`could not resolve created file '${filenameWithoutExt}' under pid=${pid}`);
 
     const base = join(home_dir, '__storage__', nodeId);

--- a/offline/workers/gdrive/importer.js
+++ b/offline/workers/gdrive/importer.js
@@ -37,6 +37,17 @@ const PAGE_SIZE = 1000;
 // long-running job (large files, slow network) doesn't fail mid-traverse
 // with a 401 on every Drive request.
 const TOKEN_SAFETY_SEC = 60;
+// Per-request ceiling for EVERY Drive HTTP call. With the job-level timeout
+// disabled (see migrationQueue.js), this is what reaps a hung socket: without
+// it a stalled list/download would hang until Bull's stall-detector fires
+// (minutes of dead time). For streamed downloads axios applies this to the
+// response/inactivity, which is the case we care about (a wedged connection),
+// not a slow-but-progressing transfer.
+const DRIVE_HTTP_TIMEOUT_MS = 120000;
+// Cap the RETAINED per-file error list so a pathological run (e.g. a 10k-file
+// folder where every child fails NOT_GRANTED) can't bloat job.returnvalue,
+// which is JSON-serialized into Redis. The TRUE total is tracked in errorCount.
+const MAX_ERRORS = 200;
 
 class GoogleDriveImporter {
   /**
@@ -47,7 +58,8 @@ class GoogleDriveImporter {
     this.job = job;
     this.data = job.data || {};
     this.yp = yp;
-    this.errors = [];
+    this.errors = [];          // retained sample, capped at MAX_ERRORS
+    this.errorCount = 0;       // true total (may exceed errors.length)
     this.processedFiles = 0;
     this.totalFolders = 0;
     this.totalFiles = 0;
@@ -178,7 +190,9 @@ class GoogleDriveImporter {
       processed_files: this.processedFiles,
       total_files: this.totalFiles,
       total_folders: this.totalFolders,
-      errors: this.errors,
+      errors: this.errors,                              // capped sample (≤ MAX_ERRORS)
+      errors_count: this.errorCount,                    // true total
+      errors_truncated: this.errorCount > this.errors.length,
       dest_nid: this._destNidOut || null,
     };
   }
@@ -290,6 +304,7 @@ class GoogleDriveImporter {
       const res = await axios.get('https://www.googleapis.com/drive/v3/files', {
         headers: { Authorization: `Bearer ${accessToken}` },
         params,
+        timeout: DRIVE_HTTP_TIMEOUT_MS,
       });
       items.push(...(res.data.files || []));
       pageToken = res.data.nextPageToken;
@@ -306,6 +321,7 @@ class GoogleDriveImporter {
     const res = await axios.get(`https://www.googleapis.com/drive/v3/files/${id}`, {
       headers: { Authorization: `Bearer ${token}` },
       params: { fields: 'id, name, mimeType, size' },
+      timeout: DRIVE_HTTP_TIMEOUT_MS,
     });
     return res.data;
   }
@@ -331,7 +347,7 @@ class GoogleDriveImporter {
       try {
         meta = await this._getMeta(folderId);
       } catch (e) {
-        this.errors.push({ folder: folderId, code: this._grantCode(e, 'META_FAILED'), reason: e.message });
+        this._pushError({ folder: folderId, code: this._grantCode(e, 'META_FAILED'), reason: e.message });
         await this._pushProgress(base);
         continue;
       }
@@ -345,7 +361,7 @@ class GoogleDriveImporter {
       // the feature is broken. NOT for SA jobs: the SA has real read access,
       // so an empty result there just means the folder IS empty.
       if (this.totalFiles === filesBefore && this.data.auth_kind !== 'sa') {
-        this.errors.push({ folder: meta.name, code: 'NOT_GRANTED', reason: 'folder children not granted' });
+        this._pushError({ folder: meta.name, code: 'NOT_GRANTED', reason: 'folder children not granted' });
       }
     }
 
@@ -355,7 +371,7 @@ class GoogleDriveImporter {
       try {
         meta = await this._getMeta(fileId);
       } catch (e) {
-        this.errors.push({ file: fileId, code: this._grantCode(e, 'META_FAILED'), reason: e.message });
+        this._pushError({ file: fileId, code: this._grantCode(e, 'META_FAILED'), reason: e.message });
         await this._pushProgress(base);
         continue;
       }
@@ -365,7 +381,7 @@ class GoogleDriveImporter {
         this.processedFiles += 1;
         await this._pushProgress(base, meta.name);
       } catch (e) {
-        this.errors.push({ file: meta.name, code: this._grantCode(e, 'IMPORT_FAILED'), reason: e.message });
+        this._pushError({ file: meta.name, code: this._grantCode(e, 'IMPORT_FAILED'), reason: e.message });
         await this._pushProgress(base);
       }
     }
@@ -390,7 +406,7 @@ class GoogleDriveImporter {
     try {
       items = await this._listFolder(opts.folderId, opts.includeSharedDrives);
     } catch (e) {
-      this.errors.push({ folder: opts.folderId, code: this._grantCode(e, 'LIST_FAILED'), reason: e.message });
+      this._pushError({ folder: opts.folderId, code: this._grantCode(e, 'LIST_FAILED'), reason: e.message });
       await this._pushProgress(opts);
       return;
     }
@@ -399,7 +415,7 @@ class GoogleDriveImporter {
     // uppy's picker importer: never follow them, record the skip.
     items = items.filter((i) => {
       if (i.mimeType === 'application/vnd.google-apps.shortcut') {
-        this.errors.push({ file: i.name, code: 'SHORTCUT_SKIPPED', reason: 'shortcuts are not followed' });
+        this._pushError({ file: i.name, code: 'SHORTCUT_SKIPPED', reason: 'shortcuts are not followed' });
         return false;
       }
       return true;
@@ -434,11 +450,21 @@ class GoogleDriveImporter {
           countSinceUpdate = 0;
         }
       } catch (e) {
-        this.errors.push({ file: item.name, code: 'IMPORT_FAILED', reason: e.message });
+        this._pushError({ file: item.name, code: 'IMPORT_FAILED', reason: e.message });
         await this._pushProgress(opts);
       }
     }
     if (countSinceUpdate > 0) await this._pushProgress(opts);
+  }
+
+  /**
+   * Append an error, but cap the RETAINED list at MAX_ERRORS so a run with
+   * thousands of failing files can't bloat job.returnvalue (Redis). errorCount
+   * keeps the true total; the FE shows it as "N errors (M shown)".
+   */
+  _pushError(entry) {
+    this.errorCount += 1;
+    if (this.errors.length < MAX_ERRORS) this.errors.push(entry);
   }
 
   /**
@@ -450,7 +476,7 @@ class GoogleDriveImporter {
       processed_files: this.processedFiles,
       total_files: this.totalFiles,
       total_folders: this.totalFolders,
-      errors_count: this.errors.length,
+      errors_count: this.errorCount,
     };
     if (currentFilename) payload.current_filename = currentFilename;
     try {
@@ -547,6 +573,7 @@ class GoogleDriveImporter {
         headers: { Authorization: `Bearer ${accessToken}` },
         responseType: 'stream',
         maxRedirects: 5,
+        timeout: DRIVE_HTTP_TIMEOUT_MS,
       });
       await new Promise((resolve, reject) => {
         const out = createWriteStream(partFile);
@@ -630,7 +657,18 @@ class GoogleDriveImporter {
     const base = join(home_dir, '__storage__', nodeId);
     const orig = join(base, `orig.${ext}`);
     await fsp.mkdir(base, { recursive: true });
-    await fsp.copyFile(source, orig);
+    try {
+      await fsp.copyFile(source, orig);
+    } finally {
+      // Free the scratch copy immediately after the durable write so peak /tmp
+      // stays at ~one file instead of the whole tree — a 10k-file import would
+      // otherwise accumulate every downloaded byte until the end-of-job rm in
+      // run() (→ ENOSPC). async fsp.unlink (never unlinkSync) per the Bull
+      // lock-stall invariant. Best-effort: the end-of-job rm is the backstop.
+      // Trade-off: defeats the in-job same-id dedup (existsSync on `source`) for
+      // a file.id|exportMime that appears twice in one tree — rare, acceptable.
+      try { await fsp.unlink(source); } catch (_) {}
+    }
   }
 
   /**

--- a/offline/workers/gdrive/retry.js
+++ b/offline/workers/gdrive/retry.js
@@ -1,0 +1,82 @@
+/**
+ * Drive API error classification + retry-with-backoff for the migration worker.
+ *
+ * Used by importer.js to wrap the list/meta/download HTTP calls. Once file-level
+ * concurrency raises the request rate on a 10k-file import, Drive starts
+ * returning 429 / 403-rateLimit / 5xx; without retry those become PERMANENT
+ * per-file failures (the importer's per-file catch records IMPORT_FAILED and the
+ * job still resolves 'completed' with files silently missing). This layer turns
+ * transient errors into a short backoff + retry instead.
+ *
+ * Invariant note: capMs (20s) stays below the Bull lockRenewTime (30s) so a
+ * single backoff sleep can never starve the job-lock renewal.
+ */
+
+const RATE_REASONS = ['userRateLimitExceeded', 'rateLimitExceeded', 'dailyLimitExceeded', 'backendError'];
+const NET_CODES = ['ECONNRESET', 'ETIMEDOUT', 'ECONNABORTED', 'EAI_AGAIN', 'EPIPE', 'ENOTFOUND', 'ERR_STREAM_PREMATURE_CLOSE'];
+
+/**
+ * @returns {'retryable'|'auth'|'fatal_grant'|'fatal'}
+ *  - retryable   : 429 / 500 / 502 / 503 / 504 / rate-limited-403 / network blip
+ *  - auth        : 401 → refresh the token once, then retry
+ *  - fatal_grant : 403 (non-rate reason) or 404 → the drive.file grant gap;
+ *                  maps to NOT_GRANTED upstream — do NOT retry
+ *  - fatal       : everything else, incl. NEEDS_RECONNECT / SA errors that carry
+ *                  no `.response` (→ propagate to run(), which job.discard()s)
+ */
+function classifyDriveError(e) {
+  const status = e && e.response && e.response.status;
+  const errs = (e && e.response && e.response.data && e.response.data.error && e.response.data.error.errors) || [];
+  const reasons = errs.map((x) => x && x.reason);
+  if (status === 429 || status === 500 || status === 502 || status === 503 || status === 504) return 'retryable';
+  if (status === 403 && reasons.some((r) => RATE_REASONS.includes(r))) return 'retryable';
+  if (e && NET_CODES.includes(e.code)) return 'retryable';
+  if (status === 401) return 'auth';
+  if (status === 403 || status === 404) return 'fatal_grant';
+  return 'fatal';
+}
+
+/**
+ * Run fn() with exponential backoff + full jitter on retryable Drive errors.
+ *
+ * @param {() => Promise<any>} fn
+ * @param {object} opts
+ * @param {() => Promise<any>} [opts.onAuth]      called ONCE on a 401 to force a
+ *        token refresh (e.g. clear the cache); then fn is retried immediately.
+ * @param {() => Promise<boolean>} [opts.isCancelled] polled before each sleep; a
+ *        truthy result rethrows the last error at once so cancellation stays
+ *        responsive and the importer's loop terminates.
+ * @param {number} [opts.maxAttempts=5]
+ * @param {number} [opts.baseMs=1000]
+ * @param {number} [opts.capMs=20000]  per-sleep ceiling (< lockRenewTime).
+ */
+async function withDriveRetry(fn, opts = {}) {
+  const { onAuth, isCancelled, maxAttempts = 5, baseMs = 1000, capMs = 20000 } = opts;
+  let authRetried = false;
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      // Cancellation outranks any retry — bail immediately, no backoff.
+      if (isCancelled && (await isCancelled())) throw e;
+      const cls = classifyDriveError(e);
+      if (cls === 'auth' && onAuth && !authRetried) {
+        authRetried = true;
+        await onAuth();
+        continue; // immediate retry with a fresh token (no backoff slot)
+      }
+      if (cls !== 'retryable') throw e;
+      if (attempt >= maxAttempts) throw e;
+      // Honor a Retry-After header if Drive sent one, else exponential.
+      const retryAfter = Number(e && e.response && e.response.headers && e.response.headers['retry-after']);
+      const ceiling = retryAfter > 0
+        ? Math.min(retryAfter * 1000, capMs)
+        : Math.min(capMs, baseMs * 2 ** (attempt - 1));
+      const delay = Math.random() * ceiling; // full jitter
+      if (isCancelled && (await isCancelled())) throw e;
+      await new Promise((r) => setTimeout(r, delay));
+    }
+  }
+}
+
+module.exports = { classifyDriveError, withDriveRetry };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.64",
+  "version": "2.9.65",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.64",
+      "version": "2.9.65",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.68",
+  "version": "2.9.69",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.68",
+      "version": "2.9.69",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.69",
+  "version": "2.9.70",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.69",
+      "version": "2.9.70",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.66",
+  "version": "2.9.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.66",
+      "version": "2.9.67",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.61",
+  "version": "2.9.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.61",
+      "version": "2.9.62",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.65",
+  "version": "2.9.66",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.65",
+      "version": "2.9.66",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.63",
+  "version": "2.9.64",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.63",
+      "version": "2.9.64",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.67",
+  "version": "2.9.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.67",
+      "version": "2.9.68",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.62",
+  "version": "2.9.63",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.62",
+      "version": "2.9.63",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.62",
+  "version": "2.9.63",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.68",
+  "version": "2.9.69",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.63",
+  "version": "2.9.64",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.61",
+  "version": "2.9.62",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.69",
+  "version": "2.9.70",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.64",
+  "version": "2.9.65",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.67",
+  "version": "2.9.68",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.66",
+  "version": "2.9.67",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.65",
+  "version": "2.9.66",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/patches/message-reaction-toggle.sql
+++ b/patches/message-reaction-toggle.sql
@@ -1,0 +1,114 @@
+-- =========================================================
+-- message_reaction_toggle  (HUB class — team chat + folder window)
+-- ONE reaction per user per message: a user holds at most one emoji.
+--   - Picking the user's current emoji again  -> remove it (toggle off).
+--   - Picking a different emoji               -> move the user to it (replace).
+-- Stored per-message in `channel`.metadata under `_reactions_`:
+--   { "<emoji>": ["<uid>", ...] }. Only the _reactions_ subpath is touched,
+-- so read-receipts (`_seen_`) and other metadata keys are preserved.
+--
+-- All writes operate DIRECTLY on `_meta` via JSON_REMOVE / JSON_ARRAY_APPEND /
+-- JSON_SET(..., JSON_ARRAY()). We never JSON_SET a string variable as the value
+-- (that double-encodes the sub-object into a quoted string). Atomic under
+-- concurrency (transaction + FOR UPDATE). Requires MariaDB 10.2.3+. Caller
+-- (service) validates emoji: single glyph, no quote/backslash/whitespace; uids
+-- are 16-char ascii hex (safe for the JSON_SEARCH removal below).
+--
+-- Returns one row: found (0 if message absent), capped (1 if a new emoji hit
+-- the distinct cap), reactions (the updated map as a JSON object).
+--
+-- Apply (DEV/STAGE ONLY — every hub instance on the server):
+--   bin/patch-from-file patches/message-reaction-toggle.sql hub
+-- =========================================================
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `message_reaction_toggle`$
+CREATE PROCEDURE `message_reaction_toggle`(
+  IN _message_id VARCHAR(16) CHARACTER SET ascii,
+  IN _uid VARCHAR(16) CHARACTER SET ascii,
+  IN _emoji VARCHAR(64) CHARACTER SET utf8mb4
+)
+BEGIN
+  DECLARE _meta LONGTEXT;
+  DECLARE _keys LONGTEXT;
+  DECLARE _arr LONGTEXT;
+  DECLARE _key VARCHAR(64) CHARACTER SET utf8mb4;
+  DECLARE _kpath VARCHAR(160);
+  DECLARE _epath VARCHAR(160);
+  DECLARE _hit VARCHAR(64);
+  DECLARE _n INT DEFAULT 0;
+  DECLARE _k INT DEFAULT 0;
+  DECLARE _was_mine INT DEFAULT 0;
+  DECLARE _capped INT DEFAULT 0;
+  DECLARE _exists INT DEFAULT 0;
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  SET _epath = CONCAT('$._reactions_."', _emoji, '"');
+
+  START TRANSACTION;
+  SELECT COUNT(1) INTO _exists FROM `channel` WHERE message_id = _message_id;
+
+  IF _exists = 0 THEN
+    COMMIT;
+    SELECT 0 AS found, 0 AS capped, JSON_OBJECT() AS reactions;
+  ELSE
+    SELECT metadata INTO _meta FROM `channel` WHERE message_id = _message_id FOR UPDATE;
+    SET _meta = COALESCE(NULLIF(_meta, ''), '{}');
+    IF JSON_EXTRACT(_meta, '$._reactions_') IS NULL THEN
+      SET _meta = JSON_SET(_meta, '$._reactions_', JSON_OBJECT());
+    END IF;
+
+    -- Remove _uid from EVERY emoji array (one-per-user; also normalises any
+    -- legacy state where the user sat on multiple emojis). Operates on _meta
+    -- directly so nothing is re-encoded as a string.
+    SET _keys = COALESCE(JSON_KEYS(JSON_EXTRACT(_meta, '$._reactions_')), JSON_ARRAY());
+    SET _n = JSON_LENGTH(_keys);
+    SET _k = 0;
+    WHILE _k < _n DO
+      SET _key = JSON_UNQUOTE(JSON_EXTRACT(_keys, CONCAT('$[', _k, ']')));
+      SET _kpath = CONCAT('$._reactions_."', _key, '"');
+      SET _arr = JSON_EXTRACT(_meta, _kpath);
+      IF _arr IS NOT NULL AND JSON_CONTAINS(_arr, JSON_QUOTE(_uid)) THEN
+        -- Compare emojis with BINARY collation. The connection's default
+        -- utf8mb4_general_ci treats DISTINCT emojis as EQUAL ('👍' = '😮' is
+        -- TRUE), which made a switch (react 👍, then pick 😮) look like a
+        -- toggle-off: _was_mine was set, the old emoji was removed, and the new
+        -- one was NEVER added until a second call. utf8mb4_bin keeps same-emoji
+        -- equal (toggle-off still works) while distinguishing different emojis.
+        IF _key = _emoji COLLATE utf8mb4_bin THEN SET _was_mine = 1; END IF;
+        SET _hit = JSON_UNQUOTE(JSON_SEARCH(_arr, 'one', _uid));
+        IF _hit IS NOT NULL THEN
+          SET _meta = JSON_REMOVE(_meta, CONCAT(_kpath, SUBSTR(_hit, 2)));
+        END IF;
+        IF JSON_LENGTH(JSON_EXTRACT(_meta, _kpath)) = 0 THEN
+          SET _meta = JSON_REMOVE(_meta, _kpath);
+        END IF;
+      END IF;
+      SET _k = _k + 1;
+    END WHILE;
+
+    -- Re-add the user to the chosen emoji unless they toggled the same one off.
+    IF _was_mine = 0 THEN
+      IF JSON_EXTRACT(_meta, _epath) IS NULL THEN
+        IF JSON_LENGTH(JSON_EXTRACT(_meta, '$._reactions_')) < 50 THEN
+          SET _meta = JSON_SET(_meta, _epath, JSON_ARRAY(_uid));
+        ELSE
+          SET _capped = 1;
+        END IF;
+      ELSE
+        SET _meta = JSON_ARRAY_APPEND(_meta, _epath, _uid);
+      END IF;
+    END IF;
+
+    UPDATE `channel` SET metadata = _meta WHERE message_id = _message_id;
+    COMMIT;
+    SELECT 1 AS found, _capped AS capped,
+           COALESCE(JSON_EXTRACT(_meta, '$._reactions_'), JSON_OBJECT()) AS reactions;
+  END IF;
+END $
+
+DELIMITER ;

--- a/patches/notification-center-next-target-folder.sql
+++ b/patches/notification-center-next-target-folder.sql
@@ -1,0 +1,188 @@
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `notification_center_next`$
+CREATE PROCEDURE `notification_center_next`()
+BEGIN
+
+DECLARE _uid VARCHAR(16) CHARACTER SET ascii;
+DECLARE _db_name VARCHAR(500);
+DECLARE _nid VARCHAR(16) CHARACTER SET ascii;
+DECLARE _domain_id INT;
+DECLARE _is_support INT DEFAULT 0 ;
+DECLARE _area VARCHAR(500);
+DECLARE _wicket_db_name VARCHAR(255);
+DECLARE _wicket_id VARCHAR(16);
+
+  SELECT id FROM yp.entity WHERE db_name = DATABASE() INTO _uid;
+
+  DROP TABLE IF EXISTS _show_node;
+  CREATE TEMPORARY TABLE _show_node (
+      resource_id  VARCHAR(16) CHARACTER SET ascii,
+      entity_id VARCHAR(16) CHARACTER SET ascii,
+      hub_id VARCHAR(16) CHARACTER SET ascii,
+      nid VARCHAR(16) CHARACTER SET ascii,
+      parent_id VARCHAR(16) CHARACTER SET ascii,
+      filename VARCHAR(128),
+      filetype VARCHAR(16),
+      item_filetype VARCHAR(16),
+      last_id INT(11) UNSIGNED,
+      ctime  INT(11) ,
+      area  VARCHAR(16),
+      category VARCHAR(16)
+
+   );
+
+
+   INSERT INTO _show_node
+   SELECT
+      ci.id  ,d.id ,_uid , NULL, NULL, NULL, NULL, NULL, NULL, mtime,'personal' ,'contact'
+   FROM
+   contact ci
+   INNER JOIN yp.drumate d ON d.id = ci.entity
+   WHERE (ci.status="received") OR (ci.status="informed") OR (ci.status="invitation");
+
+
+   INSERT INTO _show_node
+   SELECT
+      ch.message_id, ch.author_id , _uid , NULL, NULL, NULL, NULL, NULL, NULL, ch.ctime , 'personal' , 'chat'
+   FROM
+      channel ch
+   INNER JOIN read_channel rc ON ch.entity_id= rc.entity_id
+   INNER JOIN contact c ON c.uid = ch.entity_id
+   WHERE ch.entity_id = ch.author_id  AND  rc.entity_id <> rc.uid  AND  ch.sys_id > rc.ref_sys_id;
+
+
+   DROP TABLE IF EXISTS _my_hubs;
+   CREATE TEMPORARY TABLE _my_hubs  AS
+   SELECT m.sys_id , he.id , db_name , he.area
+   FROM
+   media m
+   INNER JOIN yp.entity he ON m.id = he.id
+   INNER JOIN yp.hub h ON m.id = h.id
+   WHERE category = 'hub' AND extension <> 'dmz'  AND m.status <> 'hidden' ;
+
+   ALTER TABLE _my_hubs ADD `is_checked` boolean default 0 ;
+
+   SELECT id, db_name,area FROM _my_hubs WHERE is_checked =0  LIMIT 1
+   INTO _nid, _db_name,_area;
+
+   WHILE _nid IS NOT NULL DO
+
+      SET @sql=  CONCAT(
+         "INSERT INTO _show_node
+         SELECT c.message_id,'", _nid ,"','",_nid, "' As hub_id ,NULL,NULL,NULL,NULL,NULL,NULL,c.ctime,'", _area, "','teamchat'  FROM ", _db_name ,".channel c WHERE
+         c.sys_id > (SELECT  ref_sys_id FROM ", _db_name ,".read_channel WHERE uid ='", _uid ,"')" ) ;
+      EXECUTE IMMEDIATE @sql;
+
+      SET @s = CONCAT(
+          " INSERT INTO _show_node
+            SELECT m.id, m.owner_id, '" , _nid , "', target.id, target.parent_id, target.user_filename, 'folder', m.category, m.sys_id, m.upload_time,'", _area ,"','media' FROM ", _db_name ,
+          ".media m LEFT JOIN ", _db_name ,".media target ON target.id = IF(m.category = 'folder', m.id, m.parent_id) WHERE m.file_path not REGEXP '^/__(chat|trash)__'  AND m.category != 'root' AND
+            IFNULL((is_new(m.metadata, m.owner_id, ?)), 0) =1 "
+        );
+      PREPARE stmt FROM @s;
+      EXECUTE stmt USING _uid;
+      DEALLOCATE PREPARE stmt;
+
+      UPDATE _my_hubs SET is_checked = 1 WHERE id = _nid ;
+      SELECT  NULL INTO  _nid;
+      SELECT id, db_name,area FROM _my_hubs WHERE is_checked =0  LIMIT 1 INTO _nid, _db_name,_area;
+   END WHILE;
+
+
+
+   SELECT domain_id FROM yp.privilege WHERE uid = _uid INTO _domain_id;
+   SELECT 1  FROM yp.sys_conf WHERE  conf_key = 'support_domain'
+   AND conf_value =_domain_id INTO _is_support;
+
+
+   IF _is_support <> 1 THEN
+
+      SELECT h.id FROM
+      yp.hub h INNER JOIN yp.entity e on e.id=h.id
+      WHERE h.owner_id=_uid AND `serial`=0
+      INTO _wicket_id;
+
+      SELECT db_name FROM yp.entity WHERE id=_wicket_id INTO _wicket_db_name;
+
+      SET @s = CONCAT("
+            INSERT INTO _show_node
+            SELECT
+               t.ticket_id  , t.ticket_id , 'Support Ticket', NULL,NULL,NULL,NULL,NULL,NULL,c.ctime ,'personal','ticket'
+            FROM
+               yp.ticket t
+            INNER JOIN ", _wicket_db_name ,". map_ticket mt  ON  mt.ticket_id = t.ticket_id
+            INNER JOIN ", _wicket_db_name ,".channel c ON mt.message_id = c.message_id
+            LEFT JOIN yp.read_ticket_channel rtc on rtc.ticket_id = mt.ticket_id AND rtc.uid =?
+            WHERE t.uid =? AND c.sys_id > IFNULL(rtc.ref_sys_id,0)"
+
+      );
+      PREPARE stmt FROM @s;
+      EXECUTE stmt USING _uid,_uid;
+      DEALLOCATE PREPARE stmt;
+
+   ELSE
+
+      INSERT INTO _show_node
+      SELECT
+         t.ticket_id,  t.ticket_id ,'Support Ticket', NULL,NULL,NULL,NULL,NULL,NULL,c.ctime ,'personal','ticket'
+      FROM
+         yp.ticket t
+      LEFT JOIN yp.read_ticket_channel rtc on rtc.ticket_id = t.ticket_id AND rtc.uid = _uid
+      WHERE
+         t.last_sys_id > IFNULL(rtc.ref_sys_id,0)
+         AND CASE WHEN _is_support = 1 THEN t.uid ELSE _uid END = t.uid;
+
+   END IF;
+
+
+   SELECT
+      c.id contact_id,
+      d.id drumate_id,
+      dmu.id guest_id,
+      coalesce(c.id,  d.id,dmu.id,  CASE WHEN hub_id = 'Support Ticket' THEN entity_id ELSE hub_id END  ) key_id,
+      coalesce(c.firstname, d.firstname, dmu.email) firstname,
+      coalesce(c.lastname, d.lastname, dmu.email) lastname,
+      IF ( hub_id <>'Support Ticket' , (coalesce( IFNULL(c.surname,IF(coalesce(c.firstname, c.lastname) IS NULL,coalesce(ce.email,d.email,dmu.email),
+      CONCAT( IFNULL(c.firstname, '') ,' ',  IFNULL(c.lastname, '')))) ,  h.name )), entity_id  )surname,
+      coalesce(ce.email,d.email,dmu.email) email,
+      c.status status,
+      b.hub_id hub_id,
+      b.nid,
+      b.parent_id,
+      b.filename,
+      b.filetype,
+      b.item_filetype,
+      b.last_id,
+
+      b.ctime,
+      b.category,
+      b.cnt,
+      b.area,
+
+      (SELECT GROUP_CONCAT(t.tag_id) FROM
+      tag t INNER JOIN map_tag mt ON t.tag_id = mt.tag_id
+      WHERE mt.id = coalesce(c.id,  d.id,dmu.id,  CASE WHEN hub_id = 'Support Ticket' THEN entity_id ELSE hub_id END  )) as tag_id
+   FROM
+   (SELECT
+      count(1) cnt ,entity_id,hub_id,category,max(ctime) ctime ,area,
+      nid,
+      MAX(parent_id) parent_id,
+      MAX(filename) filename,
+      MAX(filetype) filetype,
+      MAX(item_filetype) item_filetype,
+      MAX(last_id) last_id
+   FROM  _show_node
+   GROUP BY entity_id,hub_id,category,area,nid ) b
+
+   LEFT JOIN yp.hub h ON h.id = b.hub_id
+   LEFT JOIN yp.dmz_user dmu ON b.entity_id = dmu.id
+   LEFT JOIN yp.drumate d ON b.entity_id = d.id
+   LEFT JOIN contact c ON  b.entity_id = c.uid  OR  b.entity_id = c.entity
+   LEFT JOIN contact_email ce ON ce.contact_id = c.id   AND ce.is_default = 1
+   ORDER BY b.ctime DESC;
+
+
+END $
+
+DELIMITER ;

--- a/patches/p2p-message-reaction-toggle.sql
+++ b/patches/p2p-message-reaction-toggle.sql
@@ -1,0 +1,108 @@
+-- =========================================================
+-- p2p_message_reaction_toggle  (DRUMATE class — inbox DM / P2P)
+-- One reaction per user per message (same rule as message_reaction_toggle).
+-- P2P messages are single-write in the AUTHOR's drumate DB, so chat.react runs
+-- this locally for own messages and via forward_proc(peer_id, ...) for
+-- peer-authored ones — this SP always acts on the row in whichever DB it runs.
+--
+-- All writes operate DIRECTLY on `_meta` via JSON_REMOVE / JSON_ARRAY_APPEND /
+-- JSON_SET(..., JSON_ARRAY()) — never JSON_SET a string variable as the value
+-- (that double-encodes the sub-object). Preserves `_seen_`. Requires MariaDB
+-- 10.2.3+. Caller validates emoji; uids are 16-char ascii hex.
+--
+-- Target table `p2p_channel` (verified present with a metadata column on stage).
+--
+-- Returns one row: found (0 if message absent -> caller tries the peer DB via
+-- forward_proc), capped (1 if a new emoji hit the cap), reactions (the map).
+--
+-- Apply (DEV/STAGE ONLY — every drumate instance on the server):
+--   bin/patch-from-file patches/p2p-message-reaction-toggle.sql drumate
+-- =========================================================
+DELIMITER $
+
+DROP PROCEDURE IF EXISTS `p2p_message_reaction_toggle`$
+CREATE PROCEDURE `p2p_message_reaction_toggle`(
+  IN _message_id VARCHAR(16) CHARACTER SET ascii,
+  IN _uid VARCHAR(16) CHARACTER SET ascii,
+  IN _emoji VARCHAR(64) CHARACTER SET utf8mb4
+)
+BEGIN
+  DECLARE _meta LONGTEXT;
+  DECLARE _keys LONGTEXT;
+  DECLARE _arr LONGTEXT;
+  DECLARE _key VARCHAR(64) CHARACTER SET utf8mb4;
+  DECLARE _kpath VARCHAR(160);
+  DECLARE _epath VARCHAR(160);
+  DECLARE _hit VARCHAR(64);
+  DECLARE _n INT DEFAULT 0;
+  DECLARE _k INT DEFAULT 0;
+  DECLARE _was_mine INT DEFAULT 0;
+  DECLARE _capped INT DEFAULT 0;
+  DECLARE _exists INT DEFAULT 0;
+  DECLARE EXIT HANDLER FOR SQLEXCEPTION
+  BEGIN
+    ROLLBACK;
+    RESIGNAL;
+  END;
+
+  SET _epath = CONCAT('$._reactions_."', _emoji, '"');
+
+  START TRANSACTION;
+  SELECT COUNT(1) INTO _exists FROM `p2p_channel` WHERE message_id = _message_id;
+
+  IF _exists = 0 THEN
+    COMMIT;
+    SELECT 0 AS found, 0 AS capped, JSON_OBJECT() AS reactions;
+  ELSE
+    SELECT metadata INTO _meta FROM `p2p_channel` WHERE message_id = _message_id FOR UPDATE;
+    SET _meta = COALESCE(NULLIF(_meta, ''), '{}');
+    IF JSON_EXTRACT(_meta, '$._reactions_') IS NULL THEN
+      SET _meta = JSON_SET(_meta, '$._reactions_', JSON_OBJECT());
+    END IF;
+
+    SET _keys = COALESCE(JSON_KEYS(JSON_EXTRACT(_meta, '$._reactions_')), JSON_ARRAY());
+    SET _n = JSON_LENGTH(_keys);
+    SET _k = 0;
+    WHILE _k < _n DO
+      SET _key = JSON_UNQUOTE(JSON_EXTRACT(_keys, CONCAT('$[', _k, ']')));
+      SET _kpath = CONCAT('$._reactions_."', _key, '"');
+      SET _arr = JSON_EXTRACT(_meta, _kpath);
+      IF _arr IS NOT NULL AND JSON_CONTAINS(_arr, JSON_QUOTE(_uid)) THEN
+        -- Compare emojis with BINARY collation. The connection's default
+        -- utf8mb4_general_ci treats DISTINCT emojis as EQUAL ('👍' = '😮' is
+        -- TRUE), which made a switch (react 👍, then pick 😮) look like a
+        -- toggle-off: _was_mine was set, the old emoji was removed, and the new
+        -- one was NEVER added until a second call. utf8mb4_bin keeps same-emoji
+        -- equal (toggle-off still works) while distinguishing different emojis.
+        IF _key = _emoji COLLATE utf8mb4_bin THEN SET _was_mine = 1; END IF;
+        SET _hit = JSON_UNQUOTE(JSON_SEARCH(_arr, 'one', _uid));
+        IF _hit IS NOT NULL THEN
+          SET _meta = JSON_REMOVE(_meta, CONCAT(_kpath, SUBSTR(_hit, 2)));
+        END IF;
+        IF JSON_LENGTH(JSON_EXTRACT(_meta, _kpath)) = 0 THEN
+          SET _meta = JSON_REMOVE(_meta, _kpath);
+        END IF;
+      END IF;
+      SET _k = _k + 1;
+    END WHILE;
+
+    IF _was_mine = 0 THEN
+      IF JSON_EXTRACT(_meta, _epath) IS NULL THEN
+        IF JSON_LENGTH(JSON_EXTRACT(_meta, '$._reactions_')) < 50 THEN
+          SET _meta = JSON_SET(_meta, _epath, JSON_ARRAY(_uid));
+        ELSE
+          SET _capped = 1;
+        END IF;
+      ELSE
+        SET _meta = JSON_ARRAY_APPEND(_meta, _epath, _uid);
+      END IF;
+    END IF;
+
+    UPDATE `p2p_channel` SET metadata = _meta WHERE message_id = _message_id;
+    COMMIT;
+    SELECT 1 AS found, _capped AS capped,
+           COALESCE(JSON_EXTRACT(_meta, '$._reactions_'), JSON_OBJECT()) AS reactions;
+  END IF;
+END $
+
+DELIMITER ;

--- a/plans/260621-0238-message-reactions-backend/phase-01-db-reaction-toggle-sp.md
+++ b/plans/260621-0238-message-reactions-backend/phase-01-db-reaction-toggle-sp.md
@@ -1,0 +1,44 @@
+---
+phase: 1
+title: "DB Reaction Toggle SP"
+status: pending
+effort: "M"
+---
+
+# Phase 1: DB Reaction Toggle SP
+
+## Overview
+SP toggle per-user emoji nguyên tử trong `messages.metadata._reactions_`, **giữ nguyên `_seen_`**. 2 DB class: `hub` (channel message), `drumate` (P2P message).
+
+## Requirements
+- Functional: **1 react/user/message** (cập nhật 2026-06-21) — pick emoji mới → gỡ uid khỏi MỌI emoji rồi thêm vào emoji chọn (replace); pick lại chính emoji đang giữ → gỡ (toggle off); chuẩn hoá luôn legacy multi; mảng rỗng → bỏ key; trả `_reactions_` map + cờ `capped`.
+- Non-functional: nguyên tử dưới đồng thời (transaction + row lock); idempotent (`DROP IF EXISTS` trước `CREATE`); không đụng `_seen_` hay key metadata khác.
+
+## Architecture
+- Storage: cột `metadata` (JSON) trên bảng message; `_reactions_ = {"👍":["u1","u2"]}`.
+- SP `message_reaction_toggle(_message_id, _uid, _emoji)` (hub) + `p2p_message_reaction_toggle(...)` (drumate; có thể chung shape).
+- Toggle: `SELECT metadata ... FOR UPDATE` → kiểm tra `_uid` trong `$._reactions_."<emoji>"` → `JSON_REMOVE`(theo path/idx; drop key nếu rỗng) hoặc init `[]` + `JSON_ARRAY_APPEND` → ghi lại bằng `JSON_SET(metadata,'$._reactions_', ...)` CHỈ subpath reactions.
+
+## Related Code Files
+- Create: `server-team/patches/message-reaction-toggle.sql` (hub class)
+- Create: `server-team/patches/p2p-message-reaction-toggle.sql` (drumate class)
+- Reference (introspect runtime): SP `channel_read_messages` (hub), SP P2P acknowledge (drumate) — để biết bảng + cột metadata + PK.
+
+## Implementation Steps
+1. **Introspect storage** (schemas repo không local): trên MariaDB dev chạy `SHOW CREATE PROCEDURE channel_read_messages` (hub) + SP P2P acknowledge (drumate) → lấy chính xác tên bảng message, cột metadata, cột PK (message_id). Ghi lại.
+2. Viết SP hub `message_reaction_toggle`: transaction; `SELECT metadata FROM <msg_table> WHERE message_id=_message_id FOR UPDATE`; logic toggle (xem Architecture); `JSON_SET` subpath `$._reactions_`; `SELECT` trả `_reactions_` (hoặc JSON_OBJECTAGG emoji→count).
+3. Viết SP drumate `p2p_message_reaction_toggle` tương tự (điều chỉnh bảng/đa-bản nếu P2P lưu khác — phối hợp phase 3).
+4. Validate `_emoji` đầu SP (length cap ~16 byte; chặn rỗng) — defense-in-depth. **Service** validate 1-emoji format + **cap distinct emoji/message ~50** chặn bloat (Validation S1). P2P: SP single-row (không dual-write); caller route own-DB vs peer-DB qua `forward_proc` (phase 3).
+5. Thêm 2 file vào `patches/`; áp dev: `bin/patch-from-file patches/message-reaction-toggle.sql hub` và `... p2p-message-reaction-toggle.sql drumate`.
+
+## Success Criteria
+- [ ] Toggle cùng uid+emoji 2 lần → add rồi remove (round-trip).
+- [ ] Nhiều emoji/nhiều uid cùng tồn tại đúng.
+- [ ] `_seen_` còn nguyên sau toggle.
+- [ ] 2 session toggle đồng thời → không mất update (test tay).
+- [ ] Trả `_reactions_` map (+ count).
+
+## Risk Assessment
+- Emoji-as-JSON-key multibyte → quote `'$._reactions_."👍"'`; nếu trục trặc, đổi shape `_reactions_:[{e,u[]}]`.
+- Schemas repo vắng → introspect runtime (đã xử lý ở step 1).
+- `bin/patch` áp mọi instance hub/drumate → chỉ dev/stage trước.

--- a/plans/260621-0238-message-reactions-backend/phase-02-channel-react-endpoint.md
+++ b/plans/260621-0238-message-reactions-backend/phase-02-channel-react-endpoint.md
@@ -1,0 +1,40 @@
+---
+phase: 2
+title: "Channel React Endpoint"
+status: pending
+effort: "S"
+---
+
+# Phase 2: Channel React Endpoint
+<!-- Updated: Validation Session 1 - permission write→read (khớp channel.acknowledge) -->
+
+## Overview
+Service `channel.react` (team chat + folder window): scope hub, permission **read** (khớp `channel.acknowledge`); toggle qua SP hub; broadcast `{message_id, reactions}` tới member.
+
+## Requirements
+- Functional: validate `message_id`+`emoji`; gọi SP; trả + broadcast `{message_id, reactions}`.
+- Non-functional: chỉ member hub (ACL); loại self khỏi broadcast; emoji sanitize.
+
+## Architecture
+- Nhân `task.comment_react` (`task.js:490-503`) + broadcast kiểu `channel.js:1083` (`entity_sockets(hub_id)` trừ self → `RedisStore.sendData(this.payload(data,{service:"channel.react"}), recipients)`).
+
+## Related Code Files
+- Modify: `server-team/acl/channel.json` (+ `react`)
+- Modify: `server-team/service/private/channel.js` (+ `react()`, bind trong constructor)
+- Reference: `acl/task.json:454`, `service/private/task.js:490-503`, `channel.js` post/broadcast.
+
+## Implementation Steps
+1. `acl/channel.json`: thêm `"react": { scope:"hub", permission:{src:"read"}, params:{message_id:req, emoji:req, socket_id:req}, returns:{message_id, reactions} }`. (read = khớp `acknowledge`; bất kỳ member xem channel đều react được.)
+2. `channel.js`: bind `this.react` trong ctor; `async react()`: `const message_id=this.input.need('message_id'); const emoji=this.input.need('emoji');` validate emoji (whitelist/length); `const reactions = await this.db.await_proc('message_reaction_toggle', message_id, this.uid, emoji);` build `data={message_id, reactions}`; broadcast tới `entity_sockets(hub_id)` trừ self qua `RedisStore.sendData(this.payload(data,{service:'channel.react'}), recipients)`; `this.output.data(data)`.
+3. Confirm `SERVICE.channel.react` xuất hiện trong env FE đọc (`yp.get_env` merge) sau khi thêm ACL.
+
+## Success Criteria
+- [ ] React → list message thấy reaction; gọi lại → gỡ.
+- [ ] Member khác nhận broadcast real-time (test 2 client).
+- [ ] permission read enforce (anonymous bị từ chối; member chỉ-read react được — khớp acknowledge).
+- [ ] Service cap distinct emoji/message (~50); reject emoji format lạ.
+- [ ] `_seen_` không đổi.
+
+## Risk Assessment
+- `SERVICE.channel.react` chưa vào env tới khi reload → verify (phase 4).
+- Emoji injection / metadata bloat → validate + (cân nhắc cap emoji distinct/message).

--- a/plans/260621-0238-message-reactions-backend/phase-03-dm-chat-react-endpoint.md
+++ b/plans/260621-0238-message-reactions-backend/phase-03-dm-chat-react-endpoint.md
@@ -1,0 +1,41 @@
+---
+phase: 3
+title: "DM Chat React Endpoint"
+status: pending
+effort: "M"
+---
+
+# Phase 3: DM Chat React Endpoint
+<!-- Updated: Validation Session 1 - P2P single-write+forward_proc resolved; permission write (chat.post) -->
+
+## Overview
+Service `chat.react` cho inbox DM (P2P): scope hub, permission **write** (khớp `chat.post`); toggle qua SP drumate; thông báo peer real-time. P2P message lưu **1 row trong DB người gửi** (`drumate`).
+
+## Requirements
+- Functional: validate; toggle; trả `{message_id, reactions}`; push tới peer + self-sockets khác.
+- Non-functional: reaction nhất quán cho cả 2 phía sau reload.
+
+## Architecture
+- Nhân `chat.js` post/acknowledge + notify-peer (`chat.js` user_sockets push).
+- **P2P storage (RESOLVED, Validation S1)**: message lưu **1 row, single-write trong DB người gửi** (`acl/chat.json:582`). Khi caller react message **mình gửi** → row ở DB mình (`this.db`). Khi react message **peer gửi** → row ở DB peer → route cross-DB qua `forward_proc(peer_id, "p2p_message_reaction_toggle", ...)` — đúng pattern đọc P2P sẵn có (`chat.js:60-65`). KHÔNG dual-write.
+
+## Related Code Files
+- Modify: `server-team/acl/chat.json` (+ `react`)
+- Modify: `server-team/service/private/chat.js` (+ `react()`)
+- Reference: `chat.js:488` (notify peer), `chat.js:819` (p2p_list_messages), phase-02.
+
+## Implementation Steps
+1. `acl/chat.json`: thêm `react` { scope:"hub", permission:{src:"write"} (khớp `chat.post`), params: `message_id`, `emoji`, `entity_id`/peer_id, `socket_id` }.
+2. `chat.js`: `async react()`: validate emoji (format + cap/message); thử `this.db.await_proc('p2p_message_reaction_toggle', message_id, this.uid, emoji)`; nếu rỗng (message do peer gửi) → cross-DB `this.yp.await_proc('forward_proc', peer_id, 'p2p_message_reaction_toggle', ...)` (pattern `chat.js:60-65`); broadcast tới peer sockets (`user_sockets(peer_id)`) + self-sockets khác qua `RedisStore.sendData(this.payload(data,{service:'chat.react'}))`; trả `{message_id, reactions}`.
+3. SP `p2p_message_reaction_toggle` (drumate, phase 1) = single-row toggle (giống hub SP, không dual-write).
+
+## Success Criteria
+- [ ] React trong DM hiện cho CẢ 2 peer sau reload.
+- [ ] Real-time: peer thấy ngay không reload.
+- [ ] Toggle gỡ được ở cả 2 phía.
+- [ ] `_seen_` P2P không đổi.
+
+## Risk Assessment
+- Cross-DB routing: react message peer-authored phải dùng `forward_proc` (row ở DB peer) — nếu chỉ gọi `this.db` sẽ không tìm thấy row. Mirror `chat.js:60-65`.
+- Broadcast P2P khác channel: dùng `user_sockets(peer_id)` (không `entity_sockets`).
+- permission write (chat.react) khác read (channel.react) — đúng ý đồ (P2P theo chat.post).

--- a/plans/260621-0238-message-reactions-backend/phase-04-verify-and-apply-patch.md
+++ b/plans/260621-0238-message-reactions-backend/phase-04-verify-and-apply-patch.md
@@ -1,0 +1,44 @@
+---
+phase: 4
+title: "Verify And Apply Patch"
+status: pending
+effort: "S"
+---
+
+# Phase 4: Verify And Apply Patch
+
+## Overview
+Verify end-to-end BE + áp patch lên dev; không regression post/seen/typing/delete.
+
+## Requirements
+- SP tồn tại + endpoint chạy; `_seen_` giữ; broadcast OK; server restart sạch; SERVICE expose.
+
+## Related Code Files
+- `server-team/patches/*.sql` (áp), `service/private/channel.js`, `service/private/chat.js`, `acl/channel.json`, `acl/chat.json`.
+
+## Implementation Steps
+> Chạy trên remote dev/stage server (máy local không có DB/mysql/bin). File .sql sync theo server-team (`npm run dev`). Endpoint code + ACL cũng cần server restart để nạp.
+0. **PRE-VERIFY bảng P2P** (drumate): `SHOW CREATE TABLE p2p_channel\G` + `SHOW CREATE PROCEDURE p2p_get_message\G` trên 1 DB drumate (`9_*`) → xác nhận bảng `p2p_channel` có cột `message_id` + `metadata` (JSON). Nếu P2P thực sự nằm ở bảng `channel` → sửa 3 tên bảng trong `patches/p2p-message-reaction-toggle.sql` trước khi áp. (Giả định `p2p_channel` từ comment `chat.js:59` + fallback `p2p_get_message` — chưa verify được local.)
+1. Áp patch **dev + stage** (KHÔNG prod — bin/patch hit MỌI instance của class): `bin/patch-from-file patches/message-reaction-toggle.sql hub` + `bin/patch-from-file patches/p2p-message-reaction-toggle.sql drumate`; confirm `SHOW PROCEDURE STATUS WHERE Name LIKE '%reaction_toggle%'` có cả 2.
+1b. **DB spot-check** (1 hub DB, kiểm 1-react/user):
+    - `CALL message_reaction_toggle('<msg>','<uid>','👍');` → có 👍:[uid]
+    - `CALL message_reaction_toggle('<msg>','<uid>','❤️');` → **THAY THẾ**: 👍 mất, ❤️:[uid] (1 react/user)
+    - `CALL message_reaction_toggle('<msg>','<uid>','❤️');` → gỡ (toggle off) → rỗng
+    - `SELECT JSON_EXTRACT(metadata,'$._reactions_'), JSON_EXTRACT(metadata,'$._seen_') FROM channel WHERE message_id='<msg>';` → `_seen_` còn nguyên.
+2. Restart server (watcher `npm run dev` / PM2 `aaron/service`) sạch; kiểm `/tmp/server-team-dev.log` không lỗi.
+3. Manual channel: react add/remove + multi-emoji + `_seen_` intact + broadcast tới client thứ 2.
+4. Manual DM: react hiện cả 2 peer + real-time.
+5. Confirm `SERVICE.channel.react` + `SERVICE.chat.react` trong env (curl `yp.get_env` hoặc FE console).
+6. Edge: xoá message đã react → reaction biến mất; react message không tồn tại → lỗi gracefully (không crash).
+
+## Success Criteria
+- [ ] **Load-path trả `metadata`**: `channel.messages`/`channel_get`/`p2p_get_message` có cột `metadata` trong projection → `_reactions_` load kèm message khi mở chat (nếu thiếu, reactions chỉ hiện realtime; phải sửa list SP ở schemas repo — ngoài scope repo này). [code-review MEDIUM]
+- [ ] 2 SP áp thành công trên dev.
+- [ ] Server restart không lỗi.
+- [ ] channel + DM react/unreact + real-time OK.
+- [ ] `_seen_` + post + typing + delete không regression.
+- [ ] SERVICE.*.react có trong env.
+
+## Risk Assessment
+- `bin/patch` áp mọi instance hub/drumate trên server → chỉ dev/stage, KHÔNG prod.
+- Lỗi permission thư mục stage (`offline/drumate/` — sự cố rsync trước) không liên quan; bỏ qua.

--- a/plans/260621-0238-message-reactions-backend/plan.md
+++ b/plans/260621-0238-message-reactions-backend/plan.md
@@ -1,0 +1,71 @@
+---
+title: "Message Reactions — Backend (channel + DM)"
+description: "Emoji reactions on chat messages: metadata._reactions_ storage + toggle SP (hub & drumate) + channel.react/chat.react endpoints + real-time broadcast."
+status: in-progress
+priority: P2
+branch: "aaron-boarding-new"
+tags: [chat, reactions, websocket, mariadb]
+blockedBy: []
+blocks: []
+created: "2026-06-20T19:43:19.323Z"
+createdBy: "ck:plan"
+source: skill
+---
+
+# Message Reactions — Backend (channel + DM)
+
+## Overview
+
+Backend foundation cho emoji reaction trên chat message. Lưu trong `messages.metadata._reactions_` (JSON `{emoji:[uid,...]}`) — lặp lại đúng cách read-receipt `_seen_` đang chạy, nên reaction về kèm message lúc load (KHÔNG sửa SP list ở repo schemas ngoài). Toggle qua 1 SP mới per DB class: **hub** (channel: team chat + folder window), **drumate** (P2P inbox DM). Endpoint `channel.react` + `chat.react` nhân theo tiền lệ `task.comment_react`; broadcast real-time tới member/peer.
+
+Design doc nguồn: `../../ui-team/plans/reports/brainstorm-design-260621-0220-chat-message-reactions-report.md`
+
+Tham chiếu tiền lệ: `service/private/task.js:490-503` (comment_react), `acl/task.json:454`, broadcast `channel.js:1083` (entity_sockets + RedisStore.sendData).
+
+## Phases
+
+| Phase | Name | Status |
+|-------|------|--------|
+| 1 | [DB Reaction Toggle SP](./phase-01-db-reaction-toggle-sp.md) | Done (code, reviewed) |
+| 2 | [Channel React Endpoint](./phase-02-channel-react-endpoint.md) | Done (code, reviewed) |
+| 3 | [DM Chat React Endpoint](./phase-03-dm-chat-react-endpoint.md) | Done (code, reviewed) |
+| 4 | [Verify And Apply Patch](./phase-04-verify-and-apply-patch.md) | Pending — gate (apply on stage) |
+
+> Cook 2026-06-21: BE code (2 SP + channel.react/chat.react + ACL) viết xong, static code-review (DONE_WITH_CONCERNS) đã vá (JSON_SEARCH→loop, capped flag, emoji VARCHAR(64)), `node --check`+JSON valid. FE plan 5/5 phase code xong, build sạch. Chưa commit. Còn P4 = áp patch + restart + e2e trên remote stage.
+
+## Dependencies
+
+- **Blocks** (cross-repo, không ck-resolvable): ui-team plan `260621-0238-message-reactions-frontend`. FE phase 2+ cần `channel.react`/`chat.react` sống. Khi BE phase 2 xong → FE phase 2 unblock.
+
+## Acceptance (whole plan)
+- `channel.react` + `chat.react` toggle add/remove đúng; trả `{message_id, reactions}`.
+- `_seen_` nguyên vẹn sau toggle (không clobber).
+- Nhiều emoji/1 message; concurrent toggle không mất update.
+- Broadcast real-time tới member khác / peer.
+- Reaction về kèm message lúc load (không sửa SP list repo ngoài).
+- Không vỡ post/acknowledge/typing/delete hiện có.
+
+## Constraints
+- Không raw SQL trong service code — qua stored procedure (CLAUDE.md). 1 routine/file.
+- SP gốc ở schemas repo (`/home/somanos/...`, KHÔNG local) → tác giả SP bằng cách introspect runtime; áp qua `server-team/patches/` + `bin/patch-from-file`.
+- `bin/patch-*` áp lên TẤT CẢ instance hub/drumate trên server → chỉ chạy dev/stage, KHÔNG prod.
+- Conventional commits, không AI refs.
+
+## Open questions (resolved in Validation Session 1)
+1. ~~P2P 1-row vs 2-bản~~ → **RESOLVED**: single-write trong DB người gửi (`acl/chat.json:582`); react message do peer gửi route cross-DB qua `forward_proc` (`chat.js:60-65`). Phase 3 cập nhật.
+2. Emoji JSON key (multibyte) → **DECIDED**: shape `_reactions_:{emoji:[uid]}`, emoji làm key (quote `'$._reactions_."👍"'`); fallback `[{e,u[]}]` nếu brittle. Phase 1.
+
+## Validation Log
+
+### Session 1 — 2026-06-21 (mode: prompt)
+**Verification (Standard tier, 4 phases)** — claims ~12; Verified: `task.comment_react`(task.js:490)+`_broadcast`(task.js:53, task-local), channel inline broadcast `entity_sockets`+`RedisStore.sendData(this.payload)`(channel.js:137/1083), `channel.acknowledge`=read per-user-metadata precedent. **Failed: 1** → plan ghi `channel.react` permission=write; thực tế `channel.post`+`channel.acknowledge`=**read** → sửa thành read. **Resolved**: P2P single-write (acl/chat.json:582) + cross-DB `forward_proc` cho message peer-authored (chat.js:60-65).
+
+**Decisions**:
+- `channel.react` permission = **read** (khớp `channel.acknowledge`); `chat.react` = **write** (khớp `chat.post`).
+- Emoji = **1 emoji hợp lệ bất kỳ** (validate format/length) + **cap distinct emoji/message (~50)** chặn metadata bloat; KHÔNG whitelist server (full picker cần tự do).
+- Áp patch = **dev + stage** (KHÔNG prod).
+- P2P: 1 SP tác động lên row ở DB của nó; service route own-DB vs peer-DB qua `forward_proc`.
+- Shape `_reactions_:{emoji:[uid]}` (emoji = JSON key quoted); fallback `[{e,u[]}]`.
+
+### Whole-Plan Consistency Sweep
+Re-read plan.md + 4 phase sau propagate: permission read/write sửa ở phase-02/03; P2P single-write+forward_proc ở phase-03; emoji policy+cap ở phase-01; deploy dev+stage ở phase-04. Shape `_reactions_` khớp BE↔FE. SERVICE exposure (acl→`get_env` desk.js:205/`service/lib/env.js`) = verify lúc impl (phase 4). **Zero unresolved contradiction.**

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -296,7 +296,12 @@ class Acl {
           || SECURE_SHARE_READONLY_DENYLIST.has(service);
         if (mightMutate) {
           try {
-            const ceiling = await session.yp.await_func("get_session_priv_ceiling", session.sid());
+            // get_session_priv_ceiling is a PROCEDURE (CREATE FUNCTION is restricted
+            // under binary logging on the replicated DB; procedures are not) → await_proc.
+            // It SELECTs a single row {priv_ceiling}; null when unset or uid != ceiling_uid.
+            let _row = await session.yp.await_proc("get_session_priv_ceiling", session.sid());
+            if (Array.isArray(_row)) _row = _row[0];
+            const ceiling = (_row && _row.priv_ceiling != null) ? _row.priv_ceiling : null;
             if (ceiling != null) {
               // A chat ceiling (>=7) permits posting to a folder conversation
               // (channel.post) while still denying file-writes/calls/invite; a

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -37,22 +37,26 @@ const SECURE_SHARE_READONLY_DENYLIST = new Set([
   // channel.react: read-src but mutates message metadata (toggle emoji reaction).
   // chat.react is write-src → already caught by the threshold below.
   "channel.react",
+  // read-src but persist read receipts for this.uid (creator-bound on anon shares)
+  "channel.acknowledge", "channel.read",
   // tags — anonymous-src but mutate the bound hub's tags
   "tag.store", "tag.delete",
   // file copy / restore — read-src, mutate / exfil
   "media.copy", "media.copy_all", "media.restore", "media.restore_into", "media.mark_as_seen",
   // calls / conferences / rooms / signaling — read or anon src; recipients get no calls
   "conference.join", "conference.leave", "conference.update", "conference.accept", "conference.decline",
-  "room.join", "room.leave", "room.requestAccess", "room.request_screen_access",
+  "room.join", "room.leave", "room.requestAccess", "room.request_screen_access", "room.get_screen",
   "signaling.dial", "signaling.message",
   // transferbox — read/anon src, mutate
   "transfer.delete", "transfer.remove", "transfer.send_otp",
   // membership / inbound-share / notification mutations — anon|read src, would run as
   // the creator-bound session: leave_hub could remove the CREATOR from the shared hub;
   // sharebox.* accept/refuse the creator's pending shares; activity.dismiss_rollup
-  // mutates the creator's notification state.
+  // mutates the creator's notification state; hub.poke sends notifications as the
+  // creator; hub.accept_invite redeems an invite AS the creator; yp.device_registration
+  // (anon) would bind the viewer's push token to the creator's account.
   "desk.leave_hub", "sharebox.accept_notification", "sharebox.refuse_notification",
-  "activity.dismiss_rollup",
+  "activity.dismiss_rollup", "hub.poke", "hub.accept_invite", "yp.device_registration",
 ]);
 
 

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -38,7 +38,9 @@ const SECURE_SHARE_READONLY_DENYLIST = new Set([
   // chat.react is write-src → already caught by the threshold below.
   "channel.react",
   // read-src but persist read receipts for this.uid (creator-bound on anon shares)
-  "channel.acknowledge", "channel.read",
+  "channel.acknowledge", "channel.read", "channel.acknowledge_ticket",
+  // read-src but broadcasts an arbitrary event to the whole hub as the creator
+  "conference.broadcast",
   // tags — anonymous-src but mutate the bound hub's tags
   "tag.store", "tag.delete",
   // file copy / restore — read-src, mutate / exfil
@@ -46,6 +48,7 @@ const SECURE_SHARE_READONLY_DENYLIST = new Set([
   // calls / conferences / rooms / signaling — read or anon src; recipients get no calls
   "conference.join", "conference.leave", "conference.update", "conference.accept", "conference.decline",
   "room.join", "room.leave", "room.requestAccess", "room.request_screen_access", "room.get_screen",
+  "room.get", "room.unified_room",
   "signaling.dial", "signaling.message",
   // transferbox — read/anon src, mutate
   "transfer.delete", "transfer.remove", "transfer.send_otp",
@@ -57,6 +60,10 @@ const SECURE_SHARE_READONLY_DENYLIST = new Set([
   // (anon) would bind the viewer's push token to the creator's account.
   "desk.leave_hub", "sharebox.accept_notification", "sharebox.refuse_notification",
   "activity.dismiss_rollup", "hub.poke", "hub.accept_invite", "yp.device_registration",
+  // admin mimic (anon-src) + process-wide debug toggles (read-src) — would change
+  // impersonation / logging state while bound as the creator.
+  "adminpanel.mimic_active", "adminpanel.mimic_reject", "adminpanel.mimic_end_byuser",
+  "devel.verbosity", "devel.log_over_socket",
 ]);
 
 

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -41,11 +41,18 @@ const SECURE_SHARE_READONLY_DENYLIST = new Set([
   "tag.store", "tag.delete",
   // file copy / restore — read-src, mutate / exfil
   "media.copy", "media.copy_all", "media.restore", "media.restore_into", "media.mark_as_seen",
-  // calls / conferences / rooms — read or anon src; recipients get no calls
+  // calls / conferences / rooms / signaling — read or anon src; recipients get no calls
   "conference.join", "conference.leave", "conference.update", "conference.accept", "conference.decline",
   "room.join", "room.leave", "room.requestAccess", "room.request_screen_access",
+  "signaling.dial", "signaling.message",
   // transferbox — read/anon src, mutate
   "transfer.delete", "transfer.remove", "transfer.send_otp",
+  // membership / inbound-share / notification mutations — anon|read src, would run as
+  // the creator-bound session: leave_hub could remove the CREATOR from the shared hub;
+  // sharebox.* accept/refuse the creator's pending shares; activity.dismiss_rollup
+  // mutates the creator's notification state.
+  "desk.leave_hub", "sharebox.accept_notification", "sharebox.refuse_notification",
+  "activity.dismiss_rollup",
 ]);
 
 

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -34,6 +34,11 @@ const SECURE_SHARE_READONLY_DENYLIST = new Set([
   // chat / channel — read-src, mutate or impersonate the creator
   "channel.post", "channel.delete", "channel.post_ticket", "channel.send_ticket",
   "channel.bookmark_add", "channel.bookmark_remove", "chat.attachment",
+  // channel.react: read-src but mutates message metadata (toggle emoji reaction).
+  // chat.react is write-src → already caught by the threshold below.
+  "channel.react",
+  // tags — anonymous-src but mutate the bound hub's tags
+  "tag.store", "tag.delete",
   // file copy / restore — read-src, mutate / exfil
   "media.copy", "media.copy_all", "media.restore", "media.restore_into", "media.mark_as_seen",
   // calls / conferences / rooms — read or anon src; recipients get no calls
@@ -292,7 +297,11 @@ class Acl {
         // read/anon-src mutator) → normal read traffic adds no DB cost. Fail-OPEN on
         // lookup error so a missing SP / DB hiccup degrades to today's behaviour and
         // never blocks all writes. Self-clears via uid==ceiling_uid in the SP.
+        // A service can also mutate via its DESTINATION (e.g. media.relocate is
+        // src:read, dest:write → move_all): the src threshold alone would miss it and
+        // let a clamped session move files. Treat dest write+ as mutating too.
         const mightMutate = (permission && permission.src > READ_LEVEL)
+          || (permission && permission.dest != null && permission.dest > READ_LEVEL)
           || SECURE_SHARE_READONLY_DENYLIST.has(service);
         if (mightMutate) {
           try {

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -26,6 +26,10 @@ let LOCKED = false;
 // read/anonymous src yet still MUTATE (a threshold alone would miss them — e.g.
 // channel.post posts chat AS the creator). Audited across all acl/*.json 2026-06-18.
 const READ_LEVEL = permissionValue("read");
+// Stored cumulative privilege (lib/privilege.js) for the chat cap — a chat-ceiling
+// session may post to a folder conversation (channel.post); a lower (read-only)
+// ceiling may not. Recipients never get a ceiling above this (edit = no ceiling).
+const CHAT_CEILING = 7;
 const SECURE_SHARE_READONLY_DENYLIST = new Set([
   // chat / channel — read-src, mutate or impersonate the creator
   "channel.post", "channel.delete", "channel.post_ticket", "channel.send_ticket",
@@ -294,8 +298,15 @@ class Acl {
           try {
             const ceiling = await session.yp.await_func("get_session_priv_ceiling", session.sid());
             if (ceiling != null) {
-              worker.stop();
-              return session.exception.unauthorized(`SECURE_SHARE_READ_ONLY:${service}`);
+              // A chat ceiling (>=7) permits posting to a folder conversation
+              // (channel.post) while still denying file-writes/calls/invite; a
+              // read-only ceiling (3) denies channel.post too. Everything else stays
+              // denied for any ceiling.
+              const chatPostAllowed = (ceiling >= CHAT_CEILING && service === "channel.post");
+              if (!chatPostAllowed) {
+                worker.stop();
+                return session.exception.unauthorized(`SECURE_SHARE_READ_ONLY:${service}`);
+              }
             }
           } catch (e) {
             console.warn("[acl] secure-share ceiling check failed (fail-open):", e && e.message);

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -19,6 +19,26 @@ let Workers = new Map();
 let Plugins = new Map();
 let LOCKED = false;
 
+// A3 secure-share: anonymous recipients carry a read-only session privilege ceiling
+// (set in dmz.js _loginSecureShare via set_session_priv_ceiling). When a ceiling is
+// present, mutating operations are denied. A `permission.src > read` threshold catches
+// every write/delete/admin/owner service; the denylist below catches services that are
+// read/anonymous src yet still MUTATE (a threshold alone would miss them — e.g.
+// channel.post posts chat AS the creator). Audited across all acl/*.json 2026-06-18.
+const READ_LEVEL = permissionValue("read");
+const SECURE_SHARE_READONLY_DENYLIST = new Set([
+  // chat / channel — read-src, mutate or impersonate the creator
+  "channel.post", "channel.delete", "channel.post_ticket", "channel.send_ticket",
+  "channel.bookmark_add", "channel.bookmark_remove", "chat.attachment",
+  // file copy / restore — read-src, mutate / exfil
+  "media.copy", "media.copy_all", "media.restore", "media.restore_into", "media.mark_as_seen",
+  // calls / conferences / rooms — read or anon src; recipients get no calls
+  "conference.join", "conference.leave", "conference.update", "conference.accept", "conference.decline",
+  "room.join", "room.leave", "room.requestAccess", "room.request_screen_access",
+  // transferbox — read/anon src, mutate
+  "transfer.delete", "transfer.remove", "transfer.send_otp",
+]);
+
 
 /**
  *
@@ -262,7 +282,25 @@ class Acl {
         Workers.set(path, WorkerClass);
       }
       worker = new WorkerClass({ session, permission });
-      worker.once(GRANTED, function () {
+      worker.once(GRANTED, async function () {
+        // A3: enforce the read-only ceiling for secure-share recipient sessions.
+        // Only look up the ceiling when this service COULD mutate (write+ src, or a
+        // read/anon-src mutator) → normal read traffic adds no DB cost. Fail-OPEN on
+        // lookup error so a missing SP / DB hiccup degrades to today's behaviour and
+        // never blocks all writes. Self-clears via uid==ceiling_uid in the SP.
+        const mightMutate = (permission && permission.src > READ_LEVEL)
+          || SECURE_SHARE_READONLY_DENYLIST.has(service);
+        if (mightMutate) {
+          try {
+            const ceiling = await session.yp.await_func("get_session_priv_ceiling", session.sid());
+            if (ceiling != null) {
+              worker.stop();
+              return session.exception.unauthorized(`SECURE_SHARE_READ_ONLY:${service}`);
+            }
+          } catch (e) {
+            console.warn("[acl] secure-share ceiling check failed (fail-open):", e && e.message);
+          }
+        }
         const need = worker.before_granting;
         if (isFunction(worker[need])) {
           try {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -360,7 +360,10 @@ class __dmz extends Mfs {
     // share carries no submitted email, so fall back to the authenticated account's
     // own email (resolved from its regsid above) — never the creator's.
     let _recipientEmail = submittedEmail || null;
-    if (!_recipientEmail && isAuthenticated && user.profile) {
+    // The creator previewing their OWN share is not a recipient — don't fall back to
+    // their account email (it would persist on the access event and show the sender as
+    // a recipient, which the list_access_events creator skip can't undo once stored).
+    if (!_recipientEmail && isAuthenticated && user.profile && String(user.id) !== String(info.creator_id)) {
       try {
         const _p = (typeof user.profile === 'string') ? JSON.parse(user.profile) : user.profile;
         _recipientEmail = (_p && _p.email) ? String(_p.email).toLowerCase().trim() : null;

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -609,6 +609,23 @@ class __dmz extends Mfs {
       }
     }
 
+    // ANONYMOUS recipients stay creator-bound (so they can READ the shared node),
+    // but must be read-only. Stamp a privilege ceiling on this session bound to the
+    // bound uid (= creator). get_session_priv_ceiling() returns it ONLY while
+    // cookie.uid still equals ceiling_uid, so it self-clears if this visitor later
+    // signs up / logs in (their uid changes). router/rest enforces a read-only
+    // allowlist whenever a ceiling is present. Gated on !isAuthenticated so the owner
+    // (authenticated, also creator-bound) and logged-in recipients (rebound to their
+    // own capped uid + node grant) are NEVER clamped. If this fails we fall back to
+    // today's behaviour (creator-bound, no ceiling) — no regression.
+    if (!isAuthenticated && bindUid) {
+      try {
+        await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), 3, bindUid);
+      } catch (e) {
+        this.warn('[dmz.login] secure_share set_session_priv_ceiling failed:', e && e.message);
+      }
+    }
+
     return this.output.data({
       ...user,
       ...info,

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -570,6 +570,11 @@ class __dmz extends Mfs {
     // at the top of this method).
     // ---------------------------------------------------------------------
     let bindUid = info.creator_id;
+    // Privilege ceiling to stamp on THIS share session (enforced by router/rest):
+    // anonymous = read-only (3); a signed-in NON-member recipient gets their cap level
+    // (view/download 3, chat 7) so the gate clamps the grant's over-reach; edit (15) and
+    // owner/member get NO ceiling (full / own access). null = no clamp.
+    let ceilingToStamp = !isAuthenticated ? 3 : null;
     if (isAuthenticated && user.id && !info.file_nid && info.node_id) {
       if (memberPriv > 0 || String(user.id) === String(info.creator_id)) {
         // Member or owner — already has standing access; operate as themselves.
@@ -587,6 +592,10 @@ class __dmz extends Mfs {
               info.node_id, user.id, 0, grantPriv, 'system', 'Secure share access'
             );
             bindUid = user.id;            // rebind ONLY after the grant succeeds
+            // Clamp view/download (3) and chat (7) recipients with a session ceiling so
+            // router/rest denies file-writes (the node grant alone can't — chat grant 7
+            // carries the write bit). Edit (15) = full edit intended → no ceiling.
+            if (grantPriv < 0b0001111) ceilingToStamp = grantPriv;
           }
         } catch (e) {
           this.warn('[dmz.login] secure_share node grant failed; keeping creator binding:', e && e.message);
@@ -609,18 +618,18 @@ class __dmz extends Mfs {
       }
     }
 
-    // ANONYMOUS recipients stay creator-bound (so they can READ the shared node),
-    // but must be read-only. Stamp a privilege ceiling on this session bound to the
-    // bound uid (= creator). get_session_priv_ceiling() returns it ONLY while
-    // cookie.uid still equals ceiling_uid, so it self-clears if this visitor later
-    // signs up / logs in (their uid changes). router/rest enforces a read-only
-    // allowlist whenever a ceiling is present. Gated on !isAuthenticated so the owner
-    // (authenticated, also creator-bound) and logged-in recipients (rebound to their
-    // own capped uid + node grant) are NEVER clamped. If this fails we fall back to
-    // today's behaviour (creator-bound, no ceiling) — no regression.
-    if (!isAuthenticated && bindUid) {
+    // Stamp the session privilege ceiling computed above (read-only 3 / chat 7), bound
+    // to bindUid. get_session_priv_ceiling() returns it ONLY while cookie.uid still
+    // equals ceiling_uid, so it self-clears if an anonymous visitor later signs up (uid
+    // changes). router/rest enforces it: read-only (3) denies ALL mutations incl
+    // channel.post; chat (7) additionally PERMITS channel.post (text chat) while still
+    // denying file-writes/calls/invite. The ceiling lands on THIS share session's sid
+    // (the hub cookie — page.js gives it an independent sid), so a signed-in recipient's
+    // main account (regsid) is never clamped. Owner/member/edit → ceilingToStamp null →
+    // no clamp. Best-effort; on failure we keep the prior (un-clamped) binding.
+    if (ceilingToStamp != null && bindUid) {
       try {
-        await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), 3, bindUid);
+        await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), ceilingToStamp, bindUid);
       } catch (e) {
         this.warn('[dmz.login] secure_share set_session_priv_ceiling failed:', e && e.message);
       }

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -320,20 +320,32 @@ class __dmz extends Mfs {
     // Password gate — only evaluated after email gate passes (or was skipped for public shares)
     if (info.require_password) {
       const submittedPassword = (this.input.get(Attr.password) || '').trim();
-      if (!submittedPassword) {
-        return this.output.data({ ...safeInfo, status: 'REQUIRED_PASSWORD', is_secure: 1 });
-      }
-      if (!verifySecureSharePassword(submittedPassword, storedPasswordHash)) {
-        try { await this.yp.await_proc('secure_share_increment_attempts', token); } catch (e) {}
-        // SP locks when new count >= 3; info.failed_attempts is the pre-increment value
-        const attemptsUsed      = (info.failed_attempts || 0) + 1;
-        const attemptsRemaining = Math.max(0, 3 - attemptsUsed);
-        // Token is now locked — tell the client immediately instead of making them
-        // submit again only to receive TICKET_LOCKED on the next request.
-        if (attemptsRemaining === 0) {
-          return this.output.data({ status: 'TICKET_LOCKED', is_secure: 1 });
+      if (submittedPassword) {
+        if (!verifySecureSharePassword(submittedPassword, storedPasswordHash)) {
+          try { await this.yp.await_proc('secure_share_increment_attempts', token); } catch (e) {}
+          // SP locks when new count >= 3; info.failed_attempts is the pre-increment value
+          const attemptsUsed      = (info.failed_attempts || 0) + 1;
+          const attemptsRemaining = Math.max(0, 3 - attemptsUsed);
+          // Token is now locked — tell the client immediately instead of making them
+          // submit again only to receive TICKET_LOCKED on the next request.
+          if (attemptsRemaining === 0) {
+            return this.output.data({ status: 'TICKET_LOCKED', is_secure: 1 });
+          }
+          return this.output.data({ status: 'WRONG_PASSWORD', is_secure: 1, attempts_remaining: attemptsRemaining });
         }
-        return this.output.data({ status: 'WRONG_PASSWORD', is_secure: 1, attempts_remaining: attemptsRemaining });
+        // Correct password — remember it for THIS share session (the hub-cookie sid,
+        // which page.js persists and shares across the browser's tabs) so a later load
+        // doesn't re-prompt. Notably: after the recipient clicks Login, the share
+        // re-opens in a NEW tab that shares this same hub cookie, so the gate is skipped
+        // there instead of asking for the password a second time. Best-effort.
+        try { await this._markSharePasswordOk(token); } catch (e) { /* non-fatal */ }
+      } else {
+        // No password submitted — allow ONLY if this same session already proved it.
+        let alreadyOk = false;
+        try { alreadyOk = await this._isSharePasswordOk(token); } catch (e) { alreadyOk = false; }
+        if (!alreadyOk) {
+          return this.output.data({ ...safeInfo, status: 'REQUIRED_PASSWORD', is_secure: 1 });
+        }
       }
     }
 
@@ -660,6 +672,40 @@ class __dmz extends Mfs {
       // access" banner / viral chrome for members.
       is_member        : is_member,
     });
+  }
+
+  /**
+   * One-time-per-session password gate marker. Keyed by the share TOKEN + the
+   * share-session sid (the hub cookie, which page.js persists and shares across the
+   * browser's tabs), so once this session has entered the correct password it is not
+   * re-prompted — including in the new tab the Login button opens, which carries the
+   * same hub cookie. Stored in Redis with a bounded TTL; both helpers are best-effort
+   * and fail CLOSED (a Redis error → no marker → the password is required), so they
+   * can never grant access without a real password.
+   */
+  _sharePasswordKey(token) {
+    const sid = this.input.sid();
+    if (!token || !sid) return null;
+    return `ss:pwok:${token}:${sid}`;
+  }
+
+  async _markSharePasswordOk(token) {
+    const key = this._sharePasswordKey(token);
+    if (!key) return;
+    const client = RedisStore.getClient();
+    if (!client) return;
+    // 12h: long enough to cover the enter-password → login → return flow and a normal
+    // working session, short enough that a shared browser re-asks later.
+    await client.set(key, '1', { EX: 12 * 3600 });
+  }
+
+  async _isSharePasswordOk(token) {
+    const key = this._sharePasswordKey(token);
+    if (!key) return false;
+    const client = RedisStore.getClient();
+    if (!client) return false;
+    const v = await client.get(key);
+    return v === '1';
   }
 
   /**

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -654,7 +654,14 @@ class __dmz extends Mfs {
     // (the hub cookie — page.js gives it an independent sid), so a signed-in recipient's
     // main account (regsid) is never clamped. Owner/member/edit → ceilingToStamp null →
     // no clamp. Best-effort; on failure we keep the prior (un-clamped) binding.
-    if (ceilingToStamp != null && bindUid) {
+    //
+    // ALWAYS write (including ceilingToStamp=null, which CLEARS the ceiling) so the
+    // session's clamp tracks its CURRENT access. The share-session sid is reused across
+    // loads, and get_session_priv_ceiling only self-clears when the bound uid CHANGES —
+    // so if a recipient is elevated on the SAME uid (view/chat → edit, or becomes a
+    // member/owner), a stale read/chat ceiling would otherwise linger and keep denying
+    // writes they are now entitled to. Passing null sets priv_ceiling=NULL → no clamp.
+    if (bindUid) {
       try {
         await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), ceilingToStamp, bindUid);
       } catch (e) {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -631,6 +631,20 @@ class __dmz extends Mfs {
           this.warn('[dmz.login] secure_share node grant failed; keeping creator binding:', e && e.message);
         }
       }
+    } else if (
+      isAuthenticated && info.file_nid && user.id &&
+      !(memberPriv > 0 || String(user.id) === String(info.creator_id))
+    ) {
+      // Authenticated NON-member recipient of a single-FILE share. The folder rebind
+      // above is skipped (a single file has no subtree to node-scope), so the session
+      // stays creator-bound — without a ceiling it would otherwise inherit FULL creator
+      // privilege and let a view/download/chat recipient run creator-authorized
+      // writes/deletes after signing in. Clamp the creator-bound session to the share
+      // caps. can_edit → no clamp (they may edit the shared file; the office-editor path
+      // is node-scoped via mfs_node_in_subtree).
+      if (caps.indexOf('can_edit') === -1) {
+        ceilingToStamp = (caps.indexOf('can_chat') !== -1) ? 7 : 3;
+      }
     }
     // socket_id must be passed so entity_sockets() includes this guest socket in
     // hub broadcasts (e.g. secure_share_revoked). page.js ensures the hub cookie

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -349,8 +349,23 @@ class __dmz extends Mfs {
       }
     }
 
-    // Valid access — log it and notify sender in real time
-    const actor_id = (guest_id === user.id) ? null : (user.id || null);
+    // Valid access — log it and notify sender in real time.
+    // Attribute the open to the viewer's OWN account ONLY when they are genuinely
+    // authenticated. An anonymous recipient runs in the creator-bound guest session
+    // (user.id === creator_id), so the previous `guest_id === user.id` check logged
+    // the SENDER as the visitor — which then surfaced the sender's email in the
+    // access list. Anonymous viewers are logged as an anonymous open (no actor).
+    const actor_id = isAuthenticated ? (user.id || null) : null;
+    // Recipient email for the access list + the "opened" notification. A password-only
+    // share carries no submitted email, so fall back to the authenticated account's
+    // own email (resolved from its regsid above) — never the creator's.
+    let _recipientEmail = submittedEmail || null;
+    if (!_recipientEmail && isAuthenticated && user.profile) {
+      try {
+        const _p = (typeof user.profile === 'string') ? JSON.parse(user.profile) : user.profile;
+        _recipientEmail = (_p && _p.email) ? String(_p.email).toLowerCase().trim() : null;
+      } catch (e) { /* ignore malformed profile */ }
+    }
     try {
       const track = await this.yp.await_proc('secure_share_access_log', token, actor_id, this.input.get(Attr.socket_id));
       // v2: also record a per-visit access event (entered_at / last_seen_at) backing
@@ -359,7 +374,7 @@ class __dmz extends Mfs {
       try {
         await this.yp.await_proc(
           'secure_share_log_access_event',
-          token, submittedEmail || null, actor_id, this.input.get(Attr.socket_id)
+          token, _recipientEmail, actor_id, this.input.get(Attr.socket_id)
         );
       } catch (e) {
         this.warn('[dmz.login] secure_share access_event failed:', e && e.message);
@@ -376,7 +391,7 @@ class __dmz extends Mfs {
               event           : 'secure_share_opened',
               token,
               nid             : info.node_id,
-              recipient_email : submittedEmail,
+              recipient_email : _recipientEmail,
               access_count    : (info.access_count || 0) + 1,
             },
             { service: 'share.track_event' }

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -34,6 +34,7 @@ class __private_channel extends Entity {
     this.read = this.read.bind(this);
     this.notify_chat = this.notify_chat.bind(this);
     this.acknowledge = this.acknowledge.bind(this);
+    this.react = this.react.bind(this);
     this.typing = this.typing.bind(this);
     this.bookmark_add = this.bookmark_add.bind(this);
     this.bookmark_remove = this.bookmark_remove.bind(this);
@@ -1423,6 +1424,39 @@ class __private_channel extends Entity {
     });
     await RedisStore.sendData(this.payload(message), recipients);
     this.output.data(res);
+  }
+
+  /**
+   * Toggle the caller's emoji reaction on a channel message (add if absent,
+   * remove if present). Stored per-message in metadata._reactions_ alongside
+   * read receipts (_seen_ untouched). Broadcasts the updated reactions map to
+   * every other socket in the hub (caller's socket excluded).
+   */
+  async react() {
+    const message_id = this.input.need(Attr.message_id);
+    const emoji = this.input.need("emoji");
+    let exclude = this.input.need(Attr.socket_id);
+    if (exclude) exclude = [exclude];
+    const glyphs = Array.from(emoji || "");
+    if (!glyphs.length || glyphs.length > 8 || /['"\\\s]/.test(emoji)) {
+      return this.output.data({ status: "INVALID_EMOJI" });
+    }
+    const res = await this.db.await_proc(
+      "message_reaction_toggle",
+      message_id,
+      this.uid,
+      emoji
+    );
+    const row = Array.isArray(res) ? res[0] : res;
+    const reactions = row && row.reactions ? this.parseJSON(row.reactions) : {};
+    const hub_id = this.hub.get(Attr.id);
+    const data = { message_id, reactions, key_id: hub_id };
+    const recipients = await this.yp.await_proc("entity_sockets", { hub_id, exclude });
+    await RedisStore.sendData(
+      this.payload(data, { service: "channel.react" }),
+      recipients
+    );
+    this.output.data({ message_id, reactions, capped: row && row.capped ? 1 : 0 });
   }
 
   /**

--- a/service/private/chat.js
+++ b/service/private/chat.js
@@ -43,6 +43,7 @@ class privateChat extends Entity {
     this.attachment = this.attachment.bind(this);
     this.change_status = this.change_status.bind(this);
     this.typing = this.typing.bind(this);
+    this.react = this.react.bind(this);
   }
 
   /**
@@ -654,6 +655,61 @@ class privateChat extends Entity {
       entity_id,
     ]);
     this.output.data(res);
+  }
+
+  /**
+   * Toggle the caller's emoji reaction on a P2P message. The message is
+   * single-write in its author's DB: react locally when the caller authored it,
+   * otherwise toggle cross-DB in the peer's DB (mirrors the get/delete paths).
+   * Notifies the peer and the caller's other sessions via WebSocket.
+   */
+  async react() {
+    const message_id = this.input.need(Attr.message_id);
+    const emoji = this.input.need("emoji");
+    const peer_id = this.input.get(Attr.peer_id) || this.input.need(Attr.entity_id);
+    const socket_id = this.input.get(Attr.socket_id);
+    const glyphs = Array.from(emoji || "");
+    if (!glyphs.length || glyphs.length > 8 || /['"\\\s]/.test(emoji)) {
+      return this.output.data({ status: "INVALID_EMOJI" });
+    }
+    // Message row lives in its author's DB. Try mine; if absent, it is the
+    // peer's message -> toggle cross-DB in the peer's DB.
+    let res = await this.db.await_proc(
+      "p2p_message_reaction_toggle",
+      message_id,
+      this.uid,
+      emoji
+    );
+    let row = Array.isArray(res) ? res[0] : res;
+    if (isEmpty(row) || !row.found) {
+      res = await this.yp.await_proc(
+        "forward_proc",
+        peer_id,
+        "p2p_message_reaction_toggle",
+        `'${message_id}','${this.uid}','${emoji}'`
+      );
+      row = Array.isArray(res) ? res[0] : res;
+    }
+    const reactions = row && row.reactions ? this.parseJSON(row.reactions) : {};
+    // Notify the peer (peer_id in the payload is the caller's uid, mirroring
+    // chat.acknowledge/chat.typing so the peer widget patches the right row).
+    const hisDest = await this.yp.await_proc("user_sockets", peer_id);
+    if (!isEmpty(hisDest)) {
+      await RedisStore.sendData(
+        this.payload({ message_id, peer_id: this.uid, reactions }, { service: "chat.react" }),
+        hisDest
+      );
+    }
+    // Update the caller's sibling sessions (exclude the originating socket).
+    let myDest = await this.yp.await_proc("user_sockets", this.uid);
+    myDest = toArray(myDest).filter((e) => e && (!socket_id || e.socket_id != socket_id));
+    if (!isEmpty(myDest)) {
+      await RedisStore.sendData(
+        this.payload({ message_id, peer_id, reactions }, { service: "chat.react" }),
+        myDest
+      );
+    }
+    this.output.data({ message_id, reactions, capped: row && row.capped ? 1 : 0 });
   }
 
   /**

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -307,6 +307,42 @@ class __secure_share extends Mfs {
     const rows   = toArray(
       await this.yp.await_proc('secure_share_list_access_events', hub_id, nid, this.uid)
     );
+    // Resolve the recipient identity for SIGNED-IN opens on shares WITHOUT an email
+    // gate (e.g. a password-only link): those events are logged with actor_id but no
+    // recipient_email, so the "View access list" had nothing to show. Look the
+    // account up via the directory SP and fill recipient_email (the field the table
+    // already renders) plus actor_name/actor_email. No schema change — the stored
+    // access-event rows are untouched. Deduped per actor_id; best-effort (a lookup
+    // failure just leaves the row as-is).
+    const _cache = {};
+    for (const r of rows) {
+      if (!r || !r.actor_id || (r.recipient_email && String(r.recipient_email).trim())) continue;
+      if (!(r.actor_id in _cache)) {
+        try {
+          _cache[r.actor_id] = toArray(await this.yp.await_proc('get_user', r.actor_id))[0] || null;
+        } catch (e) {
+          this.warn('[secure_share.list_access_events] actor lookup failed:', e && e.message);
+          _cache[r.actor_id] = null;
+        }
+      }
+      const u = _cache[r.actor_id];
+      // get_user falls back to the guest account when the id is unknown — only use a
+      // genuine match so a stale/foreign actor_id can't surface a wrong identity.
+      if (!u || String(u.id) !== String(r.actor_id)) continue;
+      let email = null;
+      if (u.profile) {
+        try {
+          const p = (typeof u.profile === 'string') ? JSON.parse(u.profile) : u.profile;
+          email = p && p.email ? String(p.email) : null;
+        } catch (e) { /* ignore malformed profile */ }
+      }
+      const name = (u.fullname && String(u.fullname).trim())
+        || [u.firstname, u.lastname].filter(Boolean).join(' ').trim()
+        || null;
+      if (email) r.recipient_email = email;
+      r.actor_email = email;
+      r.actor_name  = name;
+    }
     this.output.list(rows);
   }
 

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -317,6 +317,12 @@ class __secure_share extends Mfs {
     const _cache = {};
     for (const r of rows) {
       if (!r || !r.actor_id || (r.recipient_email && String(r.recipient_email).trim())) continue;
+      // Never resolve an event whose actor is the share CREATOR (= this.uid, since the
+      // SP is creator-scoped): such rows are either the owner's own preview or a legacy
+      // event mis-attributed to the creator-bound anonymous session (fixed at the
+      // source in dmz.js). Leave them unresolved so they render as an anonymous open
+      // instead of showing the sender as a recipient.
+      if (String(r.actor_id) === String(this.uid)) continue;
       if (!(r.actor_id in _cache)) {
         try {
           _cache[r.actor_id] = toArray(await this.yp.await_proc('get_user', r.actor_id))[0] || null;


### PR DESCRIPTION
## Promote `test` → `preview` — Secure Share (enforcement + recipient fixes) + included teammate work

### Secure + public share (the intent of this promotion)
- **A3 read-only ceiling** — `Acl.run` (router/rest) denies write-src + read-src mutators for recipient sessions carrying a privilege ceiling; `dmz.js` stamps it (anonymous → 3, signed-in chat → 7) and rebinds signed-in non-member recipients to their own uid + a node-scoped grant.
- **Recipient identity in the access list + open notification** — opens are attributed to the recipient (authenticated account), never the creator; password-only shares now resolve the recipient's email.
- **One-time password gate per share session** — a Redis marker keyed by token + share-session sid so login (which opens the share in a new tab sharing the same hub cookie) doesn't re-prompt for the password. Fail-closed.
- get_session_priv_ceiling called via `await_proc` (procedure form).

### Also included (whole-branch `test → preview` — NOT mine, flag to authors/reviewers)
- `perf/fix(gdrive-migration)` phase 1 + 2
- `feat(chat): emoji message reactions — react endpoints + toggle SPs`
- `chore(plans): message-reactions backend plan`

### ⚠️ Depends on the schemas PR
The A3 ceiling cookie cols + SPs and `mfs_node_in_subtree` must be applied to the **prod DB** (Liam) or the ceiling/node-scope fail-open (safe, but not enforced).

### Notes
- Requires **1–2 human reviewers** before merge.
