### PR TITLE
fix(offline): trash/expiry purge worker ENOENT — resolve via __dirname not server_home

### DIFF
--- a/offline/workers/expiryWorker.js
+++ b/offline/workers/expiryWorker.js
@@ -21,7 +21,13 @@ const EXPIRY_SCHEDULE = process.env.EXPIRY_SCHEDULE || '0 2 * * *'; // Default: 
 console.log(`[ExpiryWorker] Starting worker: ${WORKER_NAME}`);
 console.log(`[ExpiryWorker] Schedule: ${EXPIRY_SCHEDULE}`);
 
-const { server_home, tmp_dir } = sysEnv();
+const { tmp_dir } = sysEnv();
+// Resolve the purge worker relative to THIS file, not sysEnv().server_home —
+// server_home is the bare runtime/server root (no endpoint segment), so the old
+// resolve(server_home, 'offline', 'media', 'purge.js') spawned a nonexistent
+// path (ENOENT). __dirname stays inside the running endpoint's tree. Mirrors
+// service/media.js's OFFLINE_DIR.
+const PURGE_WORKER = resolve(__dirname, '..', 'media', 'purge.js');
 const SPAWN_OPT = { detached: true, stdio: ['ignore', 'ignore', 'ignore'] };
 const JSON_OPT = { spaces: 2, EOL: '\r\n' };
 
@@ -127,8 +133,8 @@ async function processHub(hub) {
 
     console.log(`[ExpiryWorker] Spawning purge.js for ${entities.length} files`);
 
-    // Spawn purge.js
-    const cmd = resolve(server_home, 'offline', 'media', 'purge.js');
+    // Spawn purge.js (path resolved relative to this worker — see PURGE_WORKER)
+    const cmd = PURGE_WORKER;
     const args = {
       entities,
       uid: 'system' // System-triggered deletion

--- a/offline/workers/trashWorker.js
+++ b/offline/workers/trashWorker.js
@@ -16,7 +16,14 @@ const WORKER_NAME = process.env.WORKER_NAME || 'trash-worker-1';
 console.log(`[TrashWorker] Starting worker: ${WORKER_NAME}`);
 console.log(`[TrashWorker] Concurrency: ${CONCURRENCY}`);
 
-const { server_home, tmp_dir } = sysEnv();
+const { tmp_dir } = sysEnv();
+// Resolve the purge worker relative to THIS file, not sysEnv().server_home —
+// server_home comes back as the bare runtime/server root (no endpoint segment),
+// so `resolve(server_home, 'offline', 'media', 'purge.js')` pointed at a path
+// that doesn't exist (the worker lives under <endpoint>/offline/media/purge.js),
+// spawning ENOENT and failing every empty-trash job. __dirname is always inside
+// the running endpoint's tree. Mirrors service/media.js's OFFLINE_DIR.
+const PURGE_WORKER = resolve(__dirname, '..', 'media', 'purge.js');
 const SPAWN_OPT = { detached: true, stdio: ['ignore', 'ignore', 'ignore'] };
 const JSON_OPT = { spaces: 2, EOL: '\r\n' };
 
@@ -67,8 +74,8 @@ trashQueue.process('empty_trash', CONCURRENCY, async (job) => {
     
     console.log(`[TrashWorker] Found ${entities.length} files to purge`);
     
-    // Spawn purge.js
-    const cmd = resolve(server_home, 'offline', 'media', 'purge.js');
+    // Spawn purge.js (path resolved relative to this worker — see PURGE_WORKER)
+    const cmd = PURGE_WORKER;
     const args = { entities, uid };
     
     const queueDir = resolve(tmp_dir, 'offline', 'queue');


### PR DESCRIPTION
## Bug
Emptying the Trash returned **502 "The server has encountered an error"**. The service log showed:
```
Error: spawn /srv/drumee/runtime/server/offline/media/purge.js ENOENT
```

## Root cause
`trashWorker.js` (and `expiryWorker.js`) spawn the purge worker with
`resolve(server_home, 'offline', 'media', 'purge.js')`, but `sysEnv().server_home`
returns the **bare `runtime/server` root** with no endpoint segment. The purge
worker actually lives under `<endpoint>/offline/media/purge.js`, so the resolved
path doesn't exist → `spawn()` ENOENT → the `empty_trash` job crashes → 502.

Verified live on the server:
```
OLD (server_home): /srv/.../runtime/server/offline/media/purge.js          => exists: false
NEW (__dirname)  : /srv/.../runtime/server/vudangnt/offline/media/purge.js  => exists: true
```

## Fix
Resolve the purge worker relative to `__dirname` (always inside the running
endpoint's tree), mirroring `service/media.js`'s `OFFLINE_DIR = resolve(__dirname, "..", "offline", "media")`. Applied to both `trashWorker` and `expiryWorker`; dropped the now-unused `server_home` from their `sysEnv()` destructure.

## Verification
- `node --check` clean on both files.
- Deployed to the vudangnt test runtime + restarted the service; the resolved path now points to an existing file (see above), so the purge spawn no longer ENOENTs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
