### PR TITLE
feat(secure-share): re-enable neutral share host with isolated session (safe)

### DIFF
--- a/client/page.js
+++ b/client/page.js
@@ -84,7 +84,19 @@ class MainPage extends RuntimeEnv {
   refreshAuthorization(data) {
     let { id, keysel } = this.input.authorization();
     let host = main_domain;
-    if (/^(dmz|share)$/.test(data.area)) {
+    // Isolate the DMZ/share session onto its OWN host-scoped cookie in two cases:
+    //   (1) the resolved hub is a dmz/share area (per-workspace vhost link), or
+    //   (2) the connect host is the NEUTRAL share host `share.<main_domain>` — where
+    //       the bootstrap hub is the generic fallback (not a dmz/share area), so
+    //       without this the session would fall back to the apex-scoped `regsid`.
+    // The critical safety property is `host = this.input.host()`: the cookie is scoped
+    // to the CONNECT host (share.<main_domain> on the neutral host), which is NARROWER
+    // than the apex `main_domain`, so this session cookie can NEVER be read as the
+    // auth (regsid) session on app.drumee.com. That makes a DMZ-session → auth-session
+    // rebind structurally impossible here — for authenticated AND anonymous viewers
+    // (Lexis prod issue #3). The dmz.login regsid guard remains as belt-and-suspenders.
+    const isNeutralShareHost = this.input.host() === `share.${main_domain}`;
+    if (/^(dmz|share)$/.test(data.area) || isNeutralShareHost) {
       data.icon = `${endpoint_path}/avatar/${data.owner_id}?type=vignette`;
       keysel = this.hub.get(Attr.id);
       host = this.input.host();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.89",
+  "version": "2.9.92",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.89",
+      "version": "2.9.92",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.89",
+  "version": "2.9.92",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 const {
-  Attr, Cache, Messenger, RedisStore, toArray
+  Attr, Cache, Messenger, RedisStore, toArray, sysEnv
 } = require('@drumee/server-essentials');
 const { Mfs } = require('@drumee/server-core');
 const { isEmpty } = require('lodash');
@@ -140,18 +140,21 @@ class __secure_share extends Mfs {
   }
 
   /**
-   * Base URL for every share link. Anchored to the content workspace's own vhost.
-   * The neutral share host (share.<main_domain>) was REVERTED (hotfix
-   * 2026-07-10): on the neutral host the page bootstraps the default hub, so the
-   * dmz/share cookie-isolation in page.js never engaged and dmz.login's
-   * this.input.sid() resolved to the recipient's main-domain regsid — cookie_touch
-   * then rebound the recipient's AUTH session to the share creator (account
-   * takeover on app.drumee.com). The per-vhost host keeps the DMZ session on an
-   * isolated hub cookie. homepath() supplies the per-endpoint scheme + mount path.
-   * Single source of truth — used by create(), list() and access_list().
+   * Base URL for every share link. Anchored to the NEUTRAL share host
+   * (share.<main_domain>) so links don't leak the workspace vhost name. This was
+   * temporarily reverted to the per-vhost host on 2026-07-10 after the neutral host
+   * caused an auth-session takeover (Lexis prod issue #3) — the neutral host
+   * bootstrapped the generic fallback hub, so page.js never isolated the DMZ session
+   * and it fell back to the apex-scoped regsid. RE-ENABLED once page.js
+   * `refreshAuthorization` was taught to isolate the neutral share host onto its OWN
+   * `share.<main_domain>`-scoped session cookie (narrower than the apex → can never be
+   * the regsid auth session), so the takeover is now structurally impossible there.
+   * homepath() supplies the per-endpoint scheme + mount path. Single source of truth —
+   * used by create(), list() and access_list().
    */
   _shareLinkBase() {
-    return this.input.homepath(this.hub.get(Attr.vhost));
+    const { main_domain } = sysEnv();
+    return this.input.homepath(`share.${main_domain}`);
   }
 
   /**


### PR DESCRIPTION
## Restore the short/clean neutral share host — now takeover-proof

The neutral share host (`share.<main_domain>`) was reverted after the auth-session takeover (Lexis #3) because it bootstrapped the generic fallback hub, so the DMZ session fell back to the apex-scoped `regsid`. This re-enables it, made **structurally safe**.

### Fix
- **client/page.js `refreshAuthorization`**: isolate the DMZ session onto its own cookie when the connect host is `share.<main_domain>` (exact match), not just when the hub area is dmz/share. The cookie is scoped to `this.input.host()` (`share.<main_domain>`) — **narrower than the apex** — so it can never be read as the `regsid` auth session on the apex domain. Makes a DMZ-session → auth-session rebind structurally impossible there for **authenticated AND anonymous** viewers. Byte-identical for every non-neutral host.
- **secure_share.js**: re-point `_shareLinkBase` to the neutral host (+ `sysEnv` import).

Composes with the guard + rebind + token-scoped listing already on preview (all stay as belt-and-suspenders). **Also rescues old neutral-host links** already in circulation (they isolate now → work again) and **stops the `[dmz.login][SECURITY]` alert noise** those were triggering.

### Verification (test endpoint drumee.in — all passed)
- New share link = neutral host; recipient views + chats as self; **no `[SECURITY]` alert** on open (= isolation engaged); old neutral links work; vhost links + normal desk unaffected. No schema change.