### PR TITLE
Test → Preview: secure-share neutral host + task-assigned notif [carries teammate work]

### DIFF
--- a/acl/activity.json
+++ b/acl/activity.json
@@ -398,6 +398,17 @@
       }
     },
 
+    "list_task_assignments": {
+      "doc": "List the caller's undismissed task-assignment notifications for the pinned activity section and bell badge. Read-only; rows come from yp.contact_task_assigned_unread with task title/nid/hub_id/task_id flattened to the top level.",
+      "scope": "hub",
+      "permission": { "src": "read" },
+      "params": {},
+      "returns": {
+        "type": "array",
+        "description": "Undismissed task_assigned activity rows for the caller"
+      }
+    },
+
     "list": {
       "doc": "Single-call notification feed combining notification_center rollups + standalone hub-invite rows. Returns a flat array; client renders by `category` (chat | contact | media | teamchat | ticket | hub_invite).",
       "scope": "hub",

--- a/acl/drumate.json
+++ b/acl/drumate.json
@@ -70,6 +70,11 @@
         }
       ]
     },
+    "get_referral_code": {
+      "doc": "Get or create the signed-in user's referral code and link.",
+      "scope": "hub",
+      "permission": { "src": "owner" }
+    },
     "change_password": {
       "doc": "Change user password with old password verification",
       "scope": "hub",

--- a/acl/task.json
+++ b/acl/task.json
@@ -25,19 +25,58 @@
         "items": {
           "type": "object",
           "properties": {
-            "id": { "type": "string", "doc": "Task ID" },
-            "title": { "type": "string", "doc": "Task title" },
-            "description": { "type": "string", "doc": "Task description (long text), null if not set" },
-            "status": { "type": "string", "doc": "Kanban column: todo | in_progress | to_review | complete" },
-            "priority": { "type": "string", "doc": "Priority: low | medium | high | urgent" },
-            "due_date": { "type": "string", "doc": "Due date (YYYY-MM-DD), null if not set" },
-            "created_by": { "type": "string", "doc": "UID of the user who created the task" },
-            "nid": { "type": "string", "doc": "Folder node id the task belongs to, null if workspace-level (legacy)" },
-            "assignee_uids": { "type": "string", "doc": "Comma-separated list of assignee UIDs, null if unassigned" },
-            "rank": { "type": "number", "doc": "Position within the status column" },
-            "ctime": { "type": "number", "doc": "Unix timestamp of creation" },
-            "mtime": { "type": "number", "doc": "Unix timestamp of last update" },
-            "label_ids": { "type": "string", "doc": "Comma-separated list of label IDs attached to the task, null if none" }
+            "id": {
+              "type": "string",
+              "doc": "Task ID"
+            },
+            "title": {
+              "type": "string",
+              "doc": "Task title"
+            },
+            "description": {
+              "type": "string",
+              "doc": "Task description (long text), null if not set"
+            },
+            "status": {
+              "type": "string",
+              "doc": "Kanban column: todo | in_progress | to_review | complete"
+            },
+            "priority": {
+              "type": "string",
+              "doc": "Priority: low | medium | high | urgent"
+            },
+            "due_date": {
+              "type": "string",
+              "doc": "Due date (YYYY-MM-DD), null if not set"
+            },
+            "created_by": {
+              "type": "string",
+              "doc": "UID of the user who created the task"
+            },
+            "nid": {
+              "type": "string",
+              "doc": "Folder node id the task belongs to, null if workspace-level (legacy)"
+            },
+            "assignee_uids": {
+              "type": "string",
+              "doc": "Comma-separated list of assignee UIDs, null if unassigned"
+            },
+            "rank": {
+              "type": "number",
+              "doc": "Position within the status column"
+            },
+            "ctime": {
+              "type": "number",
+              "doc": "Unix timestamp of creation"
+            },
+            "mtime": {
+              "type": "number",
+              "doc": "Unix timestamp of last update"
+            },
+            "label_ids": {
+              "type": "string",
+              "doc": "Comma-separated list of label IDs attached to the task, null if none"
+            }
           }
         }
       }
@@ -69,7 +108,12 @@
           "type": "string",
           "required": false,
           "default": "medium",
-          "enum": ["low", "medium", "high", "urgent"],
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "urgent"
+          ],
           "doc": "Task priority. Defaults to medium."
         },
         "due_date": {
@@ -86,7 +130,9 @@
           "type": "array",
           "required": false,
           "doc": "UIDs of the users to assign. Optional. Each must be a valid drumate.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "assignee_uid": {
           "type": "string",
@@ -97,7 +143,9 @@
           "type": "array",
           "required": false,
           "doc": "UIDs @-mentioned in the description. Server notifies each (excluding self).",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       },
       "returns": {
@@ -105,7 +153,11 @@
         "doc": "Newly created task object"
       },
       "errors": [
-        { "code": "INVALID_ASSIGNEE", "message": "assignee_uid does not reference a valid user", "http_status": 400 }
+        {
+          "code": "INVALID_ASSIGNEE",
+          "message": "assignee_uid does not reference a valid user",
+          "http_status": 400
+        }
       ]
     },
     "update": {
@@ -133,7 +185,12 @@
         "priority": {
           "type": "string",
           "required": false,
-          "enum": ["low", "medium", "high", "urgent"],
+          "enum": [
+            "low",
+            "medium",
+            "high",
+            "urgent"
+          ],
           "doc": "New priority. Omit to keep existing value."
         },
         "due_date": {
@@ -145,7 +202,9 @@
           "type": "array",
           "required": false,
           "doc": "UIDs newly @-mentioned in this edit. Server notifies each (excluding self).",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       },
       "returns": {
@@ -153,8 +212,16 @@
         "doc": "Updated task object"
       },
       "errors": [
-        { "code": "TASK_NOT_FOUND", "message": "No task found with the given ID", "http_status": 404 },
-        { "code": "INVALID_PRIORITY", "message": "priority must be one of: low, medium, high, urgent", "http_status": 400 }
+        {
+          "code": "TASK_NOT_FOUND",
+          "message": "No task found with the given ID",
+          "http_status": 404
+        },
+        {
+          "code": "INVALID_PRIORITY",
+          "message": "priority must be one of: low, medium, high, urgent",
+          "http_status": 400
+        }
       ]
     },
     "update_status": {
@@ -180,8 +247,16 @@
         "doc": "Updated task object with new status and rank"
       },
       "errors": [
-        { "code": "TASK_NOT_FOUND", "message": "No task found with the given ID", "http_status": 404 },
-        { "code": "INVALID_STATUS", "message": "status is neither a built-in column nor an existing custom column id", "http_status": 400 }
+        {
+          "code": "TASK_NOT_FOUND",
+          "message": "No task found with the given ID",
+          "http_status": 404
+        },
+        {
+          "code": "INVALID_STATUS",
+          "message": "status is neither a built-in column nor an existing custom column id",
+          "http_status": 400
+        }
       ]
     },
     "update_assignee": {
@@ -200,7 +275,9 @@
           "type": "array",
           "required": false,
           "doc": "Full new set of assignee UIDs. [] clears all. Each must be a valid drumate.",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         },
         "assignee_uid": {
           "type": "string",
@@ -213,8 +290,16 @@
         "doc": "Updated task object"
       },
       "errors": [
-        { "code": "TASK_NOT_FOUND", "message": "No task found with the given ID", "http_status": 404 },
-        { "code": "INVALID_ASSIGNEE", "message": "assignee_uid does not reference a valid user", "http_status": 400 }
+        {
+          "code": "TASK_NOT_FOUND",
+          "message": "No task found with the given ID",
+          "http_status": 404
+        },
+        {
+          "code": "INVALID_ASSIGNEE",
+          "message": "assignee_uid does not reference a valid user",
+          "http_status": 400
+        }
       ]
     },
     "delete": {
@@ -234,8 +319,14 @@
         "type": "object",
         "doc": "Deleted task ID and affected row count",
         "properties": {
-          "id": { "type": "string", "doc": "Deleted task ID" },
-          "affected": { "type": "number", "doc": "Number of rows deleted (1 if found, 0 if not found)" }
+          "id": {
+            "type": "string",
+            "doc": "Deleted task ID"
+          },
+          "affected": {
+            "type": "number",
+            "doc": "Number of rows deleted (1 if found, 0 if not found)"
+          }
         }
       }
     },
@@ -263,14 +354,38 @@
         "items": {
           "type": "object",
           "properties": {
-            "task_id": { "type": "string", "doc": "Task ID" },
-            "file_nid": { "type": "string", "doc": "File media node ID" },
-            "linked_by": { "type": "string", "doc": "UID of the user who linked the file" },
-            "ctime": { "type": "number", "doc": "Unix timestamp of when the file was linked" },
-            "filename": { "type": "string", "doc": "File display name (user_filename from media)" },
-            "category": { "type": "string", "doc": "File category (document, image, etc.)" },
-            "extension": { "type": "string", "doc": "File extension" },
-            "filesize": { "type": "number", "doc": "File size in bytes" }
+            "task_id": {
+              "type": "string",
+              "doc": "Task ID"
+            },
+            "file_nid": {
+              "type": "string",
+              "doc": "File media node ID"
+            },
+            "linked_by": {
+              "type": "string",
+              "doc": "UID of the user who linked the file"
+            },
+            "ctime": {
+              "type": "number",
+              "doc": "Unix timestamp of when the file was linked"
+            },
+            "filename": {
+              "type": "string",
+              "doc": "File display name (user_filename from media)"
+            },
+            "category": {
+              "type": "string",
+              "doc": "File category (document, image, etc.)"
+            },
+            "extension": {
+              "type": "string",
+              "doc": "File extension"
+            },
+            "filesize": {
+              "type": "number",
+              "doc": "File size in bytes"
+            }
           }
         }
       }
@@ -297,9 +412,18 @@
         "type": "object",
         "doc": "Confirmation of the unlinked pair",
         "properties": {
-          "task_id": { "type": "string", "doc": "Task ID" },
-          "file_nid": { "type": "string", "doc": "File media node ID" },
-          "affected": { "type": "number", "doc": "1 if removed, 0 if link did not exist" }
+          "task_id": {
+            "type": "string",
+            "doc": "Task ID"
+          },
+          "file_nid": {
+            "type": "string",
+            "doc": "File media node ID"
+          },
+          "affected": {
+            "type": "number",
+            "doc": "1 if removed, 0 if link did not exist"
+          }
         }
       }
     },
@@ -328,8 +452,16 @@
         "src": "write"
       },
       "params": {
-        "task_id":  { "type": "string", "required": true, "doc": "Task ID" },
-        "label_id": { "type": "string", "required": true, "doc": "Label ID" }
+        "task_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Task ID"
+        },
+        "label_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Label ID"
+        }
       },
       "returns": {
         "type": "array",
@@ -337,11 +469,26 @@
         "items": {
           "type": "object",
           "properties": {
-            "task_id":  { "type": "string", "doc": "Task ID" },
-            "label_id": { "type": "string", "doc": "Label ID" },
-            "ctime":    { "type": "number", "doc": "Unix timestamp of when the label was linked" },
-            "name":     { "type": "string", "doc": "Label name" },
-            "color":    { "type": "string", "doc": "Label color (hex with leading #)" }
+            "task_id": {
+              "type": "string",
+              "doc": "Task ID"
+            },
+            "label_id": {
+              "type": "string",
+              "doc": "Label ID"
+            },
+            "ctime": {
+              "type": "number",
+              "doc": "Unix timestamp of when the label was linked"
+            },
+            "name": {
+              "type": "string",
+              "doc": "Label name"
+            },
+            "color": {
+              "type": "string",
+              "doc": "Label color (hex with leading #)"
+            }
           }
         }
       }
@@ -353,16 +500,30 @@
         "src": "write"
       },
       "params": {
-        "task_id":  { "type": "string", "required": true, "doc": "Task ID" },
-        "label_id": { "type": "string", "required": true, "doc": "Label ID" }
+        "task_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Task ID"
+        },
+        "label_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Label ID"
+        }
       },
       "returns": {
         "type": "object",
         "doc": "Confirmation of the unlinked pair",
         "properties": {
-          "task_id":  { "type": "string" },
-          "label_id": { "type": "string" },
-          "affected": { "type": "number" }
+          "task_id": {
+            "type": "string"
+          },
+          "label_id": {
+            "type": "string"
+          },
+          "affected": {
+            "type": "number"
+          }
         }
       }
     },
@@ -373,7 +534,11 @@
         "src": "read"
       },
       "params": {
-        "task_id": { "type": "string", "required": true, "doc": "Task ID" }
+        "task_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Task ID"
+        }
       },
       "returns": {
         "type": "array",
@@ -387,9 +552,24 @@
         "src": "read"
       },
       "params": {
-        "pattern": { "type": "string", "required": true, "minLength": 1, "doc": "Filename substring" },
-        "task_id": { "type": "string", "required": false, "doc": "Exclude files already linked to this task" },
-        "page":    { "type": "number", "required": false, "default": 1, "min": 1, "doc": "Page number for pagination" }
+        "pattern": {
+          "type": "string",
+          "required": true,
+          "minLength": 1,
+          "doc": "Filename substring"
+        },
+        "task_id": {
+          "type": "string",
+          "required": false,
+          "doc": "Exclude files already linked to this task"
+        },
+        "page": {
+          "type": "number",
+          "required": false,
+          "default": 1,
+          "min": 1,
+          "doc": "Page number for pagination"
+        }
       },
       "returns": {
         "type": "array",
@@ -397,13 +577,34 @@
         "items": {
           "type": "object",
           "properties": {
-            "nid":      { "type": "string", "doc": "Media node ID" },
-            "filename": { "type": "string", "doc": "Display filename" },
-            "ext":      { "type": "string", "doc": "File extension" },
-            "category": { "type": "string", "doc": "File category" },
-            "filesize": { "type": "number", "doc": "File size in bytes" },
-            "mtime":    { "type": "number", "doc": "Unix timestamp of last upload" },
-            "score":    { "type": "number", "doc": "Match score (higher = better)" }
+            "nid": {
+              "type": "string",
+              "doc": "Media node ID"
+            },
+            "filename": {
+              "type": "string",
+              "doc": "Display filename"
+            },
+            "ext": {
+              "type": "string",
+              "doc": "File extension"
+            },
+            "category": {
+              "type": "string",
+              "doc": "File category"
+            },
+            "filesize": {
+              "type": "number",
+              "doc": "File size in bytes"
+            },
+            "mtime": {
+              "type": "number",
+              "doc": "Unix timestamp of last upload"
+            },
+            "score": {
+              "type": "number",
+              "doc": "Match score (higher = better)"
+            }
           }
         }
       }
@@ -411,9 +612,15 @@
     "comment_list": {
       "doc": "List a task's comments (flat, chronological). Author name/avatar is resolved client-side from the hub member list.",
       "scope": "hub",
-      "permission": { "src": "read" },
+      "permission": {
+        "src": "read"
+      },
       "params": {
-        "task_id": { "type": "string", "required": true, "doc": "Task ID to list comments for" }
+        "task_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Task ID to list comments for"
+        }
       },
       "returns": {
         "type": "array",
@@ -421,13 +628,34 @@
         "items": {
           "type": "object",
           "properties": {
-            "id":         { "type": "string", "doc": "Comment ID" },
-            "task_id":    { "type": "string", "doc": "Parent task ID" },
-            "author_uid": { "type": "string", "doc": "UID of the comment author" },
-            "body":       { "type": "string", "doc": "Comment body in marker form [@Name](user:uid)" },
-            "edited":     { "type": "number", "doc": "1 if the comment was edited" },
-            "ctime":      { "type": "number", "doc": "Unix timestamp of creation" },
-            "mtime":      { "type": "number", "doc": "Unix timestamp of last edit" }
+            "id": {
+              "type": "string",
+              "doc": "Comment ID"
+            },
+            "task_id": {
+              "type": "string",
+              "doc": "Parent task ID"
+            },
+            "author_uid": {
+              "type": "string",
+              "doc": "UID of the comment author"
+            },
+            "body": {
+              "type": "string",
+              "doc": "Comment body in marker form [@Name](user:uid)"
+            },
+            "edited": {
+              "type": "number",
+              "doc": "1 if the comment was edited"
+            },
+            "ctime": {
+              "type": "number",
+              "doc": "Unix timestamp of creation"
+            },
+            "mtime": {
+              "type": "number",
+              "doc": "Unix timestamp of last edit"
+            }
           }
         }
       }
@@ -435,84 +663,175 @@
     "comment_create": {
       "doc": "Add a comment to a task. @-mentioned members are notified.",
       "scope": "hub",
-      "permission": { "src": "write" },
+      "permission": {
+        "src": "write"
+      },
       "params": {
-        "task_id": { "type": "string", "required": true, "doc": "Task ID to comment on" },
-        "body":    { "type": "string", "required": true, "doc": "Comment body in marker form [@Name](user:uid)" },
-        "parent_id": { "type": "string", "required": false, "doc": "Root comment id when this is a reply; omit/null for a top-level comment" },
+        "task_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Task ID to comment on"
+        },
+        "body": {
+          "type": "string",
+          "required": true,
+          "doc": "Comment body in marker form [@Name](user:uid)"
+        },
+        "parent_id": {
+          "type": "string",
+          "required": false,
+          "doc": "Root comment id when this is a reply; omit/null for a top-level comment"
+        },
         "mention_uids": {
           "type": "array",
           "required": false,
           "doc": "UIDs @-mentioned in the body. Server notifies each (excluding self).",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       },
-      "returns": { "type": "object", "doc": "The created comment row" }
+      "returns": {
+        "type": "object",
+        "doc": "The created comment row"
+      }
     },
     "comment_react": {
       "doc": "Toggle the caller's emoji reaction on a comment (add if absent, remove if present).",
       "scope": "hub",
-      "permission": { "src": "write" },
+      "permission": {
+        "src": "write"
+      },
       "params": {
-        "comment_id": { "type": "string", "required": true, "doc": "Comment ID to react to" },
-        "task_id":    { "type": "string", "required": true, "doc": "Parent task ID (so the broadcast targets the right feed)" },
-        "emoji":      { "type": "string", "required": true, "doc": "Reaction emoji" }
+        "comment_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Comment ID to react to"
+        },
+        "task_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Parent task ID (so the broadcast targets the right feed)"
+        },
+        "emoji": {
+          "type": "string",
+          "required": true,
+          "doc": "Reaction emoji"
+        }
       },
       "returns": {
         "type": "object",
         "doc": "Toggled reaction summary",
         "properties": {
-          "comment_id": { "type": "string" },
-          "emoji":      { "type": "string" },
-          "count":      { "type": "number", "doc": "Remaining count for that emoji" }
+          "comment_id": {
+            "type": "string"
+          },
+          "emoji": {
+            "type": "string"
+          },
+          "count": {
+            "type": "number",
+            "doc": "Remaining count for that emoji"
+          }
         }
       }
     },
     "comment_update": {
       "doc": "Edit your own comment. Returns COMMENT_NOT_FOUND if the caller is not the author.",
       "scope": "hub",
-      "permission": { "src": "write" },
+      "permission": {
+        "src": "write"
+      },
       "params": {
-        "id":   { "type": "string", "required": true, "doc": "Comment ID to edit" },
-        "body": { "type": "string", "required": true, "doc": "New comment body in marker form" },
+        "id": {
+          "type": "string",
+          "required": true,
+          "doc": "Comment ID to edit"
+        },
+        "body": {
+          "type": "string",
+          "required": true,
+          "doc": "New comment body in marker form"
+        },
         "mention_uids": {
           "type": "array",
           "required": false,
           "doc": "UIDs @-mentioned in the body. Server notifies each (excluding self).",
-          "items": { "type": "string" }
+          "items": {
+            "type": "string"
+          }
         }
       },
-      "returns": { "type": "object", "doc": "The updated comment row" },
+      "returns": {
+        "type": "object",
+        "doc": "The updated comment row"
+      },
       "errors": [
-        { "code": "COMMENT_NOT_FOUND", "message": "No comment with that ID owned by the caller", "http_status": 404 }
+        {
+          "code": "COMMENT_NOT_FOUND",
+          "message": "No comment with that ID owned by the caller",
+          "http_status": 404
+        }
       ]
     },
     "comment_delete": {
       "doc": "Delete your own comment.",
       "scope": "hub",
-      "permission": { "src": "write" },
+      "permission": {
+        "src": "write"
+      },
       "params": {
-        "id":      { "type": "string", "required": true, "doc": "Comment ID to delete" },
-        "task_id": { "type": "string", "required": true, "doc": "Parent task ID (so the broadcast targets the right feed)" }
+        "id": {
+          "type": "string",
+          "required": true,
+          "doc": "Comment ID to delete"
+        },
+        "task_id": {
+          "type": "string",
+          "required": true,
+          "doc": "Parent task ID (so the broadcast targets the right feed)"
+        }
       },
       "returns": {
         "type": "object",
         "doc": "Deleted comment ID and affected row count",
         "properties": {
-          "id":       { "type": "string" },
-          "task_id":  { "type": "string" },
-          "affected": { "type": "number" }
+          "id": {
+            "type": "string"
+          },
+          "task_id": {
+            "type": "string"
+          },
+          "affected": {
+            "type": "number"
+          }
         }
       }
     },
     "activity": {
       "doc": "Recent task activity for a folder scope (Project Health feed): create / update / status / complete / assignee / link_file / comment events, newest first.",
       "scope": "hub",
-      "permission": { "src": "read" },
+      "permission": {
+        "src": "read"
+      },
       "params": {
-        "nid": { "type": "string", "required": false, "doc": "Folder node id to scope to (mirrors task.list)" },
-        "include_unscoped": { "type": "number", "required": false, "default": 0, "doc": "When 1, also include legacy nid-less rows (workspace root)" },
-        "limit": { "type": "number", "required": false, "default": 30, "doc": "Max rows returned" }
+        "nid": {
+          "type": "string",
+          "required": false,
+          "doc": "Folder node id to scope to (mirrors task.list)"
+        },
+        "include_unscoped": {
+          "type": "number",
+          "required": false,
+          "default": 0,
+          "doc": "When 1, also include legacy nid-less rows (workspace root)"
+        },
+        "limit": {
+          "type": "number",
+          "required": false,
+          "default": 30,
+          "doc": "Max rows returned"
+        }
       },
       "returns": {
         "type": "array",
@@ -522,9 +841,15 @@
     "column_list": {
       "doc": "List the custom Kanban columns for a folder scope. Built-in columns (todo / in_progress / to_review / complete) are implicit client-side and never stored.",
       "scope": "hub",
-      "permission": { "src": "read" },
+      "permission": {
+        "src": "read"
+      },
       "params": {
-        "nid": { "type": "string", "required": false, "doc": "Folder node id to scope to (mirrors task.list)" }
+        "nid": {
+          "type": "string",
+          "required": false,
+          "doc": "Folder node id to scope to (mirrors task.list)"
+        }
       },
       "returns": {
         "type": "array",
@@ -532,13 +857,32 @@
         "items": {
           "type": "object",
           "properties": {
-            "id":       { "type": "string", "doc": "Column id — doubles as the task.status key for its tasks" },
-            "nid":      { "type": "string", "doc": "Folder node id, null at workspace root" },
-            "name":     { "type": "string", "doc": "User-entered column name" },
-            "theme":    { "type": "string", "doc": "Palette theme: default | orange | yellow | green | cyan | blue | purple | pink | red" },
-            "position": { "type": "number", "doc": "Board order among custom columns" },
-            "ctime":    { "type": "number" },
-            "mtime":    { "type": "number" }
+            "id": {
+              "type": "string",
+              "doc": "Column id — doubles as the task.status key for its tasks"
+            },
+            "nid": {
+              "type": "string",
+              "doc": "Folder node id, null at workspace root"
+            },
+            "name": {
+              "type": "string",
+              "doc": "User-entered column name"
+            },
+            "theme": {
+              "type": "string",
+              "doc": "Palette theme: default | orange | yellow | green | cyan | blue | purple | pink | red"
+            },
+            "position": {
+              "type": "number",
+              "doc": "Board order among custom columns"
+            },
+            "ctime": {
+              "type": "number"
+            },
+            "mtime": {
+              "type": "number"
+            }
           }
         }
       }
@@ -546,46 +890,112 @@
     "column_create": {
       "doc": "Create a custom Kanban column for a folder scope.",
       "scope": "hub",
-      "permission": { "src": "write" },
-      "params": {
-        "name":  { "type": "string", "required": true, "doc": "Column display name (1–100 chars)" },
-        "theme": { "type": "string", "required": false, "default": "default", "doc": "Palette theme key; invalid values fall back to default" },
-        "nid":   { "type": "string", "required": false, "doc": "Folder node id the column belongs to" }
+      "permission": {
+        "src": "write"
       },
-      "returns": { "type": "object", "doc": "The created column row" },
+      "params": {
+        "name": {
+          "type": "string",
+          "required": true,
+          "doc": "Column display name (1–100 chars)"
+        },
+        "theme": {
+          "type": "string",
+          "required": false,
+          "default": "default",
+          "doc": "Palette theme key; invalid values fall back to default"
+        },
+        "nid": {
+          "type": "string",
+          "required": false,
+          "doc": "Folder node id the column belongs to"
+        }
+      },
+      "returns": {
+        "type": "object",
+        "doc": "The created column row"
+      },
       "errors": [
-        { "code": "INVALID_COLUMN_NAME", "message": "name is empty after trimming", "http_status": 400 }
+        {
+          "code": "INVALID_COLUMN_NAME",
+          "message": "name is empty after trimming",
+          "http_status": 400
+        },
+        {
+          "code": "COLUMN_CREATE_FAILED",
+          "message": "insert returned no row — hub DB likely missing the task_column migration",
+          "http_status": 500
+        }
       ]
     },
     "column_update": {
       "doc": "Rename and/or re-theme a custom column. Omit a field to keep it.",
       "scope": "hub",
-      "permission": { "src": "write" },
-      "params": {
-        "id":    { "type": "string", "required": true, "doc": "Column id" },
-        "name":  { "type": "string", "required": false, "doc": "New display name" },
-        "theme": { "type": "string", "required": false, "doc": "New palette theme key" }
+      "permission": {
+        "src": "write"
       },
-      "returns": { "type": "object", "doc": "The updated column row" },
+      "params": {
+        "id": {
+          "type": "string",
+          "required": true,
+          "doc": "Column id"
+        },
+        "name": {
+          "type": "string",
+          "required": false,
+          "doc": "New display name"
+        },
+        "theme": {
+          "type": "string",
+          "required": false,
+          "doc": "New palette theme key"
+        }
+      },
+      "returns": {
+        "type": "object",
+        "doc": "The updated column row"
+      },
       "errors": [
-        { "code": "INVALID_COLUMN_NAME", "message": "name is empty after trimming", "http_status": 400 },
-        { "code": "COLUMN_NOT_FOUND", "message": "No column with that id", "http_status": 404 }
+        {
+          "code": "INVALID_COLUMN_NAME",
+          "message": "name is empty after trimming",
+          "http_status": 400
+        },
+        {
+          "code": "COLUMN_NOT_FOUND",
+          "message": "No column with that id",
+          "http_status": 404
+        }
       ]
     },
     "column_delete": {
       "doc": "Delete a custom column. Its tasks are moved back to the built-in 'todo' column (never lost).",
       "scope": "hub",
-      "permission": { "src": "write" },
+      "permission": {
+        "src": "write"
+      },
       "params": {
-        "id": { "type": "string", "required": true, "doc": "Column id to delete" }
+        "id": {
+          "type": "string",
+          "required": true,
+          "doc": "Column id to delete"
+        }
       },
       "returns": {
         "type": "object",
         "doc": "Deletion summary",
         "properties": {
-          "id":          { "type": "string" },
-          "affected":    { "type": "number", "doc": "1 if the column existed" },
-          "moved_tasks": { "type": "number", "doc": "How many tasks were moved back to todo" }
+          "id": {
+            "type": "string"
+          },
+          "affected": {
+            "type": "number",
+            "doc": "1 if the column existed"
+          },
+          "moved_tasks": {
+            "type": "number",
+            "doc": "How many tasks were moved back to todo"
+          }
         }
       }
     }

--- a/acl/task.json
+++ b/acl/task.json
@@ -63,8 +63,7 @@
           "type": "string",
           "required": false,
           "default": "todo",
-          "enum": ["todo", "in_progress", "to_review", "complete"],
-          "doc": "Initial Kanban column. Defaults to todo."
+          "doc": "Initial Kanban column: a built-in key (todo | in_progress | to_review | complete) or a custom task_column id. Defaults to todo."
         },
         "priority": {
           "type": "string",
@@ -173,8 +172,7 @@
         "status": {
           "type": "string",
           "required": true,
-          "enum": ["todo", "in_progress", "to_review", "complete"],
-          "doc": "Destination Kanban column"
+          "doc": "Destination Kanban column: a built-in key (todo | in_progress | to_review | complete) or a custom task_column id"
         }
       },
       "returns": {
@@ -183,7 +181,7 @@
       },
       "errors": [
         { "code": "TASK_NOT_FOUND", "message": "No task found with the given ID", "http_status": 404 },
-        { "code": "INVALID_STATUS", "message": "status must be one of: todo, in_progress, to_review, complete", "http_status": 400 }
+        { "code": "INVALID_STATUS", "message": "status is neither a built-in column nor an existing custom column id", "http_status": 400 }
       ]
     },
     "update_assignee": {
@@ -504,6 +502,90 @@
           "id":       { "type": "string" },
           "task_id":  { "type": "string" },
           "affected": { "type": "number" }
+        }
+      }
+    },
+    "activity": {
+      "doc": "Recent task activity for a folder scope (Project Health feed): create / update / status / complete / assignee / link_file / comment events, newest first.",
+      "scope": "hub",
+      "permission": { "src": "read" },
+      "params": {
+        "nid": { "type": "string", "required": false, "doc": "Folder node id to scope to (mirrors task.list)" },
+        "include_unscoped": { "type": "number", "required": false, "default": 0, "doc": "When 1, also include legacy nid-less rows (workspace root)" },
+        "limit": { "type": "number", "required": false, "default": 30, "doc": "Max rows returned" }
+      },
+      "returns": {
+        "type": "array",
+        "doc": "Activity rows (task_id, actor_uid, action, meta, ctime, plus live task title/priority/status when the task still exists)"
+      }
+    },
+    "column_list": {
+      "doc": "List the custom Kanban columns for a folder scope. Built-in columns (todo / in_progress / to_review / complete) are implicit client-side and never stored.",
+      "scope": "hub",
+      "permission": { "src": "read" },
+      "params": {
+        "nid": { "type": "string", "required": false, "doc": "Folder node id to scope to (mirrors task.list)" }
+      },
+      "returns": {
+        "type": "array",
+        "doc": "Custom column rows in board order",
+        "items": {
+          "type": "object",
+          "properties": {
+            "id":       { "type": "string", "doc": "Column id — doubles as the task.status key for its tasks" },
+            "nid":      { "type": "string", "doc": "Folder node id, null at workspace root" },
+            "name":     { "type": "string", "doc": "User-entered column name" },
+            "theme":    { "type": "string", "doc": "Palette theme: default | orange | yellow | green | cyan | blue | purple | pink | red" },
+            "position": { "type": "number", "doc": "Board order among custom columns" },
+            "ctime":    { "type": "number" },
+            "mtime":    { "type": "number" }
+          }
+        }
+      }
+    },
+    "column_create": {
+      "doc": "Create a custom Kanban column for a folder scope.",
+      "scope": "hub",
+      "permission": { "src": "write" },
+      "params": {
+        "name":  { "type": "string", "required": true, "doc": "Column display name (1–100 chars)" },
+        "theme": { "type": "string", "required": false, "default": "default", "doc": "Palette theme key; invalid values fall back to default" },
+        "nid":   { "type": "string", "required": false, "doc": "Folder node id the column belongs to" }
+      },
+      "returns": { "type": "object", "doc": "The created column row" },
+      "errors": [
+        { "code": "INVALID_COLUMN_NAME", "message": "name is empty after trimming", "http_status": 400 }
+      ]
+    },
+    "column_update": {
+      "doc": "Rename and/or re-theme a custom column. Omit a field to keep it.",
+      "scope": "hub",
+      "permission": { "src": "write" },
+      "params": {
+        "id":    { "type": "string", "required": true, "doc": "Column id" },
+        "name":  { "type": "string", "required": false, "doc": "New display name" },
+        "theme": { "type": "string", "required": false, "doc": "New palette theme key" }
+      },
+      "returns": { "type": "object", "doc": "The updated column row" },
+      "errors": [
+        { "code": "INVALID_COLUMN_NAME", "message": "name is empty after trimming", "http_status": 400 },
+        { "code": "COLUMN_NOT_FOUND", "message": "No column with that id", "http_status": 404 }
+      ]
+    },
+    "column_delete": {
+      "doc": "Delete a custom column. Its tasks are moved back to the built-in 'todo' column (never lost).",
+      "scope": "hub",
+      "permission": { "src": "write" },
+      "params": {
+        "id": { "type": "string", "required": true, "doc": "Column id to delete" }
+      },
+      "returns": {
+        "type": "object",
+        "doc": "Deletion summary",
+        "properties": {
+          "id":          { "type": "string" },
+          "affected":    { "type": "number", "doc": "1 if the column existed" },
+          "moved_tasks": { "type": "number", "doc": "How many tasks were moved back to todo" }
         }
       }
     }

--- a/docs/superpowers/plans/2026-07-06-referral-code-account-settings.md
+++ b/docs/superpowers/plans/2026-07-06-referral-code-account-settings.md
@@ -1,0 +1,417 @@
+# Referral code in Account Settings → Profile — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a signed-in user view and copy their referral code + link from Account Settings → Profile.
+
+**Architecture:** A new authenticated `server-team` service (`drumate.get_referral_code`) reuses the reward-hub proc against the live reward DB and returns `{referral_code, referral_url}` with a per-tenant link. The `ui-team` Account Settings widget fetches it, stores it in the model, renders a referral section in the Profile skeleton, and copies values via `copyToClipboard`.
+
+**Tech Stack:** Node (drumee `@drumee/server-core` Entity services + MariaDB procs), webpack UI (`@drumee/ui-core` LetcBox widgets, `@drumee/ui-essentials`).
+
+## Global Constraints
+
+- Reward DB name comes from `reward_hub_conf.db_name` (`Cache.getSysConf('reward_hub_conf')`) — **never hardcode** `C_reward`.
+- Referral link = `${this.input.homepath()}#/welcome/signup?ref=<code>` (per-tenant homepath).
+- Referral code proc `reward_get_referral_code(uid)` is idempotent (get-or-create); call it with the authenticated `this.uid`.
+- One code per user (`user_referral_code.user_id` PK); code is 6 chars.
+- Copy uses `copyToClipboard` from `@drumee/ui-essentials` (as in `sharebox-setting`).
+- Deploy/verify against tenant `huan` on `drumee.in` (served at `https://drumee.in/-/huan/`); the reward DB there is what `reward_hub_conf.db_name` resolves to.
+
+---
+
+## File Structure
+
+**server-team**
+- `service/private/drumate.js` — add `get_referral_code()` method (+ import `Cache`, `toArray`).
+- `acl/drumate.json` — add `get_referral_code` ACL entry.
+
+**ui-team**
+- `src/drumee/lex/services.json` — map `drumate.get_referral_code`.
+- `src/drumee/builtins/widget/settings/account/index.js` — fetch + model + copy dispatch (+ import `copyToClipboard`).
+- `src/drumee/builtins/widget/settings/account/skeleton/profile.js` — referral section.
+- `src/drumee/builtins/widget/settings/account/skin/index.scss` — referral section styles.
+
+---
+
+## Task 1: Backend — `drumate.get_referral_code` service + ACL
+
+**Files:**
+- Modify: `server-team/service/private/drumate.js` (imports near line 22-24; add method in the class)
+- Modify: `server-team/acl/drumate.json` (services block)
+
+**Interfaces:**
+- Produces: service `drumate.get_referral_code` (POST/GET, `scope: hub`, `permission: owner`) → `{ referral_code: string, referral_url: string }` on success, or `{ error: string }` on failure.
+
+- [ ] **Step 1: Add imports**
+
+In `service/private/drumate.js`, the destructure from `@drumee/server-essentials` currently reads:
+```js
+const {
+  Messenger, DrumeeCache, RedisStore
+} = require("@drumee/server-essentials")
+```
+Change it to add `Cache` and `toArray`:
+```js
+const {
+  Messenger, DrumeeCache, RedisStore, Cache, toArray
+} = require("@drumee/server-essentials")
+```
+(If `Cache`/`toArray` are already present in this or another require line, don't duplicate — just ensure both are in scope.)
+
+- [ ] **Step 2: Add the `get_referral_code` method**
+
+Add this method inside the `class` in `service/private/drumate.js` (near `update_profile`):
+```js
+  /**
+   * Get or create the signed-in user's referral code + link.
+   * Reads the live reward DB from reward_hub_conf, calls the reward-hub
+   * proc (idempotent get-or-create), and builds a per-tenant referral link.
+   */
+  async get_referral_code() {
+    let rewardDb = null;
+    try {
+      rewardDb = JSON.parse(Cache.getSysConf('reward_hub_conf') || '{}').db_name;
+    } catch (e) {
+      rewardDb = null;
+    }
+    if (!rewardDb) {
+      return this.output.data({ error: 'reward_not_configured' });
+    }
+    let code = null;
+    try {
+      const rows = toArray(await this.yp.await_proc(`${rewardDb}.reward_get_referral_code`, this.uid));
+      code = (rows[0] || {}).referral_code || null;
+    } catch (e) {
+      this.warn('[drumate.get_referral_code] proc failed', e && e.message);
+      return this.output.data({ error: 'referral_unavailable' });
+    }
+    if (!code) {
+      return this.output.data({ error: 'referral_unavailable' });
+    }
+    const referral_url = `${this.input.homepath()}#/welcome/signup?ref=${encodeURIComponent(code)}`;
+    this.output.data({ referral_code: code, referral_url });
+  }
+```
+
+- [ ] **Step 3: Add the ACL entry**
+
+In `acl/drumate.json`, inside the `"services": { ... }` object, add:
+```json
+    "get_referral_code": {
+      "doc": "Get or create the signed-in user's referral code and link.",
+      "scope": "hub",
+      "permission": { "src": "owner" }
+    },
+```
+(Place it next to `update_profile`; ensure valid JSON — trailing commas only where the format allows.)
+
+- [ ] **Step 4: Syntax-check both files**
+
+Run:
+```bash
+cd /home/drumee/server-team
+node --check service/private/drumate.js && echo JS_OK
+node -e "JSON.parse(require('fs').readFileSync('acl/drumate.json','utf8')); console.log('JSON_OK')"
+```
+Expected: `JS_OK` and `JSON_OK`.
+
+- [ ] **Step 5: Deploy to huan and restart**
+
+The deployed copy lives under the endpoint runtime. Deploy the two files and restart the service:
+```bash
+DS=/srv/drumee/runtime/server/... # server-team deploy path for the huan endpoint
+```
+Determine the deployed server-team path for huan first:
+```bash
+ssh huan@drumee.in "sudo pm2 describe huan/service | grep -iE 'cwd|script path' "
+```
+Then copy the two edited files to that deployed tree (mirror the repo-relative paths `service/private/drumate.js` and `acl/drumate.json`) via `sudo tee`, and restart:
+```bash
+ssh huan@drumee.in "sudo drumee start huan/service && echo RESTARTED"
+```
+
+- [ ] **Step 6: Verify the code lands in the LIVE reward DB via the proc path**
+
+Confirm the live reward DB and that the proc get-or-creates for a real user (use a known uid, e.g. h0anghu7n = `1fe9136a1fe9137f`):
+```bash
+ssh huan@drumee.in "LIVE=\$(sudo mysql yp -N -e \"CALL get_sys_conf()\" | awk -F'\t' '/reward_hub_conf/{print \$2}' | sed -E 's/.*\"db_name\": *\"([^\"]+)\".*/\1/'); echo LIVE=\$LIVE; sudo mysql \$LIVE -e \"CALL reward_get_referral_code('1fe9136a1fe9137f')\""
+```
+Expected: prints `LIVE=c_...` and a `referral_code | status` row (`existing` or `generated`). A second run returns the **same** code (`existing`).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/drumee/server-team
+git checkout -b feat/referral-code-account-settings 2>/dev/null || git checkout feat/referral-code-account-settings
+git add service/private/drumate.js acl/drumate.json
+git commit -m "feat(drumate): add get_referral_code service (reward code + per-tenant link)
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Frontend — service mapping + fetch/copy wiring
+
+**Files:**
+- Modify: `ui-team/src/drumee/lex/services.json` (`drumate` block)
+- Modify: `ui-team/src/drumee/builtins/widget/settings/account/index.js`
+
+**Interfaces:**
+- Consumes: `drumate.get_referral_code` from Task 1.
+- Produces: model keys `referral_code`, `referral_url`, `referral_error` (read by Task 3's skeleton); `onUiEvent` cases `copy-referral-code` / `copy-referral-link`.
+
+- [ ] **Step 1: Map the service**
+
+In `src/drumee/lex/services.json`, inside the `"drumate": { ... }` object, add:
+```json
+    "get_referral_code": "drumate.get_referral_code",
+```
+Verify JSON:
+```bash
+cd /home/drumee/ui-team
+node -e "JSON.parse(require('fs').readFileSync('src/drumee/lex/services.json','utf8')); console.log('JSON_OK')"
+```
+Expected: `JSON_OK`.
+
+- [ ] **Step 2: Import `copyToClipboard`**
+
+At the very top of `builtins/widget/settings/account/index.js` (before the class declaration on line 5), add:
+```js
+const { copyToClipboard } = require("@drumee/ui-essentials");
+```
+
+- [ ] **Step 3: Add the `loadReferral` method**
+
+Add this method to the `settings_account` class (e.g. after `getApi()`):
+```js
+  /**
+   * Fetch the user's referral code/link once, store on the model, and
+   * re-render the Profile tab so the section fills in. POST (not GET) to
+   * avoid the browser HTTP-caching stale fetchService GETs.
+   */
+  async loadReferral() {
+    if (this._referralFetched) return;
+    this._referralFetched = true;
+    try {
+      const data = await this.postService(SERVICE.drumate.get_referral_code, {
+        hub_id: Visitor.id,
+      });
+      if (data && data.referral_code) {
+        this.mset({ referral_code: data.referral_code, referral_url: data.referral_url || "" });
+      } else {
+        this.mset({ referral_error: 1 });
+      }
+    } catch (e) {
+      this.warn("[account] get_referral_code failed", e);
+      this.mset({ referral_error: 1 });
+    }
+    if (this._page === 0 && this.__content) {
+      this.__content.feed(this.skeletons[0](this));
+    }
+  }
+```
+
+- [ ] **Step 4: Trigger the fetch on mount**
+
+In `onDomRefresh()` (currently lines 73-77), add the `loadReferral()` call after the feed:
+```js
+  onDomRefresh() {
+    this._page = 0;
+    this._category = "*";
+    this.feed(require("./skeleton").default(this));
+    this.loadReferral();
+  }
+```
+
+- [ ] **Step 5: Add copy dispatch cases**
+
+In `onUiEvent(cmd, args)`, inside the `switch (service)` block, add these cases (e.g. right before `case "manage-seats":`):
+```js
+      case "copy-referral-code": {
+        const v = this.mget("referral_code");
+        if (v) copyToClipboard(v);
+        return;
+      }
+
+      case "copy-referral-link": {
+        const v = this.mget("referral_url");
+        if (v) copyToClipboard(v);
+        return;
+      }
+```
+
+- [ ] **Step 6: Syntax-check**
+
+Run:
+```bash
+cd /home/drumee/ui-team
+node --check src/drumee/builtins/widget/settings/account/index.js && echo JS_OK
+```
+Expected: `JS_OK`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/drumee/ui-team
+git checkout -b feat/referral-code-account-settings 2>/dev/null || git checkout feat/referral-code-account-settings
+git add src/drumee/lex/services.json src/drumee/builtins/widget/settings/account/index.js
+git commit -m "feat(settings): fetch referral code + copy handlers in account widget
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Frontend — referral section in Profile + styles
+
+**Files:**
+- Modify: `ui-team/src/drumee/builtins/widget/settings/account/skeleton/profile.js`
+- Modify: `ui-team/src/drumee/builtins/widget/settings/account/skin/index.scss`
+
+**Interfaces:**
+- Consumes: model keys `referral_code`, `referral_url`, `referral_error` and `onUiEvent` cases from Task 2.
+
+- [ ] **Step 1: Add the `referral` section function**
+
+In `skeleton/profile.js`, add this function above `settings_body`:
+```js
+/**
+ * Referral section: shows the user's code + link, each with a copy button.
+ * Reads values from the widget model (populated by account.loadReferral()).
+ */
+function referral(ui) {
+  const fig = `${ui.fig.family}__referral`;
+  const code = ui.mget("referral_code");
+  const url = ui.mget("referral_url");
+  const errored = ui.mget("referral_error");
+
+  const row = (label, value, copyService) =>
+    Skeletons.Box.Y({
+      className: `${fig}-row`,
+      kids: [
+        Skeletons.Note({ className: `${fig}-label`, content: label }),
+        Skeletons.Box.X({
+          className: `${fig}-field`,
+          kids: [
+            Skeletons.Note({ className: `${fig}-value`, content: value || "Loading…", active: 0 }),
+            value
+              ? Skeletons.Box.X({
+                  className: `${fig}-copy`,
+                  service: copyService,
+                  uiHandler: [ui],
+                  kids: [Skeletons.Note({ className: `${fig}-copy-txt`, content: LOCALE.COPY || "Copy" })],
+                })
+              : null,
+          ],
+        }),
+      ],
+    });
+
+  return Skeletons.Box.Y({
+    className: `${fig}`,
+    kids: [
+      Skeletons.Note({ className: `${fig}-title`, content: "Invite & earn" }),
+      errored
+        ? Skeletons.Note({ className: `${fig}-muted`, content: "Referral not available yet" })
+        : Skeletons.Box.Y({
+            className: `${fig}-rows`,
+            kids: [
+              row("Referral code", code, "copy-referral-code"),
+              row("Referral link", url, "copy-referral-link"),
+            ],
+          }),
+    ],
+  });
+}
+```
+
+- [ ] **Step 2: Append the section to `settings_body`**
+
+Change `settings_body` (currently returns `[user(ui), spacer, form(ui)]`) to:
+```js
+function settings_body(ui) {
+  return [
+    user(ui),
+    Skeletons.Element({ className: `${ui.fig.family}__spacer` }),
+    form(ui),
+    Skeletons.Element({ className: `${ui.fig.family}__spacer` }),
+    referral(ui),
+  ];
+}
+```
+
+- [ ] **Step 3: Add styles**
+
+Append to `skin/index.scss` (use the widget's family prefix; match the file's existing selector style — the family is the same `&__…` root used by `__avatar`, `__spacer`, etc.):
+```scss
+  &__referral {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+
+    &-title { font-weight: 600; }
+    &-muted { opacity: 0.6; }
+    &-rows { display: flex; flex-direction: column; gap: 10px; }
+    &-row { display: flex; flex-direction: column; gap: 4px; }
+    &-label { font-size: 12px; opacity: 0.7; }
+    &-field {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      justify-content: space-between;
+    }
+    &-value {
+      font-family: monospace;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    &-copy {
+      cursor: pointer;
+      padding: 4px 10px;
+      border-radius: 6px;
+      background: rgba(83, 74, 183, 0.1);
+      white-space: nowrap;
+    }
+  }
+```
+(Nest it under the same root selector block that holds `&__avatar` / `&__spacer` in this file. If those live at the top level rather than nested, add `.<family>__referral { … }` as a top-level rule mirroring the existing pattern — inspect the file first and follow whatever nesting it already uses.)
+
+- [ ] **Step 4: Build & deploy the UI (one-shot)**
+
+ui-team uses the same tooling as analytics-ui. `drumee-ui-deploy devel` sources `.dev-tools.rc/devel.sh` (targets `drumee.in`, `BUILD_TARGET=app`, `UI_RUNTIME_PATH=/srv/drumee/runtime/ui/<user>/`), builds via webpack, and rsyncs to the endpoint. Run a one-shot build+deploy (webpack must be on PATH; `NO_WATCH=1` disables watch mode):
+```bash
+cd /home/drumee/ui-team
+export PATH="$PWD/node_modules/.bin:$PATH"
+rm -f /tmp/home-drumee-ui-team-drumee-ui-deploy.pid 2>/dev/null
+NO_WATCH=1 drumee-ui-deploy devel 2>&1 | tail -20
+```
+Expected: `webpack … compiled successfully` and `Done!` (the sync step). This rebuilds and deploys the **whole desk app** for the endpoint — heavier than a plugin build; confirm no webpack errors.
+> If `devel.sh` references an unset `$user`, set the endpoint first (e.g. `export user=huan`) or use the repo's normal `npm run dev` watch flow; confirm `UI_RUNTIME_PATH` resolves to `/srv/drumee/runtime/ui/huan/`.
+
+- [ ] **Step 5: Verify end-to-end (manual)**
+
+1. Load `https://drumee.in/-/huan/`, open **Account Settings → Profile** (hard-refresh once to bypass any cached bundle).
+2. Confirm the **Invite & earn** section shows a **Referral code** and a **Referral link** whose domain is `drumee.in/-/huan/…` (not `app.drumee.org`).
+3. Click each **Copy** button and paste elsewhere — verify the code / link copy correctly.
+4. Confirm the link is `https://drumee.in/-/huan/#/welcome/signup?ref=<code>` and that `<code>` matches the row in the live reward DB (`user_referral_code`) for your uid.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd /home/drumee/ui-team
+git add src/drumee/builtins/widget/settings/account/skeleton/profile.js src/drumee/builtins/widget/settings/account/skin/index.scss
+git commit -m "feat(settings): referral code + link section in account Profile
+
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Notes for the implementer
+
+- **No unit-test harness** exists for these service/UI files in this codebase; verification is integration/manual (proc call, service deploy, UI load), as reflected in the steps.
+- The reward proc runs against the **live** reward DB resolved at runtime — do not hardcode a DB name.
+- If `copyToClipboard` isn't exported by the installed `@drumee/ui-essentials`, use the same copy mechanism `sharebox-setting/index.js` uses (import it the same way that file does).
+- Server-team deploy path for `huan` is under `/srv/drumee/runtime/server/…`; confirm via `pm2 describe huan/service` before copying files.

--- a/docs/superpowers/specs/2026-07-06-referral-code-account-settings-design.md
+++ b/docs/superpowers/specs/2026-07-06-referral-code-account-settings-design.md
@@ -1,0 +1,137 @@
+# Get referral code in Account Settings → Profile
+
+**Date:** 2026-07-06
+**Repos:** `server-team` (backend service), `ui-team` (Account Settings UI)
+**Status:** Approved design — pending spec review
+
+## Goal
+
+Let a signed-in user see and copy their own referral code and referral link
+from **Account Settings → Profile**, without opening the Reward Hub.
+
+## Background
+
+- The referral code lives in the live per-hub reward DB (`reward_hub_conf.db_name`,
+  e.g. `c_67c9b37e67c9b37f`), table `user_referral_code` (PK `user_id`,
+  `referral_code` UNIQUE), created/read by the proc `reward_get_referral_code(uid)`
+  (idempotent: returns the existing code or generates a unique 6-char one).
+- The referral link is `<homepath>#/welcome/signup?ref=<code>`. Signups via this
+  link get `profile.$.ref = <code>`, which the analytics dashboard attributes.
+- The existing reward-hub-ui builds the displayed link with a **hardcoded**
+  `app.drumee.org` domain (it ignores the server's `referral_url`). This feature
+  uses `input.homepath()` server-side so the link carries the correct per-tenant
+  domain.
+
+## Non-goals (YAGNI)
+
+- No referral **stats** (clicks/signups) in this surface.
+- No new Settings tab (section lives inside the existing Profile tab).
+- No changes to reward-hub-server / reward-hub-ui.
+
+## Backend — `server-team`
+
+**New authenticated service `drumate.get_referral_code`** in
+`service/private/drumate.js`:
+
+```js
+async get_referral_code() {
+  let rewardDb;
+  try { rewardDb = JSON.parse(Cache.getSysConf('reward_hub_conf') || '{}').db_name; } catch (e) {}
+  if (!rewardDb) return this.output.data({ error: 'reward_not_configured' });
+  const rows = toArray(await this.yp.await_proc(`${rewardDb}.reward_get_referral_code`, this.uid));
+  const code = (rows[0] || {}).referral_code;
+  if (!code) return this.output.data({ error: 'referral_unavailable' });
+  const referral_url = `${this.input.homepath()}#/welcome/signup?ref=${encodeURIComponent(code)}`;
+  this.output.data({ referral_code: code, referral_url });
+}
+```
+
+- `this.uid` = the authenticated user (the referrer/owner).
+- Calls the reward proc by qualified name against the live reward DB; reuses its
+  idempotent get-or-create behavior (no code duplication).
+- Requires `Cache` and `toArray` from `@drumee/server-essentials` (add to imports
+  if not already present in the file).
+
+**ACL** — add to `acl/drumate.json`:
+
+```json
+"get_referral_code": {
+  "doc": "Get or create the signed-in user's referral code and link.",
+  "scope": "hub",
+  "permission": { "src": "owner" }
+}
+```
+
+## Frontend — `ui-team`
+
+1. **Service map** — add under `drumate` in `src/drumee/lex/services.json`:
+   `"get_referral_code": "drumate.get_referral_code"`.
+
+2. **`builtins/widget/settings/account/index.js`**
+   - On Profile load, fetch `SERVICE.drumate.get_referral_code`
+     (`{ service, hub_id: Visitor.id }`).
+   - On success: `this.mset({ referral_code, referral_url })` and re-render the
+     Profile tab so the section shows the values.
+   - Copy buttons use the established desk pattern: `copyToClipboard` from
+     `@drumee/ui-essentials`, invoked from the widget's `declareHandlers` switch
+     (e.g. `case 'copy-referral-code': copyToClipboard(this.mget('referral_code'))`,
+     `case 'copy-referral-link': copyToClipboard(this.mget('referral_url'))`), as
+     done in `sharebox-setting`.
+
+3. **`builtins/widget/settings/account/skeleton/profile.js`**
+   - Add a `referral(ui)` section appended to `settings_body(ui)` after `form(ui)`.
+   - Two rows: **Referral code** (`ui.mget("referral_code")`) and
+     **Referral link** (`ui.mget("referral_url")`), each with a copy button.
+   - Fallback text "Loading…" until the values arrive; if the fetch returned
+     `{error}`, render a muted "Referral not available yet" line instead of the rows.
+
+4. **Styles / locale**
+   - Add referral-section styles to `builtins/widget/settings/account/skin/index.scss`.
+   - Add a LOCALE label (e.g. `REFERRAL` / "Invite & earn") — or reuse a literal if
+     no locale key is warranted.
+
+## Data flow
+
+```
+Profile tab render
+  → account/index.js fetch SERVICE.drumate.get_referral_code {hub_id}
+  → server: JSON.parse(reward_hub_conf).db_name
+           → CALL <rewardDb>.reward_get_referral_code(this.uid)   (get-or-create)
+           → { referral_code, referral_url:`${homepath}#/welcome/signup?ref=<code>` }
+  → mset(model) → profile.js renders code + link rows with copy buttons
+```
+
+## Error handling
+
+- Reward hub not configured (`reward_hub_conf` missing / no `db_name`) → server
+  returns `{ error: 'reward_not_configured' }`.
+- Proc returns no code → `{ error: 'referral_unavailable' }`.
+- UI: on any `error` (or missing `referral_code`), render the muted
+  "Referral not available yet" line — never crash, never show a broken link.
+- Copy: `copyToClipboard(value)`; guarded to no-op when the value is empty.
+
+## Testing / verification
+
+- Server: call `drumate.get_referral_code` as an authenticated user; assert it
+  returns `{ referral_code, referral_url }`, that the code appears in the live
+  reward DB's `user_referral_code`, and that a second call returns the **same**
+  code (idempotent).
+- Link correctness: `referral_url` uses the tenant homepath
+  (`https://drumee.in/-/huan/#/welcome/signup?ref=<code>`), not `app.drumee.org`.
+- UI: Profile tab shows the code + link; copy buttons copy the right values;
+  error state renders gracefully when reward hub is unconfigured.
+- Round-trip: signing up via the shown link sets `profile.$.ref` and the code
+  resolves to this user's email in the analytics "Referred by" column.
+
+## Files touched
+
+**server-team**
+- `service/private/drumate.js` — add `get_referral_code()` (+ imports if needed)
+- `acl/drumate.json` — add ACL entry
+
+**ui-team**
+- `src/drumee/lex/services.json` — add service mapping
+- `src/drumee/builtins/widget/settings/account/index.js` — fetch + model + re-render
+- `src/drumee/builtins/widget/settings/account/skeleton/profile.js` — referral section
+- `src/drumee/builtins/widget/settings/account/skin/index.scss` — styles
+- locale file — referral label (if a key is added)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.80",
+  "version": "2.9.81",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.80",
+      "version": "2.9.81",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.79",
+  "version": "2.9.80",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.79",
+      "version": "2.9.80",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.81",
+  "version": "2.9.82",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.81",
+      "version": "2.9.82",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.80",
+  "version": "2.9.81",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.79",
+  "version": "2.9.80",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.81",
+  "version": "2.9.82",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/private/activity.js
+++ b/service/private/activity.js
@@ -311,6 +311,7 @@ class MfsActivity extends Entity {
       if (r.task_title == null) r.task_title = meta.title || '';
       if (r.task_nid == null) r.task_nid = meta.nid || null;
       if (r.task_hub_id == null) r.task_hub_id = meta.hub_id || null;
+      if (r.task_id == null) r.task_id = meta.task_id || null;
     }
 
     this.output.list(result);

--- a/service/private/activity.js
+++ b/service/private/activity.js
@@ -66,6 +66,26 @@ function mapNotificationRow(r) {
   return item;
 }
 
+// Surface task-assignment fields (title/nid/hub_id/task_id) at the top level from
+// the nested contact_activity `data` JSON, so the client renders "assigned you to
+// <task>" and navigates to the task without relying on the nested JSON surviving
+// the LETC model. Idempotent; only touches task_assigned rows.
+function flattenTaskAssigned(rows) {
+  for (const r of rows) {
+    if (!r || r.event !== 'task_assigned') continue;
+    let meta = r.data;
+    if (typeof meta === 'string') {
+      try { meta = JSON.parse(meta); } catch (e) { meta = null; }
+    }
+    meta = meta || {};
+    if (r.task_title == null) r.task_title = meta.title || '';
+    if (r.task_nid == null) r.task_nid = meta.nid || null;
+    if (r.task_hub_id == null) r.task_hub_id = meta.hub_id || null;
+    if (r.task_id == null) r.task_id = meta.task_id || null;
+  }
+  return rows;
+}
+
 class MfsActivity extends Entity {
 
 
@@ -278,43 +298,36 @@ class MfsActivity extends Entity {
       }
     }
 
-    // Task-assignment notifications ("{creator} assigned you to {task}"). Under
-    // Unread ON the base feed is mfs_get_activity_feed (MFS-only), so an
-    // assignment would be invisible until the user toggled Unread OFF. Merge the
-    // caller's UNDISMISSED task_assigned rows into the unread feed so it shows in
-    // the default view — mirroring the secure_share_open_feed merge above. Under
-    // Unread OFF, activity_get_feed_all already returns them (read + unread), so
-    // only merge for the unread view to avoid duplicates. Best-effort.
-    if (unreadOnly && filter !== 'mentions' && filter !== 'shares' && page <= 1) {
-      try {
-        const assigned = toArray(await this.yp.await_proc('contact_task_assigned_unread', this.uid));
-        for (const r of assigned) {
-          if (r) result.push(r);
-        }
-        result.sort((a, b) => (Number(b.timestamp || b.ctime || 0) - Number(a.timestamp || a.ctime || 0)));
-      } catch (e) {
-        this.warn('[ACTIVITY] contact_task_assigned_unread merge failed', e && e.message);
-      }
-    }
-
-    // Surface task-assignment fields at the top level so the client renders the
-    // task title and navigates to the tracker without depending on the nested
-    // `data` JSON surviving the LETC model. Applies to both the unread-merge rows
-    // and the activity_get_feed_all (Unread OFF) rows.
-    for (const r of result) {
-      if (!r || r.event !== 'task_assigned') continue;
-      let meta = r.data;
-      if (typeof meta === 'string') {
-        try { meta = JSON.parse(meta); } catch (e) { meta = null; }
-      }
-      meta = meta || {};
-      if (r.task_title == null) r.task_title = meta.title || '';
-      if (r.task_nid == null) r.task_nid = meta.nid || null;
-      if (r.task_hub_id == null) r.task_hub_id = meta.hub_id || null;
-      if (r.task_id == null) r.task_id = meta.task_id || null;
-    }
+    // Flatten task-assignment fields onto the Unread-OFF feed rows (from
+    // activity_get_feed_all) so the client renders "assigned you to <task>" and
+    // can open the task. Unread-ON visibility is handled by the pinned badge
+    // merge (list_task_assignments) — NOT by merging into this feed, which would
+    // double-show the row (pinned + feed) under Unread ON.
+    flattenTaskAssigned(result);
 
     this.output.list(result);
+  }
+
+  /**
+   * List the caller's UNDISMISSED task-assignment notifications for the pinned
+   * activity section + bell badge (mirrors how task @-mentions are surfaced).
+   * Rows come from contact_task_assigned_unread (shaped like
+   * activity_get_feed_all's contact branch); task fields are flattened so the
+   * item renders "assigned you to <task>" and the click opens the task. The
+   * panel merges these into its unread `merged` list so an assignment shows —
+   * and bumps the badge — even while the panel is closed.
+   * Endpoint: POST /activity.list_task_assignments
+   */
+  async list_task_assignments() {
+    let rows = [];
+    try {
+      rows = toArray(await this.yp.await_proc('contact_task_assigned_unread', this.uid));
+    } catch (e) {
+      this.warn('[ACTIVITY] contact_task_assigned_unread failed', e && e.message);
+      return this.output.list([]);
+    }
+    flattenTaskAssigned(rows);
+    this.output.list(rows);
   }
 
 

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -1906,6 +1906,7 @@ class __private_channel extends Entity {
             `SELECT ca.id, ca.timestamp AS ctime, ca.uid AS author_id,
               JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.task_id')) AS task_id,
               JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.hub_id')) AS hub_id,
+              JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.nid')) AS nid,
               JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.title')) AS name,
               CONCAT('["', ca.target_uid, '"]') AS mention_ids,
               COALESCE(CONCAT(d.firstname, ' ', d.lastname), d.email, '') AS fullname,

--- a/service/private/drumate.js
+++ b/service/private/drumate.js
@@ -20,7 +20,7 @@ const { resolve } = require('path');
 const { isEmpty, isArray } = require('lodash');
 const {
   Attr, toArray, Remit, Constants, sendSms,
-  Messenger, DrumeeCache, RedisStore
+  Messenger, DrumeeCache, RedisStore, Cache
 } = require("@drumee/server-essentials")
 
 const {
@@ -435,7 +435,37 @@ class __private_drumate extends Entity {
   }
 
   /**
-   * 
+   * Get or create the signed-in user's referral code + link.
+   * Reads the live reward DB from reward_hub_conf, calls the reward-hub
+   * proc (idempotent get-or-create), and builds a per-tenant referral link.
+   */
+  async get_referral_code() {
+    let rewardDb = null;
+    try {
+      rewardDb = JSON.parse(Cache.getSysConf('reward_hub_conf') || '{}').db_name;
+    } catch (e) {
+      rewardDb = null;
+    }
+    if (!rewardDb) {
+      return this.output.data({ error: 'reward_not_configured' });
+    }
+    let code = null;
+    try {
+      const rows = toArray(await this.yp.await_proc(`${rewardDb}.reward_get_referral_code`, this.uid));
+      code = (rows[0] || {}).referral_code || null;
+    } catch (e) {
+      this.warn('[drumate.get_referral_code] proc failed', e && e.message);
+      return this.output.data({ error: 'referral_unavailable' });
+    }
+    if (!code) {
+      return this.output.data({ error: 'referral_unavailable' });
+    }
+    const referral_url = `${this.input.homepath()}#/welcome/signup?ref=${encodeURIComponent(code)}`;
+    this.output.data({ referral_code: code, referral_url });
+  }
+
+  /**
+   *
    */
   async get_settings() {
     const user_id = this.input.need(Attr.user_id);

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 const {
-  Attr, Cache, Messenger, RedisStore, toArray
+  Attr, Cache, Messenger, RedisStore, toArray, sysEnv
 } = require('@drumee/server-essentials');
 const { Mfs } = require('@drumee/server-core');
 const { isEmpty } = require('lodash');
@@ -102,8 +102,7 @@ class __secure_share extends Mfs {
       return this.output.data({ status: 'CREATE_FAILED' });
     }
 
-    const host = this.hub.get(Attr.vhost);
-    const link = `${this.input.homepath(host)}#/dmz/share/${token}`;
+    const link = `${this._shareLinkBase()}#/dmz/share/${token}`;
 
     // Send invitation email only when sharing with exactly one named recipient (not domain, not public)
     const singleEmail = allowedEmails && allowedEmails.length === 1
@@ -141,13 +140,29 @@ class __secure_share extends Mfs {
   }
 
   /**
+   * Base URL for every share link. Anchored to the neutral share host
+   * (share.<main_domain>) instead of the content workspace's vhost, so links no
+   * longer leak the workspace name. Safe because a share resolves 100% by token
+   * (dmz.login → secure_share_info) AND the recipient FE pins the content hub_id
+   * on every DMZ request (ui @drumee/ui-essentials defaultPayload patch), so the
+   * neutral connect host never mis-resolves the hub. The neutral host itself needs
+   * no dedicated hub — bootstrap get_env falls back to the default hub.
+   * homepath() supplies the per-endpoint scheme + mount path (/-/, /-/preview/…).
+   * Single source of truth — used by create(), list() and access_list().
+   */
+  _shareLinkBase() {
+    const { main_domain } = sysEnv();
+    return this.input.homepath(`share.${main_domain}`);
+  }
+
+  /**
    * List all secure share tokens created by the current user for a given node.
    */
   async list() {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
     const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
-    const base   = this.input.homepath(this.hub.get(Attr.vhost));
+    const base   = this._shareLinkBase();
     this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 
@@ -312,7 +327,7 @@ class __secure_share extends Mfs {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
     const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
-    const base   = this.input.homepath(this.hub.get(Attr.vhost));
+    const base   = this._shareLinkBase();
     this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 const {
-  Attr, Cache, Messenger, RedisStore, toArray, sysEnv
+  Attr, Cache, Messenger, RedisStore, toArray
 } = require('@drumee/server-essentials');
 const { Mfs } = require('@drumee/server-core');
 const { isEmpty } = require('lodash');
@@ -102,7 +102,8 @@ class __secure_share extends Mfs {
       return this.output.data({ status: 'CREATE_FAILED' });
     }
 
-    const link = `${this._shareLinkBase()}#/dmz/share/${token}`;
+    const host = this.hub.get(Attr.vhost);
+    const link = `${this.input.homepath(host)}#/dmz/share/${token}`;
 
     // Send invitation email only when sharing with exactly one named recipient (not domain, not public)
     const singleEmail = allowedEmails && allowedEmails.length === 1
@@ -140,27 +141,13 @@ class __secure_share extends Mfs {
   }
 
   /**
-   * Base URL for every share link. Anchored to the neutral share host
-   * (share.<main_domain>) instead of the content workspace's vhost, so links no
-   * longer leak the workspace name. Safe because a share resolves 100% by token
-   * (dmz.login → secure_share_info), and the neutral host bootstraps via the
-   * default-hub fallback (_initHub → _default_hub; no dedicated hub required).
-   * homepath() supplies the correct per-endpoint scheme + mount path (/-/, /-/preview/…).
-   * Single source of truth — used by create(), list() and access_list().
-   */
-  _shareLinkBase() {
-    const { main_domain } = sysEnv();
-    return this.input.homepath(`share.${main_domain}`);
-  }
-
-  /**
    * List all secure share tokens created by the current user for a given node.
    */
   async list() {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
     const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
-    const base   = this._shareLinkBase();
+    const base   = this.input.homepath(this.hub.get(Attr.vhost));
     this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 
@@ -325,7 +312,7 @@ class __secure_share extends Mfs {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
     const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
-    const base   = this._shareLinkBase();
+    const base   = this.input.homepath(this.hub.get(Attr.vhost));
     this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 const {
-  Attr, Cache, Messenger, RedisStore, toArray
+  Attr, Cache, Messenger, RedisStore, toArray, sysEnv
 } = require('@drumee/server-essentials');
 const { Mfs } = require('@drumee/server-core');
 const { isEmpty } = require('lodash');
@@ -102,8 +102,7 @@ class __secure_share extends Mfs {
       return this.output.data({ status: 'CREATE_FAILED' });
     }
 
-    const host = this.hub.get(Attr.vhost);
-    const link = `${this.input.homepath(host)}#/dmz/share/${token}`;
+    const link = `${this._shareLinkBase()}#/dmz/share/${token}`;
 
     // Send invitation email only when sharing with exactly one named recipient (not domain, not public)
     const singleEmail = allowedEmails && allowedEmails.length === 1
@@ -141,13 +140,27 @@ class __secure_share extends Mfs {
   }
 
   /**
+   * Base URL for every share link. Anchored to the neutral share host
+   * (share.<main_domain>) instead of the content workspace's vhost, so links no
+   * longer leak the workspace name. Safe because a share resolves 100% by token
+   * (dmz.login → secure_share_info), and the neutral host bootstraps via the
+   * default-hub fallback (_initHub → _default_hub; no dedicated hub required).
+   * homepath() supplies the correct per-endpoint scheme + mount path (/-/, /-/preview/…).
+   * Single source of truth — used by create(), list() and access_list().
+   */
+  _shareLinkBase() {
+    const { main_domain } = sysEnv();
+    return this.input.homepath(`share.${main_domain}`);
+  }
+
+  /**
    * List all secure share tokens created by the current user for a given node.
    */
   async list() {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
     const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
-    const base   = this.input.homepath(this.hub.get(Attr.vhost));
+    const base   = this._shareLinkBase();
     this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 
@@ -312,7 +325,7 @@ class __secure_share extends Mfs {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
     const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
-    const base   = this.input.homepath(this.hub.get(Attr.vhost));
+    const base   = this._shareLinkBase();
     this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -71,7 +71,14 @@ class __private_task extends Entity {
     if (isEmpty(uids)) return;
     const hub_id = this.hub && this.hub.get(Attr.id);
     const task_id = data && data.id;
-    const meta = { task_id, hub_id, title: (data && data.title) || '' };
+    // `nid` lets the notification click open the task's folder on its Task tab;
+    // it is null for legacy/workspace-level tasks (opens the workspace root).
+    const meta = {
+      task_id,
+      hub_id,
+      title: (data && data.title) || '',
+      nid: (data && data.nid) || null,
+    };
     for (const target_uid of uids) {
       try {
         await this.yp.await_proc(

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -19,8 +19,14 @@ const { Attr, RedisStore, toArray } = require('@drumee/server-essentials');
 const { isEmpty } = require('lodash');
 const { Entity } = require('@drumee/server-core');
 
+// Built-in Kanban columns. Custom columns live in the task_column table and
+// use their row id as the task.status key — see _isValidStatus().
 const VALID_STATUSES = ['todo', 'in_progress', 'to_review', 'complete'];
 const VALID_PRIORITIES = ['low', 'medium', 'high', 'urgent'];
+const VALID_THEMES = [
+  'default', 'orange', 'yellow', 'green', 'cyan',
+  'blue', 'purple', 'pink', 'red',
+];
 
 class __private_task extends Entity {
 
@@ -44,6 +50,21 @@ class __private_task extends Entity {
     this.comment_update = this.comment_update.bind(this);
     this.comment_delete = this.comment_delete.bind(this);
     this.comment_react = this.comment_react.bind(this);
+    this.column_list = this.column_list.bind(this);
+    this.column_create = this.column_create.bind(this);
+    this.column_update = this.column_update.bind(this);
+    this.column_delete = this.column_delete.bind(this);
+  }
+
+  /**
+   * A status key is valid when it's one of the built-in columns or the id of
+   * an existing custom column (task_column row) in this hub.
+   */
+  async _isValidStatus(status) {
+    if (VALID_STATUSES.includes(status)) return true;
+    if (!status || !/^[A-Za-z0-9_-]{1,32}$/.test(status)) return false;
+    const col = await this.db.await_proc('task_column_get', status);
+    return !isEmpty(col);
   }
 
   /**
@@ -243,7 +264,7 @@ class __private_task extends Entity {
     const assignees = (await this._validateAssignees(this._readAssignees() || []));
     if (assignees == null) return; // invalid assignee — exception already raised
 
-    if (!VALID_STATUSES.includes(status)) status = 'todo';
+    if (!(await this._isValidStatus(status))) status = 'todo';
     if (!VALID_PRIORITIES.includes(priority)) priority = 'medium';
 
     const id = await this.yp.await_func('uniqueId');
@@ -301,13 +322,14 @@ class __private_task extends Entity {
 
   /**
    * Move a task to a different Kanban column.
-   * Params: id (required), status (required — todo|in_progress|to_review|complete)
+   * Params: id (required), status (required — a built-in column key or a
+   * custom task_column id)
    */
   async update_status() {
     const id = this.input.need(Attr.id);
     let status = this.input.need(Attr.status);
 
-    if (!VALID_STATUSES.includes(status)) {
+    if (!(await this._isValidStatus(status))) {
       return this.exception.user('INVALID_STATUS');
     }
 
@@ -580,6 +602,81 @@ class __private_task extends Entity {
       comment_id,
       emoji,
       count: row && row.count,
+    });
+    this.output.data(row);
+  }
+
+  /**
+   * List the custom Kanban columns for a folder scope.
+   * Params: nid (folder node id; null/absent = workspace root scope).
+   * Built-in columns (todo/in_progress/to_review/complete) are implicit
+   * client-side and never stored.
+   */
+  async column_list() {
+    const nid = this.input.use('nid', null);
+    const data = await this.db.await_run('CALL task_column_list(?)', [nid]);
+    this.output.list(data);
+  }
+
+  /**
+   * Create a custom Kanban column.
+   * Params: name (required), theme (palette key, optional), nid (folder scope).
+   * The new column's id becomes the task.status key for tasks placed in it.
+   */
+  async column_create() {
+    const name = String(this.input.need('name')).trim().slice(0, 100);
+    if (!name) return this.exception.user('INVALID_COLUMN_NAME');
+    let theme = this.input.use('theme', 'default');
+    if (!VALID_THEMES.includes(theme)) theme = 'default';
+    const nid = this.input.use('nid', null);
+
+    const id = await this.yp.await_func('uniqueId');
+    const data = await this.db.await_run(
+      'CALL task_column_create(?, ?, ?, ?)',
+      [id, nid, name, theme]
+    );
+    await this._broadcast('task.column_create', data);
+    this.output.data(data);
+  }
+
+  /**
+   * Rename and/or re-theme a custom column.
+   * Params: id (required); name / theme (optional — omit to keep).
+   */
+  async column_update() {
+    const id = this.input.need(Attr.id);
+    let name = this.input.use('name', null);
+    if (name != null) {
+      name = String(name).trim().slice(0, 100);
+      if (!name) return this.exception.user('INVALID_COLUMN_NAME');
+    }
+    let theme = this.input.use('theme', null);
+    if (theme != null && !VALID_THEMES.includes(theme)) theme = 'default';
+
+    const data = await this.db.await_run(
+      'CALL task_column_update(?, ?, ?)',
+      [id, name, theme]
+    );
+    if (isEmpty(data)) {
+      return this.exception.user('COLUMN_NOT_FOUND');
+    }
+    await this._broadcast('task.column_update', data);
+    this.output.data(data);
+  }
+
+  /**
+   * Delete a custom column. Its tasks are moved back to the built-in 'todo'
+   * column by the proc (never lost); the response carries moved_tasks so the
+   * client re-fetches its task list when non-zero.
+   */
+  async column_delete() {
+    const id = this.input.need(Attr.id);
+    const data = await this.db.await_proc('task_column_delete', id);
+    const row = Array.isArray(data) ? data[0] : data;
+    await this._broadcast('task.column_delete', {
+      id,
+      affected: row && row.affected,
+      moved_tasks: row && row.moved_tasks,
     });
     this.output.data(row);
   }

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -683,6 +683,13 @@ class __private_task extends Entity {
       'CALL task_column_create(?, ?, ?, ?)',
       [id, nid, name, theme]
     );
+    // The DB layer swallows SQL errors (returns empty) — an empty result here
+    // means the insert didn't happen, most likely because this hub DB has not
+    // been migrated (task_column table / procs missing). Fail loudly instead
+    // of acking success with no data.
+    if (isEmpty(data)) {
+      return this.exception.user('COLUMN_CREATE_FAILED');
+    }
     await this._broadcast('task.column_create', data);
     this.output.data(data);
   }

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -50,6 +50,7 @@ class __private_task extends Entity {
     this.comment_update = this.comment_update.bind(this);
     this.comment_delete = this.comment_delete.bind(this);
     this.comment_react = this.comment_react.bind(this);
+    this.activity = this.activity.bind(this);
     this.column_list = this.column_list.bind(this);
     this.column_create = this.column_create.bind(this);
     this.column_update = this.column_update.bind(this);
@@ -185,6 +186,39 @@ class __private_task extends Entity {
   }
 
   /**
+   * Append a row to the folder-scoped task activity feed (Project Health).
+   * Best-effort: a logging failure must never break the mutation it follows.
+   * For deletions call BEFORE the row is removed (the proc snapshots task.nid).
+   */
+  async _logActivity(task_id, action, meta = {}) {
+    try {
+      await this.db.await_run('CALL task_activity_log(?, ?, ?, ?)', [
+        task_id,
+        this.uid,
+        action,
+        JSON.stringify(meta || {}),
+      ]);
+    } catch (e) {
+      this.warn('[task._logActivity] failed:', e && e.message);
+    }
+  }
+
+  /**
+   * Recent activity feed for a folder scope (Project Health view).
+   * Params: nid, include_unscoped (mirror task.list), limit (default 30).
+   */
+  async activity() {
+    const nid = this.input.use('nid', null);
+    const include_unscoped = this.input.use('include_unscoped', 0) ? 1 : 0;
+    const limit = Number(this.input.use('limit', 30)) || 30;
+    const data = await this.db.await_run(
+      'CALL task_activity_list(?, ?, ?)',
+      [nid, include_unscoped, limit]
+    );
+    this.output.list(data);
+  }
+
+  /**
    * List tasks scoped to a folder node.
    * Params: nid (folder node id; null/absent = legacy unscoped), include_unscoped
    * (1 on the workspace-root view to also surface legacy nid-less tasks).
@@ -282,6 +316,7 @@ class __private_task extends Entity {
         [id, assignees.join(',')]
       );
     }
+    await this._logActivity(id, 'create', { title });
     await this._broadcast('task.create', data);
     // Every tagged member is newly mentioned on create.
     await this._notifyMentions(data, this.input.use('mention_uids', null));
@@ -314,6 +349,8 @@ class __private_task extends Entity {
     if (isEmpty(data)) {
       return this.exception.user('TASK_NOT_FOUND');
     }
+    const row = Array.isArray(data) ? data[0] : data;
+    await this._logActivity(id, 'update', { title: row && row.title });
     await this._broadcast('task.update', data);
     // Client sends only the newly-added mentions in `mention_uids`.
     await this._notifyMentions(data, this.input.use('mention_uids', null));
@@ -337,6 +374,12 @@ class __private_task extends Entity {
     if (isEmpty(data)) {
       return this.exception.user('TASK_NOT_FOUND');
     }
+    const row = Array.isArray(data) ? data[0] : data;
+    await this._logActivity(
+      id,
+      status === 'complete' ? 'complete' : 'status',
+      { title: row && row.title, status },
+    );
     await this._broadcast('task.update_status', data);
     this.output.data(data);
   }
@@ -373,6 +416,7 @@ class __private_task extends Entity {
     if (isEmpty(data)) {
       return this.exception.user('TASK_NOT_FOUND');
     }
+    await this._logActivity(id, 'assignee', {});
     await this._broadcast('task.update_assignee', data);
     // Notify only members added by this change (self excluded in _notifyAssignees).
     const added = assignees.filter((u) => !prior.has(String(u)));
@@ -386,6 +430,8 @@ class __private_task extends Entity {
    */
   async delete() {
     const id = this.input.need(Attr.id);
+    // Log BEFORE the delete — task_activity_log snapshots the task's nid/title.
+    await this._logActivity(id, 'update', { deleted: 1 });
     const data = await this.db.await_proc('task_delete', id);
     const result = { id, ...data };
     await this._broadcast('task.delete', result);
@@ -406,6 +452,7 @@ class __private_task extends Entity {
       file_nid,
       this.uid
     );
+    await this._logActivity(task_id, 'link_file', {});
     await this._broadcast('task.link_file', { task_id, files: data });
     this.output.list(data);
   }
@@ -537,6 +584,7 @@ class __private_task extends Entity {
       [id, task_id, this.uid, parent_id, body]
     );
     const row = Array.isArray(data) ? data[0] : data;
+    await this._logActivity(task_id, 'comment', {});
     await this._broadcast('task.comment_create', row);
     // Notify @-mentioned members; on a reply, also notify the parent author.
     let notify = toArray(this.input.use('mention_uids', null));

--- a/service/signup.js
+++ b/service/signup.js
@@ -45,8 +45,16 @@ class __signup extends Mfs {
     // Referral attribution: the signup UI forwards the referrer handle from a
     // ?ref=<member> link. Persisted as profile.ref so the analytics plugin's
     // `referrals` / `signup_sources` procs can count referred signups. Kept
-    // short/sanitized; omitted entirely when absent.
-    const ref = (this.input.get("ref") || "").toString().trim().slice(0, 64);
+    // short/sanitized (lowercased so `ref=V` and `ref=v` unify at the store,
+    // not just at query time); omitted entirely when absent.
+    const ref = (this.input.get("ref") || "").toString().trim().toLowerCase().slice(0, 64);
+
+    // UTM campaign params (source attribution) — stored as profile.utm.
+    const utm = {};
+    for (const k of ["utm_source", "utm_medium", "utm_campaign"]) {
+      const v = (this.input.get(k) || "").toString().trim().slice(0, 64);
+      if (v) utm[k] = v;
+    }
 
     const profile = {
       username,
@@ -61,6 +69,7 @@ class __signup extends Mfs {
       auth_method: "local",
       password_set: 1,
       ...(ref ? { ref } : {}),
+      ...(Object.keys(utm).length ? { utm } : {}),
     };
 
     const user = await this.yp.await_proc("drumate_create", password, profile);


### PR DESCRIPTION
## Whole-branch promotion `test` → `preview`

Preview only accepts PRs from `test` (guard-preview-source), so this carries the **whole** test branch — our secure-share work **plus unrelated teammate work** (flagged below for the owners to sign off).

### Our secure-share / notification work (ready + verified on drumee.in)
- **Neutral-host share links** — net of `4a3b129`→`3052c23` (revert)→`3f83d8e` (v2.9.82). `secure_share.js` emits links on `share.<main_domain>` via a single `_shareLinkBase()` helper. ⚠️ Must merge **together with ui-team PR** (this emits neutral links; ui pins the content `hub_id` — server-only → recipients 403).
- **Task-assigned notification (Option B, KAN-62 mirror)** — `7c969c1` + `ea9e445` (carry task nid/task_id on mention/assignment notifications). `activity.list_task_assignments` endpoint + emission; reuses the already-prod `contact_task_assigned_unread` proc.

### Carried teammate work (NOT ours — owners please confirm preview-readiness)
- **Referral code account settings** — `7a96e67` (#73) (`service/signup.js`, `drumate.js`, `channel.js`, `acl/drumate.json`, docs)
- **Custom Kanban task columns** — `3046413`, `bd3f77e`, `8e11609`, `b86a097` (`task.js`, `acl/task.json`) ⚠️ these add `column_*` endpoints that may call **new stored procs** — the owner must confirm those procs are on the preview/prod DB or merging errors on missing SPs.

### DB / deploy notes
- Our batch needs **no new schema/DB apply** (task-assigned procs already applied to preview/prod DB via schemas #39, 2026-07-03).
- Merging to `preview` deploys **UAT only**; **PROD** needs the manual `target=PROD` dispatch (Somanos/Liam).

Author: EddyOne81.
