### PR TITLE
perf(upload): async non-blocking file move — keep server responsive during bulk upload

### DIFF
--- a/service/media.js
+++ b/service/media.js
@@ -66,6 +66,36 @@ const {
 } = require("fs");
 
 const {
+  mkdir: mkdirAsync,
+  rename: renameAsync,
+  copyFile: copyFileAsync,
+  unlink: unlinkAsync,
+} = require("fs/promises");
+
+/**
+ * Non-blocking file move. The uploaded file lands in tmp_dir (root fs) while
+ * the MFS storage tree lives on a separate data volume, so a plain rename
+ * throws EXDEV and the shared MfsTools.mv() falls back to the SYNCHRONOUS
+ * cpSync — which blocks the single-process Node event loop for the whole copy
+ * of every uploaded file, freezing all other requests during a bulk upload.
+ * Here rename is tried first (O(1) when same-device); the cross-device copy
+ * runs on the libuv threadpool (copyFile), keeping the event loop responsive.
+ */
+async function moveFileAsync(src, dest) {
+  try {
+    await renameAsync(src, dest);
+  } catch (e) {
+    if (e && e.code === "EXDEV") {
+      await copyFileAsync(src, dest);
+      await unlinkAsync(src);
+    } else {
+      return false;
+    }
+  }
+  return true;
+}
+
+const {
   isString,
   isObject,
   map,
@@ -1321,7 +1351,7 @@ class __media extends Mfs {
    */
   async after_store(pid, incoming_file, data) {
     const base = resolve(data.mfs_root, data.id);
-    mkdirSync(base, { recursive: true });
+    await mkdirAsync(base, { recursive: true });
     const ext = data.extension.toLowerCase();
     let orig = `${base}/orig.${ext}`;
     this.granted_node(data);
@@ -1335,7 +1365,7 @@ class __media extends Mfs {
       return content;
     }
 
-    if (!mv(incoming_file, orig) || !existsSync(orig)) {
+    if (!(await moveFileAsync(incoming_file, orig)) || !existsSync(orig)) {
       this.warn(`${__filename}:337 ${orig} not found`);
       this.exception.user(FAILED_CREATE_FILE);
       return { ...data, error: 1 };


### PR DESCRIPTION
## Problem
Uploading a large batch (~200 files) made **the whole server unresponsive** — navigation, folder listing, everything hung until the batch finished.

## Root cause (confirmed)
Uploaded files are streamed to `tmp_dir` (`/srv/drumee/runtime/tmp`, on the **root** fs `/dev/md3`), while the MFS storage tree lives on a **separate data volume** (`/data`, `datavg-datalv`). In `media.js after_store()`, `MfsTools.mv(incoming_file, orig)` does `renameSync`, which throws `EXDEV` across mounts and falls back to the **synchronous `cpSync`** (+ `mkdirSync`). A synchronous full-file copy **blocks the single-process Node event loop** for the entire copy of *every* file, so no other request can be served during the batch.

## Fix
- Add `moveFileAsync(src, dest)`: `fs/promises.rename` first (O(1) same-device), and on `EXDEV` a cross-device `copyFile` (runs on the **libuv threadpool**, non-blocking) + `unlink`.
- `after_store`: `mkdirSync` → `await mkdir`, `mv` → `await moveFileAsync`.

Event loop stays responsive to other requests while a bulk upload runs. Pairs with the ui-team FE change (serial → bounded-concurrency uploader) — the async move is what makes parallel uploads safe (the old serial gate was a workaround for the gateway 504s the blocking copy caused).

## Verification
- `node --check` clean.
- Faithful async port of the existing `mv` semantics (rename → EXDEV → copy+unlink).
- Live end-to-end verification on the vudangnt test endpoint pending (deploy step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
