### PR TITLE
fix(gdrive): 3 root causes leaving migrations half-populated (DB drop + uppercase ext + duplicate names)

### DIFF
--- a/offline/workers/gdrive/importer.js
+++ b/offline/workers/gdrive/importer.js
@@ -719,7 +719,14 @@ class GoogleDriveImporter {
       }
     }
 
-    const ext = extname(filename).replace(/^\.+/, '');
+    // Lowercase the extension. It flows into BOTH the media node's `extension`
+    // column AND the on-disk file name (`orig.<ext>`). The server always reads
+    // the original back as `orig.<ext.toLowerCase()>` (get_node_content), so an
+    // uppercase Drive extension (e.g. "L.PNG") would write `orig.PNG` but be read
+    // as `orig.png` — a mismatch on a case-sensitive (Linux) filesystem → the
+    // file is "not found" → the image shows no thumbnail and won't open. The
+    // filecap lookup is case-insensitive either way.
+    const ext = extname(filename).replace(/^\.+/, '').toLowerCase();
     // Cache key includes file.id + (optional) export mime so two different
     // Workspace export formats of the same doc don't collide on the URL
     // base. The cache lives in the per-job scratch dir so it's wiped at

--- a/offline/workers/gdrive/importer.js
+++ b/offline/workers/gdrive/importer.js
@@ -110,6 +110,23 @@ class GoogleDriveImporter {
     // Per-job scratch dir — wiped on completion to avoid /tmp growing
     // unboundedly across migrations. Set in run() once job.id is known.
     this._scratchDir = null;
+    // Per-parent-folder serialization of the create-node → resolve-id →
+    // write-bytes critical section. The slow Drive download stays parallel
+    // (FILE_CONCURRENCY); only the DB+disk write serializes per folder, which
+    // lets us resolve the just-created node as the newest child under the
+    // parent — correct even when Drive has duplicate filenames that
+    // mfs_create_node auto-renames (S → S(1) → S(2)). pid → tail promise.
+    this._pidLocks = new Map();
+  }
+
+  // Run fn while holding an exclusive lock for `pid`; concurrent calls for the
+  // same pid run one at a time (different pids stay parallel). The stored tail
+  // swallows errors so one failed file never wedges the folder's queue.
+  async _withPidLock(pid, fn) {
+    const prev = this._pidLocks.get(pid) || Promise.resolve();
+    const run = prev.then(() => fn(), () => fn());
+    this._pidLocks.set(pid, run.then(() => {}, () => {}));
+    return run;
   }
 
   async run() {
@@ -802,53 +819,46 @@ class GoogleDriveImporter {
 
     const filenameWithoutExt = filename.replace(new RegExp(`\\.(${ext})$`, 'i'), '');
 
-    await opts.hubDb.await_proc(
-      'mfs_create_node',
-      {
-        owner_id,
-        filename: filenameWithoutExt,
-        pid,
-        category: filetype,
-        ext,
-        mimetype,
-        filesize: item.size || stat.size,
-        showResults: 1,
-      },
-      {},
-      { isOutput: 1 }
-    );
-    // Resolve the new node id with a direct query (mfs_create_node's CALL
-    // return shape is unreliable in the worker). Match by (pid, name); fall
-    // back to the most-recent non-folder child under pid — files are imported
-    // sequentially within a job, so that's the one just created.
-    // Resolve by (pid, name). The old "most-recent non-folder child under pid"
-    // fallback is REMOVED: under the file pool it could resolve a DIFFERENT
-    // file's id (wrong node). Name resolution is race-safe for DISTINCT names —
-    // the overwhelming common case in a folder. KNOWN LIMITATION: Google Drive
-    // permits two files with the SAME name in one folder; imported concurrently
-    // they both resolve to the first-created node (one ends up byte-less). The
-    // serial path skipped the 2nd via the path dedup above (when file_path is
-    // present); a future conflict-policy pass (rename/overwrite) is the proper
-    // fix. Accepted here over a per-folder write mutex, which would serialize
-    // every file's DB write and erode the concurrency win for a rare case.
-    const nodeId = await this._findChildId(opts.hubDb, pid, filenameWithoutExt, false);
-    if (!nodeId) throw new Error(`could not resolve created file '${filenameWithoutExt}' under pid=${pid}`);
+    // Create the node, resolve its id, and write the bytes as ONE critical
+    // section serialized per parent folder (_withPidLock). mfs_create_node's
+    // CALL return shape is unreliable in the worker, so the id is resolved with
+    // a direct SELECT — and because mfs_create_node AUTO-RENAMES a duplicate
+    // filename (S → S(1)), a match by the ORIGINAL name would resolve the wrong
+    // (already-written) node, leaving the duplicate byte-less (no thumbnail /
+    // won't open). Resolving the NEWEST child under pid instead is exact — but
+    // only while creates under this pid don't interleave, which the lock
+    // guarantees. Downloads (the slow part) already ran in parallel above.
+    await this._withPidLock(pid, async () => {
+      await opts.hubDb.await_proc(
+        'mfs_create_node',
+        {
+          owner_id,
+          filename: filenameWithoutExt,
+          pid,
+          category: filetype,
+          ext,
+          mimetype,
+          filesize: item.size || stat.size,
+          showResults: 1,
+        },
+        {},
+        { isOutput: 1 }
+      );
+      const nodeId = await this._findNewestChildId(opts.hubDb, pid);
+      if (!nodeId) throw new Error(`could not resolve created file '${filenameWithoutExt}' under pid=${pid}`);
 
-    const base = join(home_dir, '__storage__', nodeId);
-    const orig = join(base, `orig.${ext}`);
-    await fsp.mkdir(base, { recursive: true });
-    try {
-      await fsp.copyFile(source, orig);
-    } finally {
-      // Free the scratch copy immediately after the durable write so peak /tmp
-      // stays at ~one file instead of the whole tree — a 10k-file import would
-      // otherwise accumulate every downloaded byte until the end-of-job rm in
-      // run() (→ ENOSPC). async fsp.unlink (never unlinkSync) per the Bull
-      // lock-stall invariant. Best-effort: the end-of-job rm is the backstop.
-      // Trade-off: defeats the in-job same-id dedup (existsSync on `source`) for
-      // a file.id|exportMime that appears twice in one tree — rare, acceptable.
-      try { await fsp.unlink(source); } catch (_) {}
-    }
+      const base = join(home_dir, '__storage__', nodeId);
+      await fsp.mkdir(base, { recursive: true });
+      await fsp.copyFile(source, join(base, `orig.${ext}`));
+    });
+    // Free the scratch copy immediately after the durable write so peak /tmp
+    // stays at ~one file instead of the whole tree — a 10k-file import would
+    // otherwise accumulate every downloaded byte until the end-of-job rm in
+    // run() (→ ENOSPC). async fsp.unlink (never unlinkSync) per the Bull
+    // lock-stall invariant. Best-effort: the end-of-job rm is the backstop.
+    // Trade-off: defeats the in-job same-id dedup (existsSync on `source`) for
+    // a file.id|exportMime that appears twice in one tree — rare, acceptable.
+    try { await fsp.unlink(source); } catch (_) {}
   }
 
   /**
@@ -866,6 +876,24 @@ class GoogleDriveImporter {
            ${isFolder ? "AND category = 'folder'" : "AND category <> 'folder'"}
          ORDER BY id ASC LIMIT 1`,
       pid, name
+    );
+    const row = toArray(rows)[0];
+    return (row && row.id) || null;
+  }
+
+  /**
+   * Resolve the id of the just-created FILE node as the newest non-folder child
+   * under `pid` (highest sys_id). Correct only while called inside the pid lock
+   * (no interleaving creates under this pid) — but then it's exact even when
+   * mfs_create_node auto-renamed a duplicate filename, which a name match can't
+   * handle. Returns the id string or null.
+   */
+  async _findNewestChildId(hubDb, pid) {
+    const rows = await hubDb.await_query(
+      `SELECT id FROM media
+         WHERE parent_id = ? AND category <> 'folder'
+         ORDER BY sys_id DESC LIMIT 1`,
+      pid
     );
     const row = toArray(rows)[0];
     return (row && row.id) || null;

--- a/offline/workers/gdrive/importer.js
+++ b/offline/workers/gdrive/importer.js
@@ -176,8 +176,45 @@ class GoogleDriveImporter {
     if (!dbName) throw new Error(`dest hub db unresolved: hub=${hub_id} user=${user_id}`);
 
     const hubDb = new Mariadb({ name: dbName });
+
+    // The importer holds ONE hubDb connection for the whole job while doing many
+    // slow Drive downloads between DB writes (it also uses the shared yp
+    // connection for the per-file filecap lookup). During a download-heavy
+    // stretch a connection sits idle long enough for MariaDB's wait_timeout (or
+    // a network/LB idle timeout) to close it; the driver then emits an ASYNC
+    // socket 'error' with no pending query. With no 'error' listener Node turns
+    // that into an UNCAUGHT exception that CRASHES the worker mid-job — every
+    // file after that point is silently never imported (the reported symptom:
+    // sub-folder images missing / no thumbnail / won't open). Two guards keep
+    // the job alive:
+    //   1) attach an 'error' listener to the live connection so a dropped socket
+    //      degrades to a reconnect-on-next-query (the wrapper's isValid() check
+    //      re-dials) instead of crashing the process;
+    //   2) a 60s keep-alive ping (well under wait_timeout) keeps hubDb + yp warm
+    //      across downloads and re-arms the guard on the fresh connection object
+    //      a reconnect creates.
+    const guardConn = (db, label) => {
+      const c = db && typeof db.connection === 'function' && db.connection();
+      if (c && typeof c.on === 'function' && !c.__gdriveGuarded) {
+        c.__gdriveGuarded = 1;
+        c.on('error', (e) =>
+          console.warn(`[GDriveImporter] ${label} socket error (reconnect on next query): ${e && (e.code || e.message)}`));
+      }
+    };
+    const keepAlive = setInterval(() => {
+      for (const [db, label] of [[hubDb, 'hubDb'], [this.yp, 'yp']]) {
+        Promise.resolve()
+          .then(() => db.await_query('SELECT 1'))
+          .then(() => guardConn(db, label))
+          .catch(() => {});
+      }
+    }, 60000);
+
     try {
       const destFolder = await hubDb.await_proc('mfs_node_attr', nid);
+      // Arm the socket-error guard on the now-live connections.
+      guardConn(hubDb, 'hubDb');
+      guardConn(this.yp, 'yp');
       if (!destFolder || !destFolder.home_dir) {
         throw new Error(`dest_nid ${nid} invalid`);
       }
@@ -218,6 +255,7 @@ class GoogleDriveImporter {
         });
       }
     } finally {
+      clearInterval(keepAlive);
       // Mariadb.end() returns undefined (not a promise) and swallows its own
       // errors internally. Chaining `.catch()` on it threw "Cannot read
       // properties of undefined (reading 'catch')" in this finally block —

--- a/offline/workers/gdriveWorker.js
+++ b/offline/workers/gdriveWorker.js
@@ -47,6 +47,20 @@ async function startWorker() {
     await yp.await_query('SELECT 1'); // throw → crash → pm2 restarts
   }
 
+  // The shared yp connection is long-lived and used by every job for the
+  // per-file filecap lookup. If it drops (wait_timeout / network idle) the
+  // driver emits an async socket 'error' with no pending query — without a
+  // listener that becomes an uncaught exception (see the process handler
+  // below). Attach a listener so a drop degrades to reconnect-on-next-query
+  // (the Mariadb wrapper re-dials via its isValid() check) instead of a crash.
+  try {
+    const c = typeof yp.connection === 'function' && yp.connection();
+    if (c && typeof c.on === 'function') {
+      c.on('error', (e) =>
+        console.warn('[GDriveWorker] yp socket error (reconnect on next query):', e && (e.code || e.message)));
+    }
+  } catch (_) {}
+
   migrationQueue.process('migrate_google_drive', CONCURRENCY, processJob);
 
   console.log('[GDriveWorker] Worker started, waiting for jobs...');
@@ -87,6 +101,21 @@ process.on('SIGTERM', shutdown);
 process.on('SIGINT', shutdown);
 
 process.on('uncaughtException', (error) => {
+  // A dropped DB socket surfaces here as a fatal async error with no pending
+  // query (errno 45009 / ER_SOCKET_UNEXPECTED_CLOSE / PROTOCOL_CONNECTION_LOST /
+  // ECONNRESET). The Mariadb wrapper re-dials on the next query (isValid check),
+  // so it's recoverable — log and KEEP the worker (and every in-flight import)
+  // alive rather than crashing mid-migration, which would leave the imported
+  // tree half-populated (files after the drop silently never land). Any other
+  // uncaught error still exits so pm2 restarts a genuinely broken worker.
+  const blob = `${(error && error.code) || ''} ${(error && error.message) || ''}`;
+  const recoverableDbDrop =
+    error && (error.fatal || error.errno === 45009) &&
+    /SOCKET|CONNECTION_LOST|CLOSED|ECONNRESET|EPIPE|ETIMEDOUT|08S01/i.test(blob);
+  if (recoverableDbDrop) {
+    console.warn('[GDriveWorker] recoverable DB connection drop (continuing):', blob.trim());
+    return;
+  }
   console.error('[GDriveWorker] Uncaught exception:', error);
   process.exit(1);
 });


### PR DESCRIPTION
## Problem
Google Drive migrations of folders with sub-folders leave the imported tree **half-populated** — sub-folder images end up missing, show no thumbnail, or won't open. Reported: "migrate 1 folder ảnh gồm 3 subfolder → ảnh ở subfolder không hiển thị thumb, không mở được".

Investigation surfaced **three independent root causes**, each of which drops a different subset of files.

---

## Bug #1 — worker crashes on a dropped DB socket (`b7b550c`)
The importer holds **one `hubDb` connection for the whole job** (plus the shared `yp` connection for the per-file filecap lookup) while doing many **slow Drive downloads** between DB writes. During a download-heavy stretch a connection idles long enough for MariaDB's `wait_timeout` / a network idle timeout to close it. The driver then emits an **async socket `error` with no pending query**; with no listener Node turns it into an **uncaught exception**, and the worker's `uncaughtException` handler called `process.exit(1)` — **crashing the worker mid-migration**. Every file after that point is silently never imported.

Evidence: `gdrive-worker-error.log` → `SqlError … socket has unexpectedly been closed (ER_SOCKET_UNEXPECTED_CLOSE, errno 45009) → [GDriveWorker] Uncaught exception → exit`; the `gdrive-worker` pm2 process had a huge restart count (crash-looping).

**Fix**
- **importer.js**: a 60s keep-alive ping (well under `wait_timeout`) keeps `hubDb` + `yp` warm across downloads; an `error` listener on the live connections degrades a drop to *reconnect-on-next-query* (the Mariadb wrapper already re-dials via its `isValid()` check) instead of an uncaught crash; interval cleared in `finally`.
- **gdriveWorker.js**: attach the same guard to the long-lived shared `yp` connection; make the `uncaughtException` handler **tolerate a recoverable DB socket drop** (errno 45009 / SOCKET_CLOSED / CONNECTION_LOST / ECONNRESET) — log & continue instead of `exit(1)`.

---

## Bug #2 — uppercase file extension → image never renders (`f837673`)
Files whose Drive name had an **uppercase extension** (`photo.PNG`) were stored as `orig.PNG`, but the DB `extension` column and the server's `get_node_content` path builder lowercase the extension (`${base}/${format}.${ext.toLowerCase()}` → `orig.png`). On the case-sensitive server FS `orig.png` ≠ `orig.PNG`, so the read 404s → placeholder thumbnail + viewer can't open. This is why one whole sub-folder ("Mua theo HN", all `.PNG`) showed blanks while `.jpg` sub-folders were fine.

**Fix** — **importer.js**: normalize once at write time
```js
const ext = extname(filename).replace(/^\.+/, '').toLowerCase();
```
so the stored file (`orig.png`) matches the lowercased path the reader builds.

---

## Bug #3 — duplicate Drive filenames land byte-less (`eaed569`)
Within one folder, Drive allows repeated names (`S`, `S(1)`, `S(2)`, `S(3)`, `L`, `L(1)`). The importer created the node via `mfs_create_node` then looked the new node up **by filename** to find its storage id. With duplicates that lookup was ambiguous/raced across the concurrent create+resolve+copy, so the second+ duplicate resolved to the **wrong or a not-yet-created id** — `copyFile` wrote to a path whose node row didn't match, leaving the real node **byte-less** ("No such file or directory" on disk) → blank thumbnail, won't open.

**Fix** — **importer.js**: serialize create→resolve→write per parent and resolve by newest child, not by name
- `_withPidLock(pid, fn)` — a per-parent promise chain so a folder's create+resolve+copy never interleaves with a sibling's.
- `_findNewestChildId(hubDb, pid)` — `SELECT id FROM media WHERE parent_id=? AND category<>'folder' ORDER BY sys_id DESC LIMIT 1`, i.e. resolve the id we just created by recency under the lock, independent of filename.

---

## Verify — fresh end-to-end migration (owner2, all 3 fixes deployed)
Re-ran the exact reported folder (3 sub-folders, mixed `.jpg`/`.PNG`, duplicate names) on a clean account:
- **68 files imported, `errors: 0`**, worker did **not** crash (bug #1).
- Every stored file is `orig.<lowercase-ext>` — DB `extension` all lowercase (bug #2).
- Duplicate-named nodes **S, S(1), S(2), S(3), L, L(1)** each have their **own storage dir** with `orig.png` whose byte size matches the DB `filesize` exactly (bug #3):
  `S=4062150  S(1)=1553242  S(2)=4724656  S(3)=3349430  L=1995920  L(1)=3321471` — all non-zero.
- **UI:** all 10 images in the previously-broken sub-folder render thumbnails; `S(3)` (a formerly byte-less duplicate) opens full-resolution in the viewer.

**Deploy note:** the gdrive worker is a separate pm2 process — after deploy, `pm2 restart gdrive-worker` (it does NOT restart with endpoint/service).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
