### PR TITLE
feat(audit): log invite_sent / invite_accepted to action_log

### DIFF
--- a/service/butler.js
+++ b/service/butler.js
@@ -735,6 +735,20 @@ class __butler extends Mfs {
           '*', newUser.id, expiry_time, permission, 'system', 'Resolved from pending_invitation on signup'
         );
 
+        // Audit: invite redeemed on signup — never let a failure break the join.
+        try {
+          const { writeAudit } = require("./private/_audit");
+          await writeAudit(this, {
+            db: db_name,
+            uid: newUser.id,
+            action: 'invite_accepted',
+            category: 'member',
+            notify_to: 'admin',
+            entity_id: hub_id,
+            log: `Invite accepted — ${email} joined the workspace on signup`,
+          });
+        } catch (e) { /* audit only */ }
+
         // 6. Notify the (now online) user so the desk sidebar can pick up the
         // new workspace, mirroring hub.invite()'s notification for drumates.
         try {

--- a/service/private/hub.js
+++ b/service/private/hub.js
@@ -663,6 +663,15 @@ class __private_hub extends Hub {
               privilege,
               entity
             );
+            await writeAudit(this, {
+              db: this.hub.get(Attr.db_name),
+              uid: this.uid,
+              action: 'invite_sent',
+              category: 'member',
+              notify_to: 'admin',
+              entity_id: this.hub.get(Attr.id),
+              log: `Invite sent to ${entity} for workspace '${hubname}'`,
+            });
           }
         } else {
           let drumate = null;
@@ -686,6 +695,15 @@ class __private_hub extends Hub {
               privilege,
               entity
             );
+            await writeAudit(this, {
+              db: this.hub.get(Attr.db_name),
+              uid: this.uid,
+              action: 'invite_sent',
+              category: 'member',
+              notify_to: 'admin',
+              entity_id: this.hub.get(Attr.id),
+              log: `Invite sent to ${entity} for workspace '${hubname}'`,
+            });
             const isEmail = typeof entity === "string" && entity.indexOf("@") !== -1;
             if (isEmail) {
               try {
@@ -803,6 +821,15 @@ class __private_hub extends Hub {
       "permission_grant", mfs_home.chat_upload_id, uid, 0, 4,
       "no_traversal", "chat upload permission"
     );
+    await writeAudit(this, {
+      db: this.hub.get(Attr.db_name),
+      uid: this.uid,
+      action: 'added',
+      category: 'member',
+      notify_to: 'admin',
+      entity_id: uid,
+      log: `Member added to workspace '${hub_name || this.hub.get(Attr.id)}'`,
+    });
     try {
       await this.yp.await_proc(
         "contact_log_activity", this.uid, uid, "hub_invite_received",
@@ -873,6 +900,15 @@ class __private_hub extends Hub {
 
         if (isShareLink && !isDrumate) {
           await this._inviteViaToken(email, hubId, privilege, expiryTs, username, hubname, preview_items, workspace_restricted, recent_messages, publicLink);
+          await writeAudit(this, {
+            db: this.hub.get(Attr.db_name),
+            uid: this.uid,
+            action: 'invite_sent',
+            category: 'member',
+            notify_to: 'admin',
+            entity_id: hubId,
+            log: `Invite sent to ${email} for workspace '${hubname}'`,
+          });
           results.push({ email, branch: "A", status: "ok" });
         } else if (isDrumate) {
           const r = await this._grantMembership(drumate.id, privilege, 0, message, mfs_home, hubname, username);
@@ -912,6 +948,15 @@ class __private_hub extends Hub {
           await this.yp.await_proc(
             "yp_add_pending_invitation", hubId, 0, privilege, email
           );
+          await writeAudit(this, {
+            db: this.hub.get(Attr.db_name),
+            uid: this.uid,
+            action: 'invite_sent',
+            category: 'member',
+            notify_to: 'admin',
+            entity_id: hubId,
+            log: `Invite sent to ${email} for workspace '${hubname}'`,
+          });
           await this._sendInviteEmail("hub-invite-signup", email,
             `${username} invited you to join ${hubname}`,
             { inviter_name: username, workspace_name: hubname, link: publicLink, preview_items, workspace_restricted, recent_messages });
@@ -986,6 +1031,15 @@ class __private_hub extends Hub {
       '*', this.uid, 0, permission, 'system', 'Redeemed hub invite token'
     );
     await this.yp.await_proc('token_hub_invite_set_status', secret, 'accepted', null);
+    await writeAudit(this, {
+      db: db_name,
+      uid: this.uid,
+      action: 'invite_accepted',
+      category: 'member',
+      notify_to: 'admin',
+      entity_id: hub_id,
+      log: `Invite accepted — ${this.user.get(Attr.email) || this.uid} joined the workspace`,
+    });
     this.output.data({ hub_id });
   }
 
@@ -1187,6 +1241,15 @@ class __private_hub extends Hub {
                 'yp_add_pending_invitation',
                 hub_id, expiry, privilege, entity
               );
+              await writeAudit(this, {
+                db: hub_db,
+                uid: this.uid,
+                action: 'invite_sent',
+                category: 'member',
+                notify_to: 'admin',
+                entity_id: hub_id,
+                log: `Invite sent to ${entity} for workspace '${hubname}'`,
+              });
             }
           } else {
             // Not in contact list — check if user exists in Drumee
@@ -1212,6 +1275,15 @@ class __private_hub extends Hub {
                 'yp_add_pending_invitation',
                 hub_id, expiry, privilege, entity
               );
+              await writeAudit(this, {
+                db: hub_db,
+                uid: this.uid,
+                action: 'invite_sent',
+                category: 'member',
+                notify_to: 'admin',
+                entity_id: hub_id,
+                log: `Invite sent to ${entity} for workspace '${hubname}'`,
+              });
 
               // Only send email if entity looks like an email address
               const isEmail = typeof entity === 'string' && entity.indexOf('@') !== -1;
@@ -1255,6 +1327,15 @@ class __private_hub extends Hub {
         const r = await this.yp.await_proc(`${hub_db}.add_member`, uid, privilege, expiry);
         if (!r || !r.db_name) continue;
         rows.push(r);
+        await writeAudit(this, {
+          db: hub_db,
+          uid: this.uid,
+          action: 'added',
+          category: 'member',
+          notify_to: 'admin',
+          entity_id: uid,
+          log: `Member added to workspace '${hubname}'`,
+        });
 
         // Grant resource-level permission on hub root
         await this.yp.await_proc(

--- a/service/signup.js
+++ b/service/signup.js
@@ -157,6 +157,19 @@ class __signup extends Mfs {
           `${db_name}.permission_grant`,
           '*', newUser.id, expiry_time, permission, 'system', 'Resolved from pending_invitation on signup'
         );
+        // Audit: invite redeemed on signup — never let a failure break the join.
+        try {
+          const { writeAudit } = require("./private/_audit");
+          await writeAudit(this, {
+            db: db_name,
+            uid: newUser.id,
+            action: 'invite_accepted',
+            category: 'member',
+            notify_to: 'admin',
+            entity_id: hub_id,
+            log: `Invite accepted — ${email} joined the workspace on signup`,
+          });
+        } catch (e) { /* audit only */ }
 
         // Notify the (now online) user so the desk sidebar can pick up the
         // new workspace, mirroring hub.invite()'s notification for drumates.


### PR DESCRIPTION
## Summary
- Write `invite_sent` / `invite_accepted` (and related member `added`) into hub `action_log` via `writeAudit` from `hub.js`, `butler.js`, and `signup.js`.
- Required companion to schemas PR #50 (`alter_action_log_add_invite_actions` + audit filter SPs) so Admin Console Audit Logs can show invite lifecycle events.
- Clean branch from `preview` + cherry-pick only `8da1e68` (avoids unrelated `test` commits).

## Depends on
- [schemas#50](https://github.com/drumee/schemas/pull/50) — enum + `hub_get_audit_logs_*` must be patched on the environment before rows can persist / filter.

## Test plan
- [ ] Deploy this branch to an endpoint that already has schemas invite enum applied
- [ ] Send workspace invite → confirm `action_log.action = invite_sent` on the hub DB
- [ ] Accept invite / signup resolve pending → confirm `invite_accepted`
- [ ] Admin Console → Audit Logs → filter Invite sent / Invite accepted shows the new rows
- [ ] Pending Invites counter still increments (unchanged path via `pending_invitation`)


Made with [Cursor](https://cursor.com)