### PR TITLE
hotfix(secure-share): file-share recipient operates as self (chat identity + token-scoped listing)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.88",
+  "version": "2.9.89",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.88",
+      "version": "2.9.89",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.88",
+  "version": "2.9.89",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -645,11 +645,18 @@ class __dmz extends Mfs {
     //     access to elevate (they are already signed in → the request-access flow).
     //     ANONYMOUS viewers stay creator-bound until the capped guest principal lands
     //     (then they too are capped to the link's level; elevating requires login).
-    //   - FOLDER shares only (no info.file_nid): a single-file share has no
-    //     descendants and a different byte path — left on creator-binding.
+    //   - BOTH folder and single-FILE shares: the node-scoped grant is issued on the
+    //     shared node (info.node_id — the file itself for a file share; only info.nid
+    //     was remapped to the parent for the listing). The recipient then operates as
+    //     THEMSELVES for chat / downloads / notifications instead of the creator (Lexis
+    //     prod issue #4). File-share VIEWING keeps working because media.show_node_by
+    //     is src=anonymous + token-scoped: it lists the parent and hard-filters to the
+    //     shared file (see media.js `_secureShareListTarget`), so no parent ACL is
+    //     needed and no sibling is exposed. This also CLOSES the old sibling/nested
+    //     over-exposure that the creator-bound file session had.
     //   - member/owner already hold standing ACL → bind to self, NO extra grant.
     //   - a non-member gets the node-scoped grant; if the grant FAILS we keep the
-    //     creator binding so the share still WORKS (degrade, never break access).
+    //     creator binding (still CLAMPED by the ceiling) so the share degrades safely.
     // The share is guaranteed valid here (TICKET_REVOKED/EXPIRED/LOCKED returned
     // at the top of this method).
     // ---------------------------------------------------------------------
@@ -659,7 +666,7 @@ class __dmz extends Mfs {
     // (view/download 3, chat 7) so the gate clamps the grant's over-reach; edit (15) and
     // owner/member get NO ceiling (full / own access). null = no clamp.
     let ceilingToStamp = !isAuthenticated ? 3 : null;
-    if (isAuthenticated && user.id && !info.file_nid && info.node_id) {
+    if (isAuthenticated && user.id && info.node_id) {
       if (hasStanding || String(user.id) === String(info.creator_id)) {
         // Real member, manual collaborator, or owner — standing access independent
         // of any secure-share grant; operate as themselves. No extra grant. Any
@@ -668,14 +675,20 @@ class __dmz extends Mfs {
         bindUid = user.id;
       } else {
         // Pure recipient — holds only their own (or no) secure-share grant on this
-        // node. Grant capped node access, then bind to their uid. UPGRADE-ONLY:
-        // max with any already-earned secure-share priv so opening a lower link
-        // after a higher one never downgrades, and re-opening the same link is a
-        // no-op REPLACE.
+        // node (the shared FILE or FOLDER, info.node_id). Grant capped node access,
+        // then bind to their uid. UPGRADE-ONLY: max with any already-earned
+        // secure-share priv so opening a lower link after a higher one never
+        // downgrades, and re-opening the same link is a no-op REPLACE.
         let newCapPriv = 0b0000011;                                    // read / view / download
         if (caps.indexOf('can_chat') !== -1) newCapPriv = 0b0000111;   // write — chat.post
         if (caps.indexOf('can_edit') !== -1) newCapPriv = 0b0001111;   // delete/modify — edit
         const grantTarget = Math.max(newCapPriv, ownShareGrant);
+        // Clamp view/download (3) and chat (7) recipients with a session ceiling so
+        // router/rest denies file-writes (the node grant alone can't — chat grant 7
+        // carries the write bit). Edit (15) = full edit intended → no ceiling. Set
+        // BEFORE the grant so a grant FAILURE degrades to a CLAMPED creator binding,
+        // never an un-clamped creator session.
+        ceilingToStamp = grantTarget < 0b0001111 ? grantTarget : null;
         try {
           const db_name = await this.yp.await_func('get_db_name', info.hub_id);
           if (db_name) {
@@ -684,29 +697,10 @@ class __dmz extends Mfs {
               info.node_id, user.id, 0, grantTarget, 'system', 'Secure share access'
             );
             bindUid = user.id;            // rebind ONLY after the grant succeeds
-            // Clamp view/download (3) and chat (7) recipients with a session ceiling so
-            // router/rest denies file-writes (the node grant alone can't — chat grant 7
-            // carries the write bit). Edit (15) = full edit intended → no ceiling (the
-            // stamp site clears any stale one).
-            ceilingToStamp = grantTarget < 0b0001111 ? grantTarget : null;
           }
         } catch (e) {
-          this.warn('[dmz.login] secure_share node grant failed; keeping creator binding:', e && e.message);
+          this.warn('[dmz.login] secure_share node grant failed; keeping creator binding (clamped):', e && e.message);
         }
-      }
-    } else if (
-      isAuthenticated && info.file_nid && user.id &&
-      !(memberPriv > 0 || String(user.id) === String(info.creator_id))
-    ) {
-      // Authenticated NON-member recipient of a single-FILE share. The folder rebind
-      // above is skipped (a single file has no subtree to node-scope), so the session
-      // stays creator-bound — without a ceiling it would otherwise inherit FULL creator
-      // privilege and let a view/download/chat recipient run creator-authorized
-      // writes/deletes after signing in. Clamp the creator-bound session to the share
-      // caps. can_edit → no clamp (they may edit the shared file; the office-editor path
-      // is node-scoped via mfs_node_in_subtree).
-      if (caps.indexOf('can_edit') === -1) {
-        ceilingToStamp = (caps.indexOf('can_chat') !== -1) ? 7 : 3;
       }
     }
     // ---------------------------------------------------------------------
@@ -934,9 +928,18 @@ class __dmz extends Mfs {
     }
 
     if (info.validity == 'TICKET_OK' && info.uid) {
-      await this.yp.await_proc('cookie_touch', {
-        sid: this.input.sid(), uid: info.uid
-      });
+      // Same regsid-hijack guard as _loginSecureShare (defense-in-depth): NEVER rebind
+      // the caller's main-domain auth cookie (regsid) to the legacy share identity.
+      // Legacy links are per-vhost (isolated hub-cookie sid != regsid) so this normally
+      // binds the share's own hub-cookie session; the guard only trips if a legacy share
+      // ever resolves to regsid, in which case rebinding would clobber the auth session.
+      if (regsid && this.input.sid() === regsid) {
+        this.warn('[dmz.login][SECURITY] legacy dmz bind skipped: DMZ session resolved to the main-domain regsid', { share_uid: info.uid });
+      } else {
+        await this.yp.await_proc('cookie_touch', {
+          sid: this.input.sid(), uid: info.uid
+        });
+      }
     }
 
     if (info.is_public && !user.guest_name) {

--- a/service/media.js
+++ b/service/media.js
@@ -214,6 +214,48 @@ class __media extends Mfs {
   }
 
   /**
+   * Resolve the token-authorized LISTING target for a secure-share DMZ request.
+   * A logged-in recipient is node-granted only on the SHARED node; for a FILE share
+   * that grant does NOT confer access to the file's PARENT — which is the folder
+   * media.show_node_by lists. This returns, derived from the TOKEN (authoritative,
+   * never client-supplied):
+   *   { nid: <folder to list>, file_nid: <shared file to hard-filter to | null> }
+   * so the listing can (a) target the shared file's parent even when the caller's own
+   * source resolution missed it, and (b) hard-filter to the shared file so NO sibling
+   * is ever returned. Returns null when NOT a valid secure-share request (no token /
+   * legacy / invalid / revoked / expired) → the caller leaves the listing untouched
+   * (byte-identical for every normal, token-less listing).
+   */
+  async _secureShareListTarget() {
+    const token = this.input.get(Attr.token);
+    if (!token) return null;
+    let info;
+    try {
+      info = toArray(await this.yp.await_proc('secure_share_info', token))[0];
+    } catch (e) {
+      return null; // cannot classify → leave listing untouched
+    }
+    if (!info || info.failed || !info.creator_id) return null;
+    if (info.validity && info.validity !== 'TICKET_OK') return null;
+    let listNid = info.node_id;
+    let file_nid = null;
+    try {
+      const attr = toArray(
+        await this.yp.await_proc('forward_proc', info.hub_id, 'mfs_node_attr', `'${info.node_id}'`)
+      )[0] || {};
+      // A real FILE (not folder / hub / workspace-root) → list its PARENT, hard-filtered
+      // to the file itself. Mirrors the node-type remap in dmz.js::_loginSecureShare.
+      if (attr.filetype && attr.filetype !== 'folder' && attr.filetype !== 'hub' && attr.filetype !== 'root' && attr.pid) {
+        file_nid = info.node_id;
+        listNid = attr.pid;
+      }
+    } catch (e) {
+      // Node-type probe failed → treat as a container (list node_id, no file filter).
+    }
+    return { nid: listNid, file_nid };
+  }
+
+  /**
    *
    * @returns
    */
@@ -1319,7 +1361,8 @@ class __media extends Mfs {
    * 
    */
   async show_node_by() {
-    const nid = this.source_granted().id || "0";
+    const granted = this.source_granted();
+    let nid = (granted && granted.id) || "0";
     const VALID_TYPES = ['all', 'node', Attr.file, Attr.hub, 'docs', 'pdf', 'image', 'other'];
     let sort_by = this.input.use(Attr.sort, Attr.rank).toLowerCase();
     let order = this.input.use(Attr.order, "asc").toLowerCase();
@@ -1334,13 +1377,24 @@ class __media extends Mfs {
       type = 'all';
     }
     const page = this.input.use(Attr.page, 1);
+    // Secure-share (DMZ) request: authorize the listing target from the TOKEN. A
+    // logged-in recipient node-granted only on the shared FILE has no ACL on its
+    // parent, so source resolution can miss it (nid === "0"); the token supplies the
+    // parent to list. For a file share we ALSO hard-filter to the shared file below so
+    // no sibling is ever exposed. null (no token / not a secure share) → unchanged.
+    const ssTarget = await this._secureShareListTarget();
+    if (ssTarget && ssTarget.nid && nid === "0") {
+      nid = ssTarget.nid;
+    }
     let data = await this.db.await_proc(
       "mfs_show_node_by",
       nid,
       this.uid,
       { sort_by, order, page, type }
     );
-    const file_nid = this.input.get('file_nid');
+    // Token-authoritative file filter wins over the client value so a crafted request
+    // (omitting file_nid) can never enumerate the shared file's siblings.
+    const file_nid = (ssTarget && ssTarget.file_nid) || this.input.get('file_nid');
     if (file_nid) {
       data = toArray(data).filter(item => item && item.nid === file_nid);
     }
@@ -1363,7 +1417,8 @@ class __media extends Mfs {
    *
    */
   async show_node_by_with_size() {
-    const nid = this.source_granted().id || "0";
+    const granted = this.source_granted();
+    let nid = (granted && granted.id) || "0";
     const VALID_TYPES = ['all', 'node', 'file', 'hub', 'docs', 'pdf', 'image', 'other'];
     let sort_by = this.input.use(Attr.sort, Attr.rank).toLowerCase();
     let order = this.input.use(Attr.order, "asc").toLowerCase();
@@ -1378,6 +1433,11 @@ class __media extends Mfs {
       type = 'all';
     }
     const page = this.input.use(Attr.page, 1);
+    // Secure-share (DMZ) token scoping — same as show_node_by (see there). null → unchanged.
+    const ssTarget = await this._secureShareListTarget();
+    if (ssTarget && ssTarget.nid && nid === "0") {
+      nid = ssTarget.nid;
+    }
     let branch = await this.db.await_proc(
       "mfs_show_node_by",
       nid,
@@ -1386,6 +1446,10 @@ class __media extends Mfs {
     );
     if (!isArray(branch)) {
       branch = [branch];
+    }
+    const ssFileNid = (ssTarget && ssTarget.file_nid) || this.input.get('file_nid');
+    if (ssFileNid) {
+      branch = toArray(branch).filter(item => item && item.nid === ssFileNid);
     }
     let tree = [];
     for (let file of branch) {


### PR DESCRIPTION
## Lexis prod issue #4 — file-share recipient chatted AS THE CREATOR

Follow-up to the takeover hotfix (#83). A logged-in recipient of a single-FILE secure share had correct desk identity (regsid protected) but the in-share **chat posted as the creator**, because file shares were left creator-bound (folder shares already rebind the recipient).

### Fix (Option C — recipient operates as self, viewing token-scoped)
- **dmz.js `_loginSecureShare`**: extend the recipient rebind + node grant to FILE shares (grant on the shared file node `info.node_id`, bind to the recipient). Ceiling set before the grant so a grant failure degrades to a *clamped* creator binding. Removes the dead file branch.
- **media.js `show_node_by` / `show_node_by_with_size`**: token-scope the DMZ listing so a recipient granted only on the file (not its parent) can still view it — authorize the parent from the token when source resolution misses it, and **hard-filter to the shared file** so no sibling is ever exposed. Endpoint is `src: anonymous` so this is not hard-403'd. **Token-gated: byte-identical for every normal, token-less listing.**
- **dmz.js `login()`**: same regsid-hijack guard on the legacy DMZ path (defense-in-depth).

Net **security improvement**: also closes the old creator-bound sibling/nested over-exposure on file shares.

### Verification
- `node --check` clean; diff is exactly 2 files (+ version). No schema change.
- **All 6 checks passed on the test endpoint (drumee.in)**: recipient chats as self; video still plays; sees only the shared file (no siblings); folder shares still work; view-only can't upload; normal desk unaffected.