### PR TITLE
Hotfix → Preview: DMZ shared-workspace download (zip staging + branch manifest)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.79",
+  "version": "2.9.85",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.79",
+      "version": "2.9.85",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.79",
+  "version": "2.9.85",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/media.js
+++ b/service/media.js
@@ -1772,6 +1772,15 @@ class __media extends Mfs {
     for (let k of dump) {
       if ([Attr.hub, Attr.folder].includes(k.type)) continue;
       if (existsSync(k.src)) {
+        // Clear any pre-existing entry at the destination before linking: two
+        // branch nodes can map to the same archive path (duplicate filenames),
+        // and a retried download can leave a stale symlink — either makes
+        // symlinkSync throw EEXIST and fail the whole download
+        // (SERVICE_FAILED:media.download). Mirror zip()'s rm-before-symlink.
+        // force:true = no error when there is nothing to remove (the normal
+        // case: dest_dir is freshly created per zipid), so behaviour is
+        // unchanged except in the colliding/stale case.
+        rmSync(k.dest, { force: true });
         symlinkSync(k.src, k.dest);
       }
     }

--- a/service/media.js
+++ b/service/media.js
@@ -1810,8 +1810,18 @@ class __media extends Mfs {
     if (isArray(ids)) {
       let res = [];
       for (let n of ids) {
+        // Manifest EACH selected node on ITS OWN hub DB. The old code computed
+        // db_name but discarded it, and called mfs_manifest with the OUTER `nid`
+        // (source_granted's single node) on this.db every iteration — so a
+        // multi-item selection (e.g. "download the whole workspace", which sends
+        // every top-level item) manifested one node N times → after de-dup only
+        // that one node's content landed in the zip. Mirror the offline worker
+        // (offline/media/download.js get_branch_nodes): `${db_name}.mfs_manifest`
+        // with n.nid. mfs_manifest returns each node's own absolute file_path, so
+        // concatenating per-item manifests yields the full tree with no path
+        // collisions.
         let db_name = await this.yp.await_func("get_db_name", n.hub_id);
-        r = await this.db.await_proc("mfs_manifest", { nid, uid: this.uid, show_nodes: 1 });
+        r = await this.yp.await_proc(`${db_name}.mfs_manifest`, { nid: n.nid, uid: this.uid, show_nodes: 1 });
         res = res.concat(r[0]);
         size = parseInt(size) + parseInt(r[1].total_size);
       }


### PR DESCRIPTION
## DMZ shared-workspace download — server fixes (isolated hotfix)

Cherry-picked from `test` onto a `preview`-based branch so it carries **only** these two download fixes (no teammate work). Verified on drumee.in.

### What's fixed (2 commits, `service/media.js`)
- **`create_small_zip` EEXIST** — `symlinkSync` had no rm-first, so a duplicate/stale destination made the whole download fail (`SERVICE_FAILED:media.download`). Now `rmSync({force:true})` before the symlink, mirroring the `zip()` method.
- **`get_branch_nodes` manifested the wrong node** — the `isArray` branch computed `db_name` from `n.hub_id` but discarded it and manifested the **outer** `nid` every iteration, so "download whole workspace" produced a zip with **only the first file**. Now `${db_name}.mfs_manifest` with `n.nid` — each selected node on its own hub DB — mirroring the offline (>5MB) worker that already did it right.

### ⚠️ Notes
- **Must merge together with ui-team hotfix `hotfix/dmz-download`** — client + server download fixes are interdependent.
- The `check-source` guard will show a red ✗ (head isn't `test`); it's **not a required check**, so merge past it.
- **No schema change.** Merging to `preview` = UAT; PROD needs the manual `target=PROD` dispatch (Somanos/Liam).

Author: EddyOne81.
