### PR TITLE
feat(billing): native cancel/resume endpoints + webhook cancel-path fixes

### DIFF
--- a/acl/payment.json
+++ b/acl/payment.json
@@ -4,6 +4,8 @@
     "checkout":            { "scope": "hub", "permission": { "src": "owner" }, "params": { "period": { "type": "string", "required": true }, "plan": { "type": "string", "required": false }, "seats": { "type": "integer", "required": false, "default": 1 }, "entity_type": { "type": "string", "required": false }, "bundle": { "type": "string", "required": false } } },
     "subscription_status": { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
     "portal":              { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
+    "cancel_subscription": { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
+    "resume_subscription": { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
     "checkout_result":     { "scope": "hub", "permission": { "src": "owner" }, "params": { "session_id": { "type": "string", "required": true } } },
     "webhook":             { "scope": "hub", "permission": { "src": "read", "fast_check": "public-api" }, "method": "receive", "params": { "stripe-signature": { "type": "string", "required": true }, "raw_body": { "type": "string", "required": true } }, "errors": [{ "code": "WEBHOOK_ERROR", "http_status": 400 }] }
   },

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -155,6 +155,58 @@ class __private_payment extends Entity {
     this.output.data({ url: session.url });
   }
 
+  // Native in-app cancel: schedule the subscription to end at the current
+  // period end (Stripe cancel_at_period_end=true). The user keeps the paid tier
+  // until period_end; the customer.subscription.updated webhook mirrors
+  // status='canceled', and the entitlement is dropped only by the final
+  // customer.subscription.deleted. Returns the live status + period_end so the
+  // FE flips to "ends on {date}" immediately, without waiting on the webhook.
+  // _subscription_row() is caller-scoped (own sub, or the org this owner owns),
+  // so a member can never cancel someone else's / a team they don't own.
+  async cancel_subscription() {
+    let stripe;
+    try { stripe = this._stripe(); }
+    catch (e) { return this.output.data({ status: 'STRIPE_NOT_CONFIGURED' }); }
+    const sub = await this._subscription_row();
+    const subscription_id = sub && sub.subscription_id;
+    if (!subscription_id) return this.output.data({ status: 'NO_SUBSCRIPTION' });
+    let s;
+    try {
+      s = await stripe.subscriptions.update(subscription_id, { cancel_at_period_end: true });
+    } catch (e) {
+      return this.output.data({ status: 'CANCEL_FAILED', error: e && e.message });
+    }
+    const items = (s.items && s.items.data) || [];
+    this.output.data({
+      status: 'canceled',
+      cancel_at_period_end: true,
+      period_end: s.current_period_end || (items[0] && items[0].current_period_end) || (sub && sub.period_end) || 0,
+    });
+  }
+
+  // Undo a scheduled cancellation (Stripe cancel_at_period_end=false) — the
+  // subscription resumes normal renewal. The webhook re-mirrors status='active'.
+  async resume_subscription() {
+    let stripe;
+    try { stripe = this._stripe(); }
+    catch (e) { return this.output.data({ status: 'STRIPE_NOT_CONFIGURED' }); }
+    const sub = await this._subscription_row();
+    const subscription_id = sub && sub.subscription_id;
+    if (!subscription_id) return this.output.data({ status: 'NO_SUBSCRIPTION' });
+    let s;
+    try {
+      s = await stripe.subscriptions.update(subscription_id, { cancel_at_period_end: false });
+    } catch (e) {
+      return this.output.data({ status: 'RESUME_FAILED', error: e && e.message });
+    }
+    const items = (s.items && s.items.data) || [];
+    this.output.data({
+      status: s.status || 'active',
+      cancel_at_period_end: false,
+      period_end: s.current_period_end || (items[0] && items[0].current_period_end) || (sub && sub.period_end) || 0,
+    });
+  }
+
   // Post-Checkout receipt details for the success/failure modal: total paid,
   // invoice number, payment date and card brand/last4, straight from the
   // Checkout Session the browser was redirected back with.

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -106,15 +106,28 @@ class __public_stripe_webhook extends Entity {
               await this.yp.await_proc('subscription_update', entity_id, customer_id, subscription_id, plan, period, 1, price, 0, status);
             }
             await this.yp.await_proc('payment_apply_entitlement', entity_id, plan, period_end, entity_type, seat_total, extra_disk);
-            await this.notify_user(entity_id, { service: 'payment.plan_updated', plan, status: 'active' });
+            // Push the REAL status (canceled when cancel_at_period_end), not a
+            // hardcoded 'active' — a pending cancel must reach the client so the
+            // billing screen flips to "ends on {period_end}" in realtime. Carry
+            // period_end so the FE can render the date without a refetch.
+            await this.notify_user(entity_id, { service: 'payment.plan_updated', plan, status, period_end });
           }
           break;
         }
         case 'customer.subscription.deleted': {
           const entity_id = md.entity_id;
           if (entity_id) {
+            const etype = md.entity_type || 'user';
             await this.yp.await_proc('subscription_remove', entity_id, obj.id || '');
-            await this.yp.await_proc('payment_apply_entitlement', entity_id, 'free', 0, md.entity_type || 'user', 0, 0);
+            if (etype === 'org') {
+              // Team cancel: DELETE the org entitlement row so every member
+              // falls back to the per-user free tier. Applying a 'free' plan to
+              // an org yields disk 0 (no ('free','org') plan row → 50GB*0 seats)
+              // and locks out the whole team.
+              await this.yp.await_proc('payment_clear_entitlement', entity_id);
+            } else {
+              await this.yp.await_proc('payment_apply_entitlement', entity_id, 'free', 0, 'user', 0, 0);
+            }
             await this.notify_user(entity_id, { service: 'payment.plan_updated', plan: 'free', status: 'canceled' });
           }
           break;
@@ -151,6 +164,11 @@ class __public_stripe_webhook extends Entity {
       }
     } catch (e) {
       this.error(`stripe reducer failed for ${event.id}: ${e.message}`); // message only, no secrets
+      // Undo the 'seen' row so Stripe's retry re-processes this event instead of
+      // hitting the duplicate guard and skipping it (which would silently drop a
+      // cancellation/downgrade). Return 500 so Stripe actually retries.
+      try { await this.yp.await_proc('stripe_event_delete', event.id); } catch (e2) {}
+      return this.exception.server({ error: '_internal_error', service: 'stripe_webhook' });
     }
     await this.yp.await_proc('stripe_event_processed', event.id);
     this.output.data({ ok: 1 });


### PR DESCRIPTION
Server half of the billing-cancel feature (schemas drumee/schemas#62 + FE drumee/ui-team companions).

## payment.js — native in-app cancel
- **cancel_subscription()**: Stripe `cancel_at_period_end=true` — schedules end at period end, user keeps the paid tier until then. Returns live status + period_end so the FE flips to 'ends on {date}' immediately.
- **resume_subscription()**: undo a scheduled cancel. Both caller-scoped via `_subscription_row` (own sub, or an org this owner owns) — a member can't cancel a team they don't own.
- acl/payment.json: register both (scope hub, src owner).

## stripe_webhook.js — cancel-path correctness
1. **Org lockout**: `subscription.deleted` for an org now calls `payment_clear_entitlement` (removes the org quota row) instead of a 'free' plan that resolves to disk 0 and locks out every member.
2. **Lost-cancel retry**: on a reducer error, delete the stripe_event row + return 500 so Stripe retries — previously the seen row de-duped every retry and the downgrade was silently dropped.
3. **Realtime status**: the `subscription.updated` notify pushes the real status (canceled on cancel_at_period_end) + period_end, not a hardcoded 'active', so the client reflects a pending cancel without a refetch.

## Verified (test env, reversible on owner1's test sub)
Stripe `cancel_at_period_end=true` → webhook → mirror `status='canceled'`; `false` (resume) → mirror `status='active'`. Deployed to the monolith payment service (the stale `stripe-server` plugin is overridden — monolith wins).

**Deploy note:** the monolith payment service serves `SERVICE.payment.*` (the `stripe-server` plugin's payment module is skipped). No worker restart needed; restart the endpoint + service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)