### PR TITLE
feat(task): allow empty search_files pattern to list all linkable files

### DIFF
--- a/service/private/task.js
+++ b/service/private/task.js
@@ -522,10 +522,11 @@ class __private_task extends Entity {
    * Search media files in the current hub that can be linked to a task.
    * Filters by user read-permission. Files already linked to task_id
    * (when provided) are excluded.
-   * Params: pattern (required, ≥1 char), task_id (optional), page (optional, default 1).
+   * Params: pattern (optional — empty lists all linkable files, most-recent
+   * first), task_id (optional), page (optional, default 1).
    */
   async search_files() {
-    const pattern = this.input.need('pattern');
+    const pattern = this.input.use('pattern', '');
     const task_id = this.input.use('task_id', null);
     const page    = this.input.use('page', 1);
 


### PR DESCRIPTION
The tasks file-picker now lists all files when focused with an empty query. The search_files service required a pattern (>=1 char); switch need() to use('pattern', '') so an empty/absent pattern is accepted. The underlying task_search_linkable_files procedure already returns all readable files for an empty pattern (LIKE '%%') and already paginates via the page param, so no schema change is needed.