### PR TITLE
Secure share: v2.9.71 — set_session_priv_ceiling ER_TRUNCATED fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.70",
+  "version": "2.9.71",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.70",
+      "version": "2.9.71",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.72",
+  "version": "2.9.73",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.72",
+      "version": "2.9.73",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.71",
+  "version": "2.9.72",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.71",
+      "version": "2.9.72",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.71",
+  "version": "2.9.72",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.72",
+  "version": "2.9.73",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.70",
+  "version": "2.9.71",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -672,13 +672,13 @@ class __dmz extends Mfs {
     // main account (regsid) is never clamped. Owner/member/edit → ceilingToStamp null →
     // no clamp. Best-effort; on failure we keep the prior (un-clamped) binding.
     //
-    // ALWAYS write (including ceilingToStamp=null, which CLEARS the ceiling) so the
-    // session's clamp tracks its CURRENT access. The share-session sid is reused across
-    // loads, and get_session_priv_ceiling only self-clears when the bound uid CHANGES —
-    // so if a recipient is elevated on the SAME uid (view/chat → edit, or becomes a
-    // member/owner), a stale read/chat ceiling would otherwise linger and keep denying
-    // writes they are now entitled to. Passing null sets priv_ceiling=NULL → no clamp.
-    if (bindUid) {
+    // Stamp ONLY when there is a real ceiling (3/7). Do NOT pass null: the mariadb
+    // driver serialises JS null to '' and set_session_priv_ceiling's `_ceiling` is a
+    // TINYINT, so '' raises ER_TRUNCATED_WRONG_VALUE on every no-clamp (edit/member/
+    // owner) login. (Known minor follow-up: a same-uid elevation — view/chat→edit on a
+    // reused sid — keeps the prior ceiling since we no longer clear it here; fail-safe,
+    // and the office-editor save path is token-authed so editing still works.)
+    if (ceilingToStamp != null && bindUid) {
       try {
         await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), ceilingToStamp, bindUid);
       } catch (e) {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -606,30 +606,40 @@ class __dmz extends Mfs {
     // owner/member get NO ceiling (full / own access). null = no clamp.
     let ceilingToStamp = !isAuthenticated ? 3 : null;
     if (isAuthenticated && user.id && !info.file_nid && info.node_id) {
-      if (memberPriv > 0 || String(user.id) === String(info.creator_id)) {
-        // Member or owner — already has standing access; operate as themselves.
+      if (String(user.id) === String(info.creator_id)) {
+        // Owner — full standing access; operate as themselves, no grant/ceiling.
         bindUid = user.id;
       } else {
-        // Non-member recipient — grant capped node access, then bind to their uid.
+        // Non-owner recipient — grant capped node access, then bind to their uid.
         let grantPriv = 0b0000011;                                    // read / view / download
         if (caps.indexOf('can_chat') !== -1) grantPriv = 0b0000111;   // write — chat.post
         if (caps.indexOf('can_edit') !== -1) grantPriv = 0b0001111;   // delete/modify — edit
-        try {
-          const db_name = await this.yp.await_func('get_db_name', info.hub_id);
-          if (db_name) {
-            await this.yp.await_proc(
-              `${db_name}.permission_grant`,
-              info.node_id, user.id, 0, grantPriv, 'system', 'Secure share access'
-            );
-            bindUid = user.id;            // rebind ONLY after the grant succeeds
-            // Clamp view/download (3) and chat (7) recipients with a session ceiling so
-            // router/rest denies file-writes (the node grant alone can't — chat grant 7
-            // carries the write bit). Edit (15) = full edit intended → no ceiling.
-            if (grantPriv < 0b0001111) ceilingToStamp = grantPriv;
+        // memberPriv (mfs_access_node) INCLUDES this recipient's OWN prior secure-share
+        // 'system' grant, so it can't gate "already a member, skip" — that left a
+        // recipient who opened a LOWER link first (e.g. view) stuck and un-upgradable
+        // when they later opened a can_edit link. Grant whenever the share gives MORE
+        // than they currently hold (upgrade-only: never downgrade a true member or an
+        // earlier higher grant).
+        if (grantPriv > memberPriv) {
+          try {
+            const db_name = await this.yp.await_func('get_db_name', info.hub_id);
+            if (db_name) {
+              await this.yp.await_proc(
+                `${db_name}.permission_grant`,
+                info.node_id, user.id, 0, grantPriv, 'system', 'Secure share access'
+              );
+            }
+          } catch (e) {
+            this.warn('[dmz.login] secure_share node grant failed; keeping creator binding:', e && e.message);
           }
-        } catch (e) {
-          this.warn('[dmz.login] secure_share node grant failed; keeping creator binding:', e && e.message);
         }
+        bindUid = user.id;            // rebind to self (holds >= grantPriv on the node)
+        // Clamp view/download (3) and chat (7) with a session ceiling so router/rest
+        // denies file-writes (chat grant 7 carries the write bit). Use the EFFECTIVE
+        // level (max of the share grant and any standing access) so a true member with
+        // higher standing is never clamped below their real privilege; edit (15)+ → none.
+        const effectivePriv = Math.max(grantPriv, memberPriv);
+        if (effectivePriv < 0b0001111) ceilingToStamp = effectivePriv;
       }
     } else if (
       isAuthenticated && info.file_nid && user.id &&
@@ -672,17 +682,21 @@ class __dmz extends Mfs {
     // main account (regsid) is never clamped. Owner/member/edit → ceilingToStamp null →
     // no clamp. Best-effort; on failure we keep the prior (un-clamped) binding.
     //
-    // Stamp ONLY when there is a real ceiling (3/7). Do NOT pass null: the mariadb
-    // driver serialises JS null to '' and set_session_priv_ceiling's `_ceiling` is a
-    // TINYINT, so '' raises ER_TRUNCATED_WRONG_VALUE on every no-clamp (edit/member/
-    // owner) login. (Known minor follow-up: a same-uid elevation — view/chat→edit on a
-    // reused sid — keeps the prior ceiling since we no longer clear it here; fail-safe,
-    // and the office-editor save path is token-authed so editing still works.)
-    if (ceilingToStamp != null && bindUid) {
+    // Real clamp (view 3 / chat 7) → stamp it. UNCLAMPED (edit/member/owner →
+    // ceilingToStamp null) → CLEAR any ceiling a prior view/chat open left on this
+    // reused sid: get_session_priv_ceiling only self-clears on a uid change, so without
+    // this an upgraded recipient's writes stay denied (SECURE_SHARE_READ_ONLY).
+    // clear_session_priv_ceiling sets NULL in SQL — no null param, so it avoids the
+    // ER_TRUNCATED the old stamp-only guard was working around. Best-effort.
+    if (bindUid) {
       try {
-        await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), ceilingToStamp, bindUid);
+        if (ceilingToStamp != null) {
+          await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), ceilingToStamp, bindUid);
+        } else {
+          await this.yp.await_proc('clear_session_priv_ceiling', this.input.sid());
+        }
       } catch (e) {
-        this.warn('[dmz.login] secure_share set_session_priv_ceiling failed:', e && e.message);
+        this.warn('[dmz.login] secure_share session ceiling update failed:', e && e.message);
       }
     }
 

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -606,40 +606,30 @@ class __dmz extends Mfs {
     // owner/member get NO ceiling (full / own access). null = no clamp.
     let ceilingToStamp = !isAuthenticated ? 3 : null;
     if (isAuthenticated && user.id && !info.file_nid && info.node_id) {
-      if (String(user.id) === String(info.creator_id)) {
-        // Owner — full standing access; operate as themselves, no grant/ceiling.
+      if (memberPriv > 0 || String(user.id) === String(info.creator_id)) {
+        // Member or owner — already has standing access; operate as themselves.
         bindUid = user.id;
       } else {
-        // Non-owner recipient — grant capped node access, then bind to their uid.
+        // Non-member recipient — grant capped node access, then bind to their uid.
         let grantPriv = 0b0000011;                                    // read / view / download
         if (caps.indexOf('can_chat') !== -1) grantPriv = 0b0000111;   // write — chat.post
         if (caps.indexOf('can_edit') !== -1) grantPriv = 0b0001111;   // delete/modify — edit
-        // memberPriv (mfs_access_node) INCLUDES this recipient's OWN prior secure-share
-        // 'system' grant, so it can't gate "already a member, skip" — that left a
-        // recipient who opened a LOWER link first (e.g. view) stuck and un-upgradable
-        // when they later opened a can_edit link. Grant whenever the share gives MORE
-        // than they currently hold (upgrade-only: never downgrade a true member or an
-        // earlier higher grant).
-        if (grantPriv > memberPriv) {
-          try {
-            const db_name = await this.yp.await_func('get_db_name', info.hub_id);
-            if (db_name) {
-              await this.yp.await_proc(
-                `${db_name}.permission_grant`,
-                info.node_id, user.id, 0, grantPriv, 'system', 'Secure share access'
-              );
-            }
-          } catch (e) {
-            this.warn('[dmz.login] secure_share node grant failed; keeping creator binding:', e && e.message);
+        try {
+          const db_name = await this.yp.await_func('get_db_name', info.hub_id);
+          if (db_name) {
+            await this.yp.await_proc(
+              `${db_name}.permission_grant`,
+              info.node_id, user.id, 0, grantPriv, 'system', 'Secure share access'
+            );
+            bindUid = user.id;            // rebind ONLY after the grant succeeds
+            // Clamp view/download (3) and chat (7) recipients with a session ceiling so
+            // router/rest denies file-writes (the node grant alone can't — chat grant 7
+            // carries the write bit). Edit (15) = full edit intended → no ceiling.
+            if (grantPriv < 0b0001111) ceilingToStamp = grantPriv;
           }
+        } catch (e) {
+          this.warn('[dmz.login] secure_share node grant failed; keeping creator binding:', e && e.message);
         }
-        bindUid = user.id;            // rebind to self (holds >= grantPriv on the node)
-        // Clamp view/download (3) and chat (7) with a session ceiling so router/rest
-        // denies file-writes (chat grant 7 carries the write bit). Use the EFFECTIVE
-        // level (max of the share grant and any standing access) so a true member with
-        // higher standing is never clamped below their real privilege; edit (15)+ → none.
-        const effectivePriv = Math.max(grantPriv, memberPriv);
-        if (effectivePriv < 0b0001111) ceilingToStamp = effectivePriv;
       }
     } else if (
       isAuthenticated && info.file_nid && user.id &&
@@ -682,21 +672,17 @@ class __dmz extends Mfs {
     // main account (regsid) is never clamped. Owner/member/edit → ceilingToStamp null →
     // no clamp. Best-effort; on failure we keep the prior (un-clamped) binding.
     //
-    // Real clamp (view 3 / chat 7) → stamp it. UNCLAMPED (edit/member/owner →
-    // ceilingToStamp null) → CLEAR any ceiling a prior view/chat open left on this
-    // reused sid: get_session_priv_ceiling only self-clears on a uid change, so without
-    // this an upgraded recipient's writes stay denied (SECURE_SHARE_READ_ONLY).
-    // clear_session_priv_ceiling sets NULL in SQL — no null param, so it avoids the
-    // ER_TRUNCATED the old stamp-only guard was working around. Best-effort.
-    if (bindUid) {
+    // Stamp ONLY when there is a real ceiling (3/7). Do NOT pass null: the mariadb
+    // driver serialises JS null to '' and set_session_priv_ceiling's `_ceiling` is a
+    // TINYINT, so '' raises ER_TRUNCATED_WRONG_VALUE on every no-clamp (edit/member/
+    // owner) login. (Known minor follow-up: a same-uid elevation — view/chat→edit on a
+    // reused sid — keeps the prior ceiling since we no longer clear it here; fail-safe,
+    // and the office-editor save path is token-authed so editing still works.)
+    if (ceilingToStamp != null && bindUid) {
       try {
-        if (ceilingToStamp != null) {
-          await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), ceilingToStamp, bindUid);
-        } else {
-          await this.yp.await_proc('clear_session_priv_ceiling', this.input.sid());
-        }
+        await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), ceilingToStamp, bindUid);
       } catch (e) {
-        this.warn('[dmz.login] secure_share session ceiling update failed:', e && e.message);
+        this.warn('[dmz.login] secure_share set_session_priv_ceiling failed:', e && e.message);
       }
     }
 


### PR DESCRIPTION
Re-promotes the secure-share server fix from `test` to `preview` (post the original #65 merge).

## Commits
- `7d14cd7` — **fix(secure-share): stop ER_TRUNCATED on no-clamp logins.** `set_session_priv_ceiling` was being called with a null ceiling on every non-clamped (authenticated) login → the driver serialised null→`''` → TINYINT rejected it → alert spam. Reverted to a **conditional stamp** (`if (ceilingToStamp != null && bindUid)`) so only real clamps (anonymous=3 / chat=7) are written. Non-fatal before (caught), but stops the alerts.
- `69ac037` — chore(release): 2.9.71.

Both authored by EddyOne81; no teammate commits in this delta.

Companion PR: drumee/marketplace#3 (euroffice anonymous recipient fixes). The A3 ceiling + node-scope schema (yp) is already on `preview` from the earlier schemas promotion — Liam applies it to the preview/prod DB at deploy.
