### PR TITLE
fix(secure-share): let logged-in non-members view single-file shares

### DIFF
--- a/offline/test/secure-share-session.test.js
+++ b/offline/test/secure-share-session.test.js
@@ -207,6 +207,29 @@ const invariants = [
     );
   }],
 
+  ['file share: recipient gets a NON-INHERITING parent grant so the listing gate passes', async () => {
+    const dmz = src('service/dmz.js');
+    // A logged-in NON-member rebound to self is granted only on the shared FILE, but
+    // media.show_node_by lists the file's PARENT (info.nid) and its src=anonymous ACL
+    // gate resolves user_permission on that parent BEFORE the body → 0 for a non-member
+    // → 403 (the reported "public file share shows no video"). The fix grants the parent
+    // a read-only, NON-INHERITING ('root') grant so the gate passes WITHOUT exposing
+    // siblings (parent_permission CASEs assign_via='root' → 0 for children). Removing
+    // this reopens the 403; changing 'root'→'system' would leak every sibling.
+    const grantIdx = dmz.indexOf("'system', 'Secure share access'");
+    assert.ok(grantIdx > 0, 'file-node grant call not found');
+    // The parent-traversal grant sits just after the file grant, still inside the branch.
+    const after = dmz.slice(grantIdx, grantIdx + 2000);
+    assert.ok(
+      /info\.file_nid\s*&&\s*info\.nid\s*&&\s*info\.nid\s*!==\s*info\.node_id/.test(after),
+      'parent-traversal grant must be gated on a real FILE share (file_nid set, parent !== file)'
+    );
+    assert.ok(
+      /info\.nid,\s*user\.id,\s*0,\s*\(grantTarget\s*&\s*0b0000011\),\s*'root',\s*'Secure share access'/.test(after),
+      "parent-traversal grant must be READ-ONLY (grantTarget & 0b0000011) and NON-INHERITING (assign_via='root')"
+    );
+  }],
+
   ['#4 media.js: listing is token-scoped + hard-filtered to the shared file', async () => {
     const media = src('service/media.js');
     assert.ok(/_secureShareListTarget\s*\(/.test(media), 'token listing helper missing');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "drumee_server",
-  "version": "2.9.93",
+  "version": "2.9.94",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "drumee_server",
-      "version": "2.9.93",
+      "version": "2.9.94",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
         "@drumee/server-core": "^1.1.79",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drumee_server",
-  "version": "2.9.93",
+  "version": "2.9.94",
   "description": "Drumee Infrastructure",
   "main": "index.js",
   "scripts": {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -696,7 +696,33 @@ class __dmz extends Mfs {
               `${db_name}.permission_grant`,
               info.node_id, user.id, 0, grantTarget, 'system', 'Secure share access'
             );
-            bindUid = user.id;            // rebind ONLY after the grant succeeds
+            // FILE share: the grant above lands on the file (info.node_id), but
+            // media.show_node_by lists the file's PARENT (info.nid, remapped ~L455).
+            // show_node_by is src=anonymous, yet its ACL gate resolves the caller's
+            // real user_permission on that parent BEFORE the worker body runs — and a
+            // logged-in NON-member has 0 there (the file grant does not confer parent
+            // access), so the listing is DENIED → 403 → the recipient sees no file.
+            // (Anonymous escapes this: it stays creator-bound; members have standing;
+            // folder shares grant the listed node itself.) Grant the recipient a
+            // READ-ONLY, NON-INHERITING grant on the parent so the gate passes without
+            // exposing siblings:
+            //   * assign_via='root' makes parent_permission() treat this grant as 0 for
+            //     CHILDREN (its anchor CASEs 'root' → 0), so siblings' user_permission
+            //     stays 0 → no sibling is listable or directly reachable. Only
+            //     parent_permission consumes assign_via='root'; nothing else keys off it
+            //     (membership is resource_id='*' + assign_via='system').
+            //   * read-only bits only (grantTarget & 0b0000011) → never write/edit on
+            //     the parent folder (defense-in-depth with the file-share write block).
+            //   * media.show_node_by ALSO hard-filters to info.file_nid → belt & braces.
+            // Gated on a real FILE share (info.file_nid set AND parent !== the file); a
+            // no-op for folder/workspace shares, anonymous, members, and non-share desk.
+            if (info.file_nid && info.nid && info.nid !== info.node_id) {
+              await this.yp.await_proc(
+                `${db_name}.permission_grant`,
+                info.nid, user.id, 0, (grantTarget & 0b0000011), 'root', 'Secure share access'
+              );
+            }
+            bindUid = user.id;            // rebind ONLY after the grant(s) succeed
           }
         } catch (e) {
           this.warn('[dmz.login] secure_share node grant failed; keeping creator binding (clamped):', e && e.message);


### PR DESCRIPTION
## Problem (prod, Lexis #5)
A **public single-FILE** secure share (video) opened by a **logged-in non-member** returned `403` on `media.show_node_by` → no video. **Anonymous/incognito worked.** Regression from the Lexis #4 file-share rebind.

## Root cause (confirmed on prod DB + logs)
`_loginSecureShare` rebinds a logged-in recipient to their own uid and grants priv only on the shared **FILE**, but `media.show_node_by` lists the file's **PARENT**. show_node_by is `src=anonymous`, yet its ACL gate resolves the caller's real `user_permission(uid, parent)` **before** the worker body — and a non-member has `0` there → DENIED → 403, so the body's token-scoped listing never runs. Anonymous escaped it (stays creator-bound), members have standing, folder shares grant the listed node itself.

## Fix (server-only, no schema/DB change)
In the pure-recipient file-share branch, after the file-node grant, also grant the recipient a **read-only, NON-INHERITING** grant on the parent folder:
`permission_grant(info.nid, user.id, 0, (grantTarget & 0b0000011), 'root', 'Secure share access')`.
- `assign_via='root'` is the only marker `parent_permission()` treats as `0` for children → the listing gate passes but **no sibling** is listable or directly reachable. `assign_via='root'` is consumed only by `parent_permission` (membership is `resource_id='*'`+`assign_via='system'`).
- read-only bits only → never write/edit the parent (defense-in-depth with the file-share write block); `show_node_by` still hard-filters to the shared file.

## Safety / regression
- Proven on real prod data inside a **rolled-back** transaction: `user_permission(parent)=3`, shared file `=3`, siblings `=0`; post-rollback `=0` (prod untouched).
- **Zero** session/cookie/regsid/ceiling code changed → hijack class unaffected.
- Byte-identical for: token-less desk, anonymous, members/owner, folder + workspace shares (all guarded). Grant-failure degrades to the clamped creator binding.
- Added a source-invariant regression canary in `offline/test/secure-share-session.test.js` (fails if the grant is removed or `'root'`→`'system'`). Full suite 21/21.
- Verified end-to-end on drumee.in (test, v2.9.94): logged-in non-member views the file, no siblings; folder/anonymous/member paths unaffected.

Note: the `check-source` CI gate is expected to flag this (preview PR from a hotfix branch, not `test`) — same as prior hotfix PRs; admin override to merge.