### PR TITLE
Promote test → preview (Manage-access converge v2.9.79 + hub/channel personal-entity guard)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.78",
+  "version": "2.9.79",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.78",
+      "version": "2.9.79",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.78",
+  "version": "2.9.79",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -443,7 +443,14 @@ class __dmz extends Mfs {
       // or the hub name for the root/hub node — correct in both cases. Capture before
       // the file→pid swap below so a file share titles on the file, not its parent.
       if (nodeAttr.filename) info.title = nodeAttr.filename;
-      if (nodeAttr.filetype && nodeAttr.filetype !== 'folder' && nodeAttr.filetype !== 'hub' && nodeAttr.pid) {
+      // Only remap a real FILE to its parent. Containers — folder, hub, AND the
+      // workspace 'root' node (its filetype is 'root', not 'folder'/'hub') — must
+      // keep their own nid so show_node_by lists their children and the folder
+      // node-grant below is issued on the shared node. Without exempting 'root',
+      // a workspace-root share (Manage access) was treated as a file → file_nid set
+      // → the recipient grant branch skipped → recipient had 0 permission on every
+      // child → blank list (uploads still wrote via the token path).
+      if (nodeAttr.filetype && nodeAttr.filetype !== 'folder' && nodeAttr.filetype !== 'hub' && nodeAttr.filetype !== 'root' && nodeAttr.pid) {
         info.file_nid = info.nid;  // specific file — sent to UI for filtering
         info.nid = nodeAttr.pid;   // parent folder — used by show_node_by
       }

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -1962,6 +1962,19 @@ class __private_channel extends Entity {
    */
   async acknowledge() {
     const message_id = this.input.use(Attr.message_id);
+    // A personal/drumate entity resolved as the hub (e.g. a P2P conversation
+    // whose hub_id is the peer's personal entity_id). Personal DBs carry the
+    // single-JSON-arg acknowledge_message (not the 2-arg hub form), and P2P
+    // read receipts are owned by chat.acknowledge (contact.js) against the
+    // caller's own DB — so the hub path here both crashes
+    // (ER_SP_WRONG_NO_OF_ARGS) and would target the wrong DB. Skip it cleanly.
+    if (this.hub.get(Attr.area) === "personal") {
+      this.warn(
+        "[channel.acknowledge] skipped on personal entity; P2P ack belongs to chat.acknowledge",
+        this.hub.get(Attr.id)
+      );
+      return this.output.data({});
+    }
     let exclude = this.input.need(Attr.socket_id);
     if (exclude) exclude = [exclude];
 

--- a/service/private/hub.js
+++ b/service/private/hub.js
@@ -103,17 +103,30 @@ class __private_hub extends Hub {
   }
 
   /**
-   * 
+   * hub_get_members_by_type is a hub-only proc. When a hub-scoped endpoint is
+   * reached with a personal/drumate entity as hub_id (e.g. a P2P/personal
+   * context whose hub_id is a personal entity_id), the resolved DB may lack the
+   * proc (ER_SP_DOES_NOT_EXIST), which tears down the request's DB connection.
+   * A personal space has no workspace members, so return an empty set. Real
+   * hubs (area private/org/share/dmz/…) are never 'personal' and are unaffected.
    */
-  async get_members_by_type() {
-    const type = this.input.need(Attr.type);
-    const page = this.input.use(Attr.page, 1);
-    let members = await this.db.await_proc(
+  async _members_by_type(type, page) {
+    if (this.hub.get(Attr.area) === "personal") return [];
+    return await this.db.await_proc(
       "hub_get_members_by_type",
       this.uid,
       type,
       page
     );
+  }
+
+  /**
+   *
+   */
+  async get_members_by_type() {
+    const type = this.input.need(Attr.type);
+    const page = this.input.use(Attr.page, 1);
+    let members = await this._members_by_type(type, page);
     members = await this._hydrateMemberProfileNames(members, { type, page });
     this.output.list(members);
   }
@@ -524,12 +537,7 @@ class __private_hub extends Hub {
     opt.hubname = this.hub.get(Attr.name);
     let visitor = await this.db.await_proc("member_show_privilege", this.uid);
     opt.visitor = visitor;
-    let users = await this.db.await_proc(
-      "hub_get_members_by_type",
-      this.uid,
-      "all",
-      1
-    );
+    let users = await this._members_by_type("all", 1);
     // opt.users = users;
     users = toArray(users);
     opt.users = filter(users, (el) => {
@@ -546,12 +554,7 @@ class __private_hub extends Hub {
   async show_privilege() {
     let owner = {};
     if ([Attr.all, Attr.owner, 'not_owner', 'admin', Attr.other].includes(this.input.get(Attr.type))) {
-      owner = await this.db.await_proc(
-        "hub_get_members_by_type",
-        this.uid,
-        this.input.get(Attr.type),
-        1
-      )
+      owner = await this._members_by_type(this.input.get(Attr.type), 1)
     }
     let { filesize } = await this.db.await_query("SELECT sum(filesize) filesize FROM media");
     let visitor = await this.db.await_proc(
@@ -774,12 +777,7 @@ class __private_hub extends Hub {
     // res = filter(res, (el) => {
     //   return (el.privilege & 32) == 0;
     // });
-    users = await this.db.await_proc(
-      "hub_get_members_by_type",
-      this.uid,
-      "not_owner",
-      1
-    );
+    users = await this._members_by_type("not_owner", 1);
     this.output.data(users);
   }
 
@@ -1770,12 +1768,7 @@ class __private_hub extends Hub {
         log: `Member removed from workspace '${hub_name}'`,
       });
     }
-    users = await this.db.await_proc(
-      "hub_get_members_by_type",
-      this.uid,
-      "not_owner",
-      1
-    );
+    users = await this._members_by_type("not_owner", 1);
     this.output.list(users);
   }
 
@@ -1866,12 +1859,7 @@ class __private_hub extends Hub {
       entity_id: uid,
       log: `Member privilege set to ${privilege} in workspace '${this.hub.get(Attr.name) || this.hub.get(Attr.id)}'`,
     });
-    let users = await this.db.await_proc(
-      "hub_get_members_by_type",
-      this.uid,
-      "not_owner",
-      1
-    );
+    let users = await this._members_by_type("not_owner", 1);
     this.output.list(users);
   }
 


### PR DESCRIPTION
Promote `test` → `preview` (whole branch). ⚠️ prod deploys from preview — **merging = LIVE ON PROD**; a reviewer merges.

## Delta (3 commits — all this-team, no teammate work)
- `97eb36c` fix(dmz): treat workspace 'root' node as a container in secure-share login — the **Manage-access → secure-share v2 converge** server piece (v2.9.79). Fixes the root-share recipient blank-listing (root now keeps its nid so the recipient node-grant is created). Duy verified end-to-end on drumee.in (listing/create/upload/chat/access-list).
- `47f8361` 2.9.79 release bump.
- `3922993` fix(hub,channel): guard hub-only procs against personal-entity context — stops the prod alerts `hub_get_members_by_type ER_SP_DOES_NOT_EXIST` and `acknowledge_message ER_SP_WRONG_NO_OF_ARGS` when a hub/channel endpoint is reached with a personal entity as `hub_id` (P2P/personal). Real hubs get byte-identical proc calls → no regression. Verified end-to-end on the test/main endpoint (rode on 2.9.79, no separate version bump).

## DB — no action needed
No new schema. The converge's yp SPs (incl. `secure_share_list_access_events`) are already applied + verified on the prod DB (Liam, 2026-07-03). The guard fix is server-only.

## Verify on preview
- Manage-access Public Link opens clean for a recipient; the root share lists content; permission edits apply; logged-in recipient recognized.
- Personal/P2P context no longer errors on `get_members_by_type` / `acknowledge`; real workspace member lists + read receipts still work.
