### PR TITLE
fix(gdrive): export Google Docs as DOCX instead of PDF

### DIFF
--- a/offline/workers/gdrive/importer.js
+++ b/offline/workers/gdrive/importer.js
@@ -707,8 +707,11 @@ class GoogleDriveImporter {
       item.mimeType.startsWith('application/vnd.google-apps');
     if (isWorkspaceDoc) {
       // Google Workspace doc — has no binary content; must be exported.
+      // Docs export as DOCX (editable, layout preserved) to match the
+      // Sheets→XLSX / Slides→PPTX convention — PDF froze the document into a
+      // non-editable, often distorted rendering.
       const EXPORT = {
-        'google-apps.document':     { mime: 'application/pdf',                                                                      ext: 'pdf'  },
+        'google-apps.document':     { mime: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',              ext: 'docx' },
         'google-apps.spreadsheet':  { mime: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',                    ext: 'xlsx' },
         'google-apps.presentation': { mime: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',            ext: 'pptx' },
         'google-apps.drawing':      { mime: 'image/png',                                                                            ext: 'png'  },


### PR DESCRIPTION
## Bug
Migrating from Google Drive converts **Google Docs → PDF**: the imported file opens in the PDF viewer, cannot be edited, and the layout is often distorted.

## Root cause
`offline/workers/gdrive/importer.js` EXPORT map was inconsistent — Sheets→**XLSX** and Slides→**PPTX** keep an editable office format, but Docs→**PDF** froze the document.

## Fix
`google-apps.document` now exports as `application/vnd.openxmlformats-officedocument.wordprocessingml.document` (**.docx**). `yp.filecap` already maps `docx → category=document` with the proper mimetype, so the imported node behaves exactly like a regular .docx upload (poster/preview pipeline included).

UI companion: drumee/ui-team `fix/gdrive-docs-export-docx` updates the migrate-popup hint (PDF/XLSX/PPTX → DOCX/XLSX/PPTX).

**Deploy note:** the gdrive worker is a separate pm2 process — after deploy, `pm2 restart gdrive-worker`.

Note: existing already-migrated PDFs stay as-is (re-running the migration imports the Doc again as `name.docx` alongside, since the conflict check is by filename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)