### PR TITLE
feat(payment): full catalog + org-aware status/portal + pro per-seat checkout + checkout_result

### DIFF
--- a/acl/payment.json
+++ b/acl/payment.json
@@ -4,6 +4,7 @@
     "checkout":            { "scope": "hub", "permission": { "src": "owner" }, "params": { "period": { "type": "string", "required": true }, "plan": { "type": "string", "required": false }, "seats": { "type": "integer", "required": false, "default": 1 }, "entity_type": { "type": "string", "required": false }, "bundle": { "type": "string", "required": false } } },
     "subscription_status": { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
     "portal":              { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
+    "checkout_result":     { "scope": "hub", "permission": { "src": "owner" }, "params": { "session_id": { "type": "string", "required": true } } },
     "webhook":             { "scope": "hub", "permission": { "src": "read", "fast_check": "public-api" }, "method": "receive", "params": { "stripe-signature": { "type": "string", "required": true }, "raw_body": { "type": "string", "required": true } }, "errors": [{ "code": "WEBHOOK_ERROR", "http_status": 400 }] }
   },
   "modules": { "private": "service/private/payment", "public": "service/public/stripe_webhook" }

--- a/service/callback.js
+++ b/service/callback.js
@@ -23,11 +23,17 @@ const {Entity} = require('@drumee/server-core');
 // the FE plan updates via the WS payment.plan_updated event.
 class __callback extends Entity {
   async check_out_cancel() {
-    this.output.html(`<script> window.location.href = '${this.input.homepath()}#/desk/' </script>`);
+    // ?checkout=cancel lets the desk show the payment-failure/cancel modal.
+    this.output.html(`<script> window.location.href = '${this.input.homepath()}?checkout=cancel#/desk/' </script>`);
   }
 
   async check_out_success() {
-    this.output.html(`<script> window.location.href = '${this.input.homepath()}#/desk/' </script>`);
+    // Carry the Checkout Session id back so the desk can show the payment-success
+    // modal with real receipt details (payment.checkout_result). The id is
+    // whitelisted to Stripe's session-id alphabet before being echoed into HTML.
+    const sid = String(this.input.use('session_id', '')).replace(/[^a-zA-Z0-9_]/g, '');
+    const flag = sid ? `?checkout=success&session_id=${sid}` : '?checkout=success';
+    this.output.html(`<script> window.location.href = '${this.input.homepath()}${flag}#/desk/' </script>`);
   }
 }
 

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -75,8 +75,15 @@ class __private_payment extends Entity {
     // C1 Pro per-seat: the plan includes quota.$.seat seats (Pro: 5); seats
     // beyond that are a recurring pro_seat add-on line (quantity = extra).
     if (entity_type !== 'org') {
+      // plan_row.quota may arrive already parsed (driver auto-parses JSON
+      // columns) OR as a string — handle both, else JSON.parse(object) throws
+      // and the seat add-on is silently dropped (only the Pro base is billed).
       let included = 0;
-      try { included = ~~JSON.parse(plan_row.quota || '{}').seat || 0; } catch (e) { included = 0; }
+      try {
+        const q = plan_row.quota;
+        const obj = q && typeof q === 'object' ? q : JSON.parse(q || '{}');
+        included = ~~obj.seat || 0;
+      } catch (e) { included = 0; }
       const extra = seats - (included || 1);
       if (included > 0 && extra > 0) {
         const seat_addon = await this.yp.await_proc('payment_get_plan', 'pro_seat', period, 'eur');

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -13,8 +13,10 @@ class __private_payment extends Entity {
 
   // Priced catalog from yp.plan. Enriched with the live Stripe unit amount when
   // a price id + key exist, so the FE can display the authoritative price.
+  // Returns ALL entity types (user plans + org/team + add-ons incl. pro_seat)
+  // so every price the billing UI shows is catalog-driven, not hardcoded.
   async catalog() {
-    const rows = (await this.yp.await_proc('payment_get_catalog', 'eur', 'user')) || [];
+    const rows = (await this.yp.await_proc('payment_get_catalog', 'eur', '')) || [];
     const plans = Array.isArray(rows) ? rows : [rows];
     let stripe = null;
     try { stripe = this._stripe(); } catch (e) { stripe = null; }
@@ -70,6 +72,19 @@ class __private_payment extends Entity {
     }
     const quantity = entity_type === 'org' ? seats : 1;
     const line_items = [{ price: plan_row.stripe_price_id, quantity }];
+    // C1 Pro per-seat: the plan includes quota.$.seat seats (Pro: 5); seats
+    // beyond that are a recurring pro_seat add-on line (quantity = extra).
+    if (entity_type !== 'org') {
+      let included = 0;
+      try { included = ~~JSON.parse(plan_row.quota || '{}').seat || 0; } catch (e) { included = 0; }
+      const extra = seats - (included || 1);
+      if (included > 0 && extra > 0) {
+        const seat_addon = await this.yp.await_proc('payment_get_plan', 'pro_seat', period, 'eur');
+        if (seat_addon && seat_addon.stripe_price_id) {
+          line_items.push({ price: seat_addon.stripe_price_id, quantity: extra });
+        }
+      }
+    }
     // Optional storage add-on (P4): a 2nd recurring line item for this period.
     const bundle = this.input.use('bundle', '');
     if (bundle) {
@@ -91,9 +106,26 @@ class __private_payment extends Entity {
     this.output.data({ url: session.url, id: session.id });
   }
 
+  // Subscription mirror row for the caller. The webhook keys org (team)
+  // subscriptions by the ORGANISATION id, so when the personal row is empty
+  // fall back to the org the caller owns — org owners see their team sub.
+  async _subscription_row() {
+    let row = await this.yp.await_proc('payment_get_subscription', this.uid);
+    if (row && row.subscription_id) return row;
+    const org = await this.yp.await_proc('payment_get_org', this.uid);
+    if (org && org.id) {
+      const orgRow = await this.yp.await_proc('payment_get_subscription', org.id);
+      if (orgRow && orgRow.subscription_id) {
+        orgRow.entity_type = 'org';
+        orgRow.org_name = org.name;
+        return orgRow;
+      }
+    }
+    return row || {};
+  }
+
   async subscription_status() {
-    const row = await this.yp.await_proc('payment_get_subscription', this.uid);
-    this.output.data(row || {});
+    this.output.data(await this._subscription_row());
   }
 
   // Stripe Billing Portal: one hosted surface for invoice history, cancel/resume,
@@ -102,7 +134,7 @@ class __private_payment extends Entity {
     let stripe;
     try { stripe = this._stripe(); }
     catch (e) { return this.output.data({ status: 'STRIPE_NOT_CONFIGURED' }); }
-    const sub = await this.yp.await_proc('payment_get_subscription', this.uid);
+    const sub = await this._subscription_row();
     const customer_id = sub && sub.customer_id;
     if (!customer_id) return this.output.data({ status: 'NO_CUSTOMER' });
     const session = await stripe.billingPortal.sessions.create({
@@ -110,6 +142,57 @@ class __private_payment extends Entity {
       return_url: this.input.homepath() + '#/desk/',
     });
     this.output.data({ url: session.url });
+  }
+
+  // Post-Checkout receipt details for the success/failure modal: total paid,
+  // invoice number, payment date and card brand/last4, straight from the
+  // Checkout Session the browser was redirected back with.
+  async checkout_result() {
+    let stripe;
+    try { stripe = this._stripe(); }
+    catch (e) { return this.output.data({ status: 'STRIPE_NOT_CONFIGURED' }); }
+    const session_id = this.input.need('session_id');
+    let session;
+    try {
+      session = await stripe.checkout.sessions.retrieve(session_id, {
+        expand: ['invoice', 'subscription'],
+      });
+    } catch (e) {
+      return this.output.data({ status: 'SESSION_NOT_FOUND' });
+    }
+    // The session must belong to the caller (their personal or org customer).
+    const sub = await this._subscription_row();
+    const md = session.metadata || {};
+    const owns = (md.entity_id === this.uid) || (sub && sub.customer_id && sub.customer_id === session.customer);
+    if (!owns) {
+      const org = await this.yp.await_proc('payment_get_org', this.uid);
+      if (!(org && org.id && md.entity_id === org.id)) {
+        return this.output.data({ status: 'SESSION_NOT_FOUND' });
+      }
+    }
+    const inv = (session.invoice && typeof session.invoice === 'object') ? session.invoice : null;
+    let card_brand = null, card_last4 = null;
+    try {
+      const piId = inv && (typeof inv.payment_intent === 'string' ? inv.payment_intent : inv.payment_intent && inv.payment_intent.id);
+      if (piId) {
+        const pi = await stripe.paymentIntents.retrieve(piId, { expand: ['payment_method'] });
+        const pm = pi && pi.payment_method;
+        if (pm && pm.card) { card_brand = pm.card.brand; card_last4 = pm.card.last4; }
+      }
+    } catch (e) { /* card details are cosmetic — leave unset */ }
+    this.output.data({
+      status: session.status,                          // complete | open | expired
+      payment_status: session.payment_status,          // paid | unpaid | no_payment_required
+      plan: md.plan || null,
+      period: md.period || null,
+      entity_type: md.entity_type || 'user',
+      amount_total: session.amount_total,              // minor units
+      currency: session.currency,
+      invoice_number: inv && inv.number,
+      paid_at: (inv && inv.status_transitions && inv.status_transitions.paid_at) || session.created,
+      card_brand,
+      card_last4,
+    });
   }
 }
 

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -91,8 +91,12 @@ class __private_payment extends Entity {
       const addon = await this.yp.await_proc('payment_get_plan', bundle, period, 'eur');
       if (addon && addon.stripe_price_id) line_items.push({ price: addon.stripe_price_id, quantity: 1 });
     }
-    const success_url = this.input.servicepath({ service: 'callback.check_out_success' }) + '&session_id={CHECKOUT_SESSION_ID}';
-    const cancel_url = this.input.servicepath({ service: 'callback.check_out_cancel' });
+    // Build the return URLs from homepath (host-derived, endpoint-aware).
+    // servicepath() resolves the endpoint segment to 'undefined' on dev
+    // endpoints (/-/undefined/svc/...), which broke the post-payment redirect.
+    const svcbase = this.input.homepath().replace(/\/+$/, '') + '/svc/?service=';
+    const success_url = `${svcbase}callback.check_out_success&session_id={CHECKOUT_SESSION_ID}`;
+    const cancel_url = `${svcbase}callback.check_out_cancel`;
     const metadata = { entity_type, entity_id, plan, period };
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -3,22 +3,39 @@ const { Entity } = require('@drumee/server-core');
 const { stripeClient, endpointSecret } = require('../lib/stripe');
 
 class __public_stripe_webhook extends Entity {
-  // Classify subscription line items: the base plan item (quantity = seats) vs
-  // storage add-on items (entity_type='addon' in yp.plan) — sum their disk *
-  // quantity into extra_disk so the entitlement = base + add-ons (P4).
+  // Classify subscription line items: the base plan item (quantity = seats for
+  // org) vs add-on items (entity_type='addon' in yp.plan) — storage add-ons sum
+  // disk * quantity into extra_disk (P4); pro_seat add-ons sum seat * quantity
+  // into extra_seats (C1 Pro per-seat).
   async _itemsEntitlement(items) {
-    let seats = 1, price = 0, extra_disk = 0;
+    let seats = 1, price = 0, extra_disk = 0, extra_seats = 0;
     for (const it of (items || [])) {
       const pid = it && it.price && it.price.id;
       const ad = pid ? await this.yp.await_proc('payment_get_addon', pid) : null;
-      if (ad && ad.disk) {
-        extra_disk += Number(ad.disk) * (it.quantity || 1);
+      if (ad && (Number(ad.disk) || Number(ad.seat))) {
+        if (Number(ad.disk)) extra_disk += Number(ad.disk) * (it.quantity || 1);
+        if (Number(ad.seat)) extra_seats += Number(ad.seat) * (it.quantity || 1);
       } else {
         seats = it.quantity || 1;
         price = (it.price && it.price.unit_amount) || 0;
       }
     }
-    return { seats, price, extra_disk };
+    return { seats, price, extra_disk, extra_seats };
+  }
+
+  // Seat total to record on the entitlement. Org (team): the base line's
+  // quantity IS the seat count. Individual (pro): the plan includes
+  // quota.$.seat seats; purchased pro_seat add-ons extend that. Returning 0
+  // keeps the plan's default $.seat (guard in payment_apply_entitlement).
+  async _seatTotal(entity_type, plan, period, base_seats, extra_seats) {
+    if (entity_type === 'org') return base_seats;
+    if (!extra_seats) return 0;
+    let included = 0;
+    try {
+      const row = await this.yp.await_proc('payment_get_plan', plan, period, 'eur');
+      included = ~~JSON.parse((row && row.quota) || '{}').seat || 0;
+    } catch (e) { included = 0; }
+    return included + extra_seats;
   }
 
   async receive() {
@@ -66,10 +83,11 @@ class __public_stripe_webhook extends Entity {
                 period_end = period_end || s.current_period_end || (items[0] && items[0].current_period_end) || 0;
               } catch (e3) { items = []; }
             }
-            const { seats, price, extra_disk } = await this._itemsEntitlement(items);
+            const { seats, price, extra_disk, extra_seats } = await this._itemsEntitlement(items);
+            const seat_total = await this._seatTotal(entity_type, plan, period, seats, extra_seats);
             // 0, not null: await_proc maps null -> '' which a strict-mode INT param rejects.
             await this.yp.await_proc('subscription_update', entity_id, customer_id, subscription_id, plan, period, 1, price, 0, status);
-            await this.yp.await_proc('payment_apply_entitlement', entity_id, plan, period_end, entity_type, seats, extra_disk);
+            await this.yp.await_proc('payment_apply_entitlement', entity_id, plan, period_end, entity_type, seat_total, extra_disk);
             await this.notify_user(entity_id, { service: 'payment.plan_updated', plan, status: 'active' });
           }
           break;
@@ -98,8 +116,9 @@ class __public_stripe_webhook extends Entity {
               // Recurring renewal succeeded -> re-apply entitlement (bumps period_end).
               const items = (sub && sub.items && sub.items.data) || [];
               const pend = (sub && sub.current_period_end) || (items[0] && items[0].current_period_end) || 0;
-              const { seats, extra_disk } = await this._itemsEntitlement(items);
-              await this.yp.await_proc('payment_apply_entitlement', eid, smd.plan || 'pro', pend, smd.entity_type || 'user', seats, extra_disk);
+              const { seats, extra_disk, extra_seats } = await this._itemsEntitlement(items);
+              const seat_total = await this._seatTotal(smd.entity_type || 'user', smd.plan || 'pro', smd.period || 'month', seats, extra_seats);
+              await this.yp.await_proc('payment_apply_entitlement', eid, smd.plan || 'pro', pend, smd.entity_type || 'user', seat_total, extra_disk);
               await this.notify_user(eid, { service: 'payment.plan_updated', plan: smd.plan, status: 'active' });
             } else {
               // Payment failed -> keep entitlement during Stripe's smart retries

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -76,7 +76,12 @@ class __public_stripe_webhook extends Entity {
             const subscription_id = obj.object === 'checkout.session'
               ? (typeof obj.subscription === 'string' ? obj.subscription : null)
               : (obj.id || null);
-            const status = obj.status || 'active';
+            // A pending cancellation (portal "Cancel subscription" = cancel at
+            // period end) keeps Stripe status 'active'; mirror it as 'canceled'
+            // so the UI status line reads "will be canceled on {period_end}"
+            // (the design's Settings-card copy). Entitlement stays until the
+            // final customer.subscription.deleted.
+            const status = obj.cancel_at_period_end ? 'canceled' : (obj.status || 'active');
             const entity_type = md.entity_type || 'user';
             // Line items: the subscription object carries them; a checkout.session
             // does not, so retrieve the subscription to read base + add-ons.

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -33,7 +33,10 @@ class __public_stripe_webhook extends Entity {
     let included = 0;
     try {
       const row = await this.yp.await_proc('payment_get_plan', plan, period, 'eur');
-      included = ~~JSON.parse((row && row.quota) || '{}').seat || 0;
+      // quota may be a parsed object or a JSON string — handle both.
+      const q = row && row.quota;
+      const obj = q && typeof q === 'object' ? q : JSON.parse(q || '{}');
+      included = ~~obj.seat || 0;
     } catch (e) { included = 0; }
     return included + extra_seats;
   }

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -69,7 +69,13 @@ class __public_stripe_webhook extends Entity {
           if (entity_id) {
             // Mirror the live subscription for the status panel + Billing Portal.
             const customer_id = obj.customer || null;
-            const subscription_id = obj.subscription || obj.id || null;
+            // checkout.session.completed carries the SESSION in obj — its
+            // .subscription may still be null and the session id (cs_…, 66
+            // chars) must never be mirrored as a subscription id (VARCHAR(30)
+            // overflow silently killed the mirror row).
+            const subscription_id = obj.object === 'checkout.session'
+              ? (typeof obj.subscription === 'string' ? obj.subscription : null)
+              : (obj.id || null);
             const status = obj.status || 'active';
             const entity_type = md.entity_type || 'user';
             // Line items: the subscription object carries them; a checkout.session
@@ -86,7 +92,11 @@ class __public_stripe_webhook extends Entity {
             const { seats, price, extra_disk, extra_seats } = await this._itemsEntitlement(items);
             const seat_total = await this._seatTotal(entity_type, plan, period, seats, extra_seats);
             // 0, not null: await_proc maps null -> '' which a strict-mode INT param rejects.
-            await this.yp.await_proc('subscription_update', entity_id, customer_id, subscription_id, plan, period, 1, price, 0, status);
+            // Mirror only with a real subscription id — the subscription.created/
+            // updated events carry it when the session doesn't.
+            if (subscription_id) {
+              await this.yp.await_proc('subscription_update', entity_id, customer_id, subscription_id, plan, period, 1, price, 0, status);
+            }
             await this.yp.await_proc('payment_apply_entitlement', entity_id, plan, period_end, entity_type, seat_total, extra_disk);
             await this.notify_user(entity_id, { service: 'payment.plan_updated', plan, status: 'active' });
           }


### PR DESCRIPTION
## Billing — full catalog + org-aware status/portal + Pro per-seat checkout + result modal (server-team)

Backend for the **Billing UI/UX refresh** (Figma "K. BILLING"), on top of the merged Stripe subsystem.

### Commits
- `feat(payment): full catalog + org-aware status/portal + pro per-seat checkout + checkout_result`
- `fix(payment): checkout return URLs via homepath (servicepath yields /-/undefined/ on dev endpoints)`
- `fix(webhook): never mirror a checkout-session id as the subscription id`
- `feat(webhook): mirror pending cancellation as status 'canceled'`
- `fix(payment): parse plan quota robustly for Pro per-seat (object OR string)`

### What changed (`service/private/payment.js`, `service/public/stripe_webhook.js`, `service/callback.js`, `acl/payment.json`)
- **catalog()** returns EVERY plan row (user + org/team + add-ons incl. `pro_seat`) so the FE prices are all catalog/Stripe-driven (no hardcoded amounts).
- **subscription_status()/portal()** resolve the org the caller owns (webhook mirrors team subs under the ORG id, so org owners previously got `{}`/`NO_CUSTOMER`).
- **checkout()** — Pro per-seat: seats beyond the plan's included `quota.$.seat` (5) become a recurring `pro_seat` line (quantity = extra).
- **NEW `checkout_result(session_id)`** — receipt details (total, invoice number, paid_at, card brand/last4) for the post-Checkout success/failure modal; ownership-checked.
- **webhook reducer** classifies `pro_seat` add-ons into extra_seats and records seat totals on the entitlement (storage add-ons unchanged).
- **callback** return redirects carry `?checkout=success&session_id=…` / `?checkout=cancel` so the desk can surface the result modal.

### Bugs found + fixed during live testing
1. **Return URL** built with `servicepath()` → `/-/undefined/svc/…` on dev endpoints (404 after payment) → use `homepath()`.
2. **Mirror row killed**: `checkout.session.completed` could push the 66-char `cs_…` session id into `subscription_new.subscription_id` VARCHAR(30) (strict-mode data-too-long inside the reducer's catch) → only mirror a real `sub_…` id.
3. **Pending cancellation** (portal cancel = `cancel_at_period_end`, Stripe status stays `active`) → mirror as `canceled` so the UI shows "will be canceled on …".
4. **Pro per-seat dropped**: `payment_get_plan` returns `quota` already parsed to an object, so `JSON.parse(quota)` threw → included=0 → the `pro_seat` line was silently skipped (Pro seats>5 billed only the base) → parse robustly (object OR string) in `checkout()` + `_seatTotal()`.

### Verified live (real Stripe test payments)
Pro monthly+100GB (€18.99→150GB), Pro yearly (€169.90→renews 2027), **Pro 7 seats (€26.99 → 3 line items → entitlement seats=7)**, declined card, cancel-link → failure modal, portal cancel → status line. All `payment.*` require `hub_id: Visitor.id` (ACL scope:hub/owner).

**Requires:** schemas #57. **Pairs with:** ui-team #278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)