### PR TITLE
hotfix(secure-share): stop recipient auth-session hijack via share links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.86",
+  "version": "2.9.88",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.86",
+      "version": "2.9.88",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.86",
+  "version": "2.9.88",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -709,11 +709,37 @@ class __dmz extends Mfs {
         ceilingToStamp = (caps.indexOf('can_chat') !== -1) ? 7 : 3;
       }
     }
+    // ---------------------------------------------------------------------
+    // SECURITY GUARD (hotfix 2026-07-10 — regsid hijack, Lexis prod issue #3).
+    // The principal binding + ceiling below MUST only ever touch the share's
+    // ISOLATED hub-cookie session (page.js gives a dmz/share page its own sid).
+    // If this.input.sid() is instead the caller's `regsid` — the main_domain-scoped
+    // AUTH cookie that app.drumee.com reads — then:
+    //   * cookie_touch(uid=creator) would rebind the recipient's auth session to the
+    //     share creator → they are logged into the CREATOR's account on the main
+    //     domain (the reported account takeover); and
+    //   * set_session_priv_ceiling would clamp the recipient's OWN account to
+    //     read-only across the main domain.
+    // This happened once share links were served from the neutral host
+    // (share.<domain>), whose default-hub bootstrap skipped the page.js isolation so
+    // this.input.sid() fell back to regsid. NEVER apply either op to the regsid
+    // session: a share that ever resolves to it degrades (may not render) but can
+    // never hijack or clamp the auth session. Isolated sessions (sid != regsid) are
+    // completely unaffected — this is a no-op for every normal share open.
+    const _activeSid = this.input.sid();
+    const _isAuthSession = !!(regsid && _activeSid === regsid);
+    if (_isAuthSession) {
+      this.warn(
+        '[dmz.login][SECURITY] secure_share bind skipped: DMZ session resolved to the main-domain regsid (would hijack/clamp the auth session)',
+        { token, creator_id: info && info.creator_id, bindUid }
+      );
+    }
+
     // socket_id must be passed so entity_sockets() includes this guest socket in
     // hub broadcasts (e.g. secure_share_revoked). page.js ensures the hub cookie
     // has its own independent session id, so this never touches the authenticated
-    // user's regsid row.
-    if (bindUid) {
+    // user's regsid row (belt-and-suspenders: the _isAuthSession guard above).
+    if (bindUid && !_isAuthSession) {
       try {
         await this.yp.await_proc('cookie_touch', {
           sid       : this.input.sid(),
@@ -744,7 +770,7 @@ class __dmz extends Mfs {
     // serialises JS null to '' → ER_TRUNCATED_WRONG_VALUE). Best-effort: on failure
     // (e.g. the SP not yet applied to this DB) we keep the prior binding — fail-open
     // to today's behaviour, never blocking access.
-    if (bindUid) {
+    if (bindUid && !_isAuthSession) {
       try {
         if (ceilingToStamp != null) {
           await this.yp.await_proc('set_session_priv_ceiling', this.input.sid(), ceilingToStamp, bindUid);

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 const {
-  Attr, Cache, Messenger, RedisStore, toArray, sysEnv
+  Attr, Cache, Messenger, RedisStore, toArray
 } = require('@drumee/server-essentials');
 const { Mfs } = require('@drumee/server-core');
 const { isEmpty } = require('lodash');
@@ -140,19 +140,18 @@ class __secure_share extends Mfs {
   }
 
   /**
-   * Base URL for every share link. Anchored to the neutral share host
-   * (share.<main_domain>) instead of the content workspace's vhost, so links no
-   * longer leak the workspace name. Safe because a share resolves 100% by token
-   * (dmz.login → secure_share_info) AND the recipient FE pins the content hub_id
-   * on every DMZ request (ui @drumee/ui-essentials defaultPayload patch), so the
-   * neutral connect host never mis-resolves the hub. The neutral host itself needs
-   * no dedicated hub — bootstrap get_env falls back to the default hub.
-   * homepath() supplies the per-endpoint scheme + mount path (/-/, /-/preview/…).
+   * Base URL for every share link. Anchored to the content workspace's own vhost.
+   * The neutral share host (share.<main_domain>) was REVERTED (hotfix
+   * 2026-07-10): on the neutral host the page bootstraps the default hub, so the
+   * dmz/share cookie-isolation in page.js never engaged and dmz.login's
+   * this.input.sid() resolved to the recipient's main-domain regsid — cookie_touch
+   * then rebound the recipient's AUTH session to the share creator (account
+   * takeover on app.drumee.com). The per-vhost host keeps the DMZ session on an
+   * isolated hub cookie. homepath() supplies the per-endpoint scheme + mount path.
    * Single source of truth — used by create(), list() and access_list().
    */
   _shareLinkBase() {
-    const { main_domain } = sysEnv();
-    return this.input.homepath(`share.${main_domain}`);
+    return this.input.homepath(this.hub.get(Attr.vhost));
   }
 
   /**


### PR DESCRIPTION
## Critical: account takeover via secure-share links (Lexis prod issue #3)

Opening a secure-share link logged the recipient into the **share creator's** account on app.drumee.com (confirmed in prod: recipients of santabin/lala/Dante shares were bound into those accounts; Lexis→Dante reproduced).

### Root cause
The DMZ share session is bound to the creator via `cookie_touch({sid: this.input.sid(), uid: creator})`. That is only safe when `this.input.sid()` is the **isolated hub-cookie sid**. The neutral-share-host change (links served from `share.<domain>`) made the page bootstrap the default hub, so the `page.js` dmz/share cookie-isolation never engaged and `this.input.sid()` fell back to the recipient's **regsid** — the `main_domain`-scoped auth cookie that app.drumee.com reads. `cookie_touch` then rebound that auth session to the creator (takeover); `set_session_priv_ceiling` on it also clamped the recipient's own account read-only.

### Fix (server-only, 2 files)
1. **`secure_share.js`** — revert `_shareLinkBase()` to the content workspace's own vhost (`homepath(this.hub.get(Attr.vhost))`), the same host every other DMZ link uses. Restores hub-cookie isolation.
2. **`dmz.js _loginSecureShare`** — guard: never `cookie_touch` / stamp a priv_ceiling on a session whose id === the caller's `regsid`. Belt-and-suspenders on any host. No-op for isolated sessions (sid != regsid) → zero change to every normal share open.

### Verification
- `node --check` clean; diff is exactly these 2 files.
- Regression matrix: guard only fires when active sid === regsid (the takeover path); prod data confirms regsid-binds are strictly post-neutral-host, so no pre-existing working flow is affected.
- Prod session cleanup of the leaked/hijacked cookie rows already applied (Lexis re-secured).

### Known limitation (by design)
Neutral-host links already emailed (7/6–7/10) stop rendering for non-member recipients after this ships (guard blocks the creator-bind → they must be re-shared to get a vhost link). Owner/member opens still work. No schema change.