### PR TITLE
Hotfix → Preview: neutral-host share links + chat-sender name fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.85",
+  "version": "2.9.86",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.85",
+      "version": "2.9.86",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.85",
+  "version": "2.9.86",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -125,7 +125,20 @@ class __private_channel extends Entity {
     let cache = {};
     let hub_id = this.hub.get(Attr.id);
     for (let message of data) {
-      message.entity = { id: this.uid };
+      // Own-authored rows keep the viewer as the entity id, but also carry the
+      // SP-resolved display fields (incl. email) so a viewer who renders this
+      // author as NOT "me" on their side — e.g. a creator-bound secure-share
+      // recipient whose session uid equals the message author — still resolves a
+      // name/email instead of falling back to the raw author id. The
+      // `author_id != this.uid` branch below overwrites entity via
+      // shareroom_contact_get, so this only affects self-authored rows.
+      message.entity = {
+        id: this.uid,
+        firstname: message.firstname,
+        lastname: message.lastname,
+        fullname: message.fullname,
+        email: message.email,
+      };
       if (message.author_id != this.uid) {
         let key = message.author_id;
 

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 const {
-  Attr, Cache, Messenger, RedisStore, toArray
+  Attr, Cache, Messenger, RedisStore, toArray, sysEnv
 } = require('@drumee/server-essentials');
 const { Mfs } = require('@drumee/server-core');
 const { isEmpty } = require('lodash');
@@ -102,8 +102,7 @@ class __secure_share extends Mfs {
       return this.output.data({ status: 'CREATE_FAILED' });
     }
 
-    const host = this.hub.get(Attr.vhost);
-    const link = `${this.input.homepath(host)}#/dmz/share/${token}`;
+    const link = `${this._shareLinkBase()}#/dmz/share/${token}`;
 
     // Send invitation email only when sharing with exactly one named recipient (not domain, not public)
     const singleEmail = allowedEmails && allowedEmails.length === 1
@@ -141,13 +140,29 @@ class __secure_share extends Mfs {
   }
 
   /**
+   * Base URL for every share link. Anchored to the neutral share host
+   * (share.<main_domain>) instead of the content workspace's vhost, so links no
+   * longer leak the workspace name. Safe because a share resolves 100% by token
+   * (dmz.login → secure_share_info) AND the recipient FE pins the content hub_id
+   * on every DMZ request (ui @drumee/ui-essentials defaultPayload patch), so the
+   * neutral connect host never mis-resolves the hub. The neutral host itself needs
+   * no dedicated hub — bootstrap get_env falls back to the default hub.
+   * homepath() supplies the per-endpoint scheme + mount path (/-/, /-/preview/…).
+   * Single source of truth — used by create(), list() and access_list().
+   */
+  _shareLinkBase() {
+    const { main_domain } = sysEnv();
+    return this.input.homepath(`share.${main_domain}`);
+  }
+
+  /**
    * List all secure share tokens created by the current user for a given node.
    */
   async list() {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
     const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
-    const base   = this.input.homepath(this.hub.get(Attr.vhost));
+    const base   = this._shareLinkBase();
     this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 
@@ -312,7 +327,7 @@ class __secure_share extends Mfs {
     const nid    = this.input.need(Attr.nid);
     const hub_id = this.hub.get(Attr.id);
     const rows   = toArray(await this.yp.await_proc('secure_share_list', hub_id, nid, this.uid));
-    const base   = this.input.homepath(this.hub.get(Attr.vhost));
+    const base   = this._shareLinkBase();
     this.output.list(rows.map(r => ({ ...r, link: `${base}#/dmz/share/${r.id}` })));
   }
 


### PR DESCRIPTION
## Secure-share follow-ups → preview (isolated hotfix, server)

Cherry-picked from `test` onto a `preview`-based branch — only these two fixes (no teammate work). Verified on drumee.in.

### What's included (2 commits, `service/private/`)
- **Neutral-host share links** (`3f83d8e`) — `secure_share.js` emits share links on `share.<main_domain>` via one `_shareLinkBase()` helper (create/list/access_list). Pairs with the ui-team hotfix. No DB/infra.
- **Chat-sender name fix** (`1391ca0`) — `channel.js messages()` backfills self-authored chat rows with the SP display fields (firstname/lastname/fullname/email) so a creator-bound secure-share recipient sees a name/email instead of the raw uid. Its stored proc (`channel_list_messages`) is **already on preview + prod hub DBs** (schemas PR #48) — no DB action here.

### ⚠️ Notes
- **Merge together with ui-team hotfix `hotfix/secure-share-neutral-createpanel-chat`** (neutral-host needs both sides).
- **No schema change.** Preview merge = UAT; PROD = manual `target=PROD` dispatch (Somanos/Liam).
- Excludes phamtobao's task-`nid` line (KAN-62) that also sits in `channel.js` on `test` — intentionally not part of this batch.
