### PR TITLE
feat(payment): send the payment-receipt email on invoice.paid

### DIFF
--- a/service/lib/butler-mail.js
+++ b/service/lib/butler-mail.js
@@ -1,0 +1,52 @@
+// service/lib/butler-mail.js
+// Shared "butler" email sender: multipart/alternative (plain-text + HTML) with
+// deliverability headers (display-name From). Extracted from the pattern in
+// service/private/contact.js (_sendButlerMail) so non-contact senders (e.g. the
+// Stripe webhook's payment receipt) reuse it instead of re-implementing;
+// contact.js can migrate to this helper later.
+const { readFileSync } = require('fs');
+const { resolve } = require('path');
+const { sysEnv } = require('@drumee/server-essentials');
+
+let _butlerSender;
+/**
+ * The configured MTA auth user (the only From we can send as without SPF/DKIM
+ * misalignment). null when no MTA credential is configured.
+ * @returns {string|null}
+ */
+function butlerSender() {
+  if (_butlerSender !== undefined) return _butlerSender;
+  try {
+    const f = resolve(sysEnv().credential_dir, 'email.json');
+    _butlerSender = (JSON.parse(readFileSync(f, 'utf8')).auth || {}).user || null;
+  } catch (e) {
+    _butlerSender = null;
+  }
+  return _butlerSender;
+}
+
+/**
+ * Send a butler email as multipart/alternative (text + html). Falls back to
+ * Messenger.send() (HTML-only) when no MTA or no usable sender is configured,
+ * preserving the NO_MTA handling.
+ * @param {Messenger} msg - configured Messenger (subject, recipient, handler)
+ * @param {{recipient:string, subject:string, html:string, text:string}} parts
+ * @returns {Promise<{recipient:string, error:null|string[]}>}
+ */
+async function sendButlerMail(msg, { recipient, subject, html, text }) {
+  const mta = await msg.getMTA();
+  if (!mta) return msg.send({ html });
+  const sender = butlerSender();
+  if (!sender) return msg.send({ html });
+  const mailOptions = {
+    from: `"Drumee" <${sender}>`,
+    to: recipient,
+    subject,
+    text,
+    html,
+  };
+  await mta.sendMail(mailOptions);
+  return { recipient, error: null };
+}
+
+module.exports = { butlerSender, sendButlerMail };

--- a/service/private/templates/butler/payment-receipt.html
+++ b/service/private/templates/butler/payment-receipt.html
@@ -1,0 +1,172 @@
+<%
+// Payment receipt email — Figma 2803-1288 ("email invoice").
+// Vars: plan_label, cycle_label, seats (0 hides row), next_billing_date,
+// amount, paid_date_long, invoice_number, invoice_url ('' hides link),
+// receipt_url ('' hides link), lines [{label, amount}], total,
+// features [string] ([] hides block), app_link, support_email.
+var FONT = "'Geist','SF Pro Display',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif";
+%><!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="x-apple-disable-message-reformatting">
+  <title>Your Drumee <%= plan_label %> plan is active</title>
+</head>
+<body style="margin:0;padding:0;background:#fff;-webkit-font-smoothing:antialiased;font-family:'Geist','SF Pro Display',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#fff;">
+    <tr>
+      <td align="center" style="padding:0;">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;background:#fff;border:1px solid #d1d1d6;border-radius:8px;overflow:hidden;">
+
+          <!-- Header: purple signature -->
+          <tr>
+            <td bgcolor="#433cc5" align="center" style="padding:24px;background:#433cc5;">
+              <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr><td align="center" style="line-height:0;">
+                <img src="https://content.app.drumee.com/icons/logo.png" width="170" height="36" alt="Drumee" style="display:block;border:0;outline:0;text-decoration:none;-ms-interpolation-mode:bicubic;">
+              </td></tr></table>
+            </td>
+          </tr>
+
+          <!-- Main content -->
+          <tr>
+            <td style="padding:32px;">
+
+              <!-- Check badge + headline -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr><td align="center" style="padding:8px 0 16px 0;">
+                  <table role="presentation" cellpadding="0" cellspacing="0" border="0"><tr>
+                    <td align="center" valign="middle" width="56" height="56" style="width:56px;height:56px;border-radius:28px;background:#e3f4ea;font-family:<%= FONT %>;font-size:26px;line-height:56px;color:#2f9e5f;">&#10003;</td>
+                  </tr></table>
+                </td></tr>
+                <tr><td align="center">
+                  <h1 style="margin:0 0 8px 0;padding:0;font-family:<%= FONT %>;font-weight:600;font-size:24px;line-height:1.2;color:#0b0a21;">Your Drumee <%= plan_label %> plan is active</h1>
+                  <p style="margin:0;padding:0;font-family:<%= FONT %>;font-weight:400;font-size:14px;line-height:1.5;color:#65656c;">Your payment went through. Here's your receipt.</p>
+                </td></tr>
+              </table>
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="height:28px;line-height:28px;font-size:0;">&nbsp;</td></tr></table>
+
+              <!-- Plan summary rows -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="border-top:1px solid #e5e5ea;">
+                <tr>
+                  <td style="padding:10px 0;font-family:<%= FONT %>;font-size:13px;color:#65656c;">Plan</td>
+                  <td align="right" style="padding:10px 0;font-family:<%= FONT %>;font-size:13px;font-weight:600;color:#0b0a21;"><%= plan_label %> &mdash; <%= cycle_label %></td>
+                </tr>
+                <% if (seats && Number(seats) > 0) { %>
+                <tr>
+                  <td style="padding:10px 0;font-family:<%= FONT %>;font-size:13px;color:#65656c;">Seats</td>
+                  <td align="right" style="padding:10px 0;font-family:<%= FONT %>;font-size:13px;font-weight:600;color:#0b0a21;"><%= seats %></td>
+                </tr>
+                <% } %>
+                <% if (next_billing_date) { %>
+                <tr>
+                  <td style="padding:10px 0;font-family:<%= FONT %>;font-size:13px;color:#65656c;">Next billing date</td>
+                  <td align="right" style="padding:10px 0;font-family:<%= FONT %>;font-size:13px;font-weight:600;color:#0b0a21;"><%= next_billing_date %></td>
+                </tr>
+                <% } %>
+              </table>
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="height:20px;line-height:20px;font-size:0;border-top:1px solid #e5e5ea;">&nbsp;</td></tr></table>
+
+              <!-- Receipt: amount + download links -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr>
+                  <td valign="top">
+                    <p style="margin:0 0 6px 0;padding:0;font-family:<%= FONT %>;font-size:14px;font-weight:600;color:#0b0a21;">Receipt from Drumee</p>
+                    <p style="margin:0;padding:0;font-family:<%= FONT %>;font-size:32px;font-weight:700;line-height:1.15;color:#5950ff;"><%= amount %></p>
+                    <p style="margin:6px 0 0 0;padding:0;font-family:<%= FONT %>;font-size:13px;color:#65656c;">Paid <%= paid_date_long %></p>
+                  </td>
+                  <td valign="top" align="right" style="white-space:nowrap;">
+                    <% if (invoice_url) { %>
+                    <p style="margin:0 0 10px 0;padding:0;"><a href="<%= invoice_url %>" style="font-family:<%= FONT %>;font-size:13px;font-weight:600;color:#0b0a21;text-decoration:underline;">&#8681; Download invoice</a></p>
+                    <% } %>
+                    <% if (receipt_url) { %>
+                    <p style="margin:0;padding:0;"><a href="<%= receipt_url %>" style="font-family:<%= FONT %>;font-size:13px;font-weight:600;color:#0b0a21;text-decoration:underline;">&#8681; Download receipt</a></p>
+                    <% } %>
+                  </td>
+                </tr>
+              </table>
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="height:20px;line-height:20px;font-size:0;">&nbsp;</td></tr></table>
+
+              <!-- Invoice meta box -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#f2f2f7;border-radius:8px;">
+                <tr>
+                  <td width="50%" style="padding:16px 20px;">
+                    <p style="margin:0 0 4px 0;padding:0;font-family:<%= FONT %>;font-size:12px;color:#65656c;">Invoice number</p>
+                    <p style="margin:0;padding:0;font-family:<%= FONT %>;font-size:13px;font-weight:600;color:#0b0a21;"><%= invoice_number %></p>
+                  </td>
+                  <td width="50%" style="padding:16px 20px;">
+                    <p style="margin:0 0 4px 0;padding:0;font-family:<%= FONT %>;font-size:12px;color:#65656c;">Payment date</p>
+                    <p style="margin:0;padding:0;font-family:<%= FONT %>;font-size:13px;font-weight:600;color:#0b0a21;"><%= paid_date_long %></p>
+                  </td>
+                </tr>
+              </table>
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="height:20px;line-height:20px;font-size:0;">&nbsp;</td></tr></table>
+
+              <!-- Line items + total -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <% (lines || []).forEach(function (l) { %>
+                <tr>
+                  <td style="padding:8px 0;font-family:<%= FONT %>;font-size:13px;color:#65656c;border-bottom:1px solid #f2f2f7;"><%= l.label %></td>
+                  <td align="right" style="padding:8px 0;font-family:<%= FONT %>;font-size:13px;color:#0b0a21;border-bottom:1px solid #f2f2f7;"><%= l.amount %></td>
+                </tr>
+                <% }); %>
+                <tr>
+                  <td style="padding:10px 0;font-family:<%= FONT %>;font-size:14px;font-weight:700;color:#0b0a21;">Total</td>
+                  <td align="right" style="padding:10px 0;font-family:<%= FONT %>;font-size:14px;font-weight:700;color:#0b0a21;"><%= total %></td>
+                </tr>
+              </table>
+
+              <% if (features && features.length) { %>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="height:20px;line-height:20px;font-size:0;">&nbsp;</td></tr></table>
+              <p style="margin:0 0 10px 0;padding:0;font-family:<%= FONT %>;font-size:14px;font-weight:600;color:#0b0a21;">What's unlocked</p>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <% features.forEach(function (f) { %>
+                <tr>
+                  <td width="22" valign="top" style="padding:3px 0;font-family:<%= FONT %>;font-size:13px;color:#2f9e5f;">&#10003;</td>
+                  <td style="padding:3px 0;font-family:<%= FONT %>;font-size:13px;color:#0b0a21;"><%= f %></td>
+                </tr>
+                <% }); %>
+              </table>
+              <% } %>
+
+              <% if (app_link) { %>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="height:24px;line-height:24px;font-size:0;">&nbsp;</td></tr></table>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
+                <tr><td align="center" bgcolor="#433cc5" style="border-radius:6px;background:#433cc5;">
+                  <a href="<%= app_link %>" style="display:block;padding:13px 24px;font-family:<%= FONT %>;font-size:14px;font-weight:600;color:#ffffff;text-decoration:none;">Open Drumee</a>
+                </td></tr>
+              </table>
+              <% } %>
+
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0"><tr><td style="height:28px;line-height:28px;font-size:0;">&nbsp;</td></tr></table>
+
+              <!-- Help -->
+              <p style="margin:0 0 6px 0;padding:0;font-family:<%= FONT %>;font-size:14px;font-weight:600;color:#0b0a21;">Need Help?</p>
+              <p style="margin:0;padding:0;font-family:<%= FONT %>;font-size:13px;color:#65656c;">Our customer support team is available to assist you:<br>
+                <a href="mailto:<%= support_email %>" style="color:#433cc5;text-decoration:underline;"><%= support_email %></a>
+              </p>
+
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td bgcolor="#f2f2f7" align="center" style="padding:20px;background:#f2f2f7;">
+              <p style="margin:0;padding:0;font-family:<%= FONT %>;font-size:12px;color:#65656c;">
+                <a href="https://drumee.org" style="color:#65656c;text-decoration:none;">drumee.org</a>
+                &nbsp;|&nbsp;
+                <a href="https://drumee.com/privacy/" style="color:#65656c;text-decoration:underline;">Privacy Policy</a>
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -1,8 +1,98 @@
 // service/public/stripe_webhook.js
 const { Entity } = require('@drumee/server-core');
+const { Messenger } = require('@drumee/server-essentials');
+const { resolve } = require('path');
 const { stripeClient, endpointSecret } = require('../lib/stripe');
+const { sendButlerMail } = require('../lib/butler-mail');
+
+// "What's unlocked" checklist per plan (payment-receipt email, Figma 2803-1288).
+// Static marketing copy matching the billing plans page; unknown plans get none.
+const PLAN_FEATURES = {
+  pro: ['50 GB storage', '5 editor seats included', '7-day version history', 'Permissions & roles', 'Guest access'],
+  team: ['50 GB storage per seat', 'Org-wide entitlement', '30-day version history', 'Admin-managed billing'],
+};
+
+const CURRENCY_SYMBOL = { eur: '€', usd: '$', gbp: '£' };
 
 class __public_stripe_webhook extends Entity {
+  // "€169.90" from Stripe minor units; falls back to "<CODE> 12.34".
+  _money(minor, currency) {
+    const n = (Number(minor) || 0) / 100;
+    const sym = CURRENCY_SYMBOL[(currency || 'eur').toLowerCase()];
+    return sym ? `${sym}${n.toFixed(2)}` : `${(currency || '').toUpperCase()} ${n.toFixed(2)}`;
+  }
+
+  // "January 7, 2026" (en-US, UTC) from a unix timestamp.
+  _longDate(ts) {
+    if (!ts) return '';
+    return new Date(Number(ts) * 1000).toLocaleDateString('en-US', {
+      year: 'numeric', month: 'long', day: 'numeric', timeZone: 'UTC',
+    });
+  }
+
+  /**
+   * Payment-receipt email for a paid invoice (Figma 2803-1288). Recipient is
+   * the Stripe customer email, falling back to the payer's account email.
+   * Stripe never emails customers in test mode (and live receipts are a
+   * dashboard opt-in), so the app owns this email. Callers must not let a
+   * mail failure fail the webhook.
+   */
+  async _sendReceiptEmail(invoice, sub, smd, { seat_total } = {}) {
+    let recipient = invoice.customer_email || null;
+    if (!recipient && smd.entity_id && (smd.entity_type || 'user') !== 'org') {
+      const payer = await this.yp.await_proc('payment_get_payer', smd.entity_id);
+      recipient = (payer && payer.email) || null;
+    }
+    if (!recipient) {
+      this.warn(`receipt email skipped for ${invoice.id}: no recipient email`);
+      return;
+    }
+    const plan = (smd.plan || 'pro').toLowerCase();
+    const plan_label = plan.charAt(0).toUpperCase() + plan.slice(1);
+    const cycle_label = (smd.period || 'month') === 'year' ? 'billed yearly' : 'billed monthly';
+    const paidTs = (invoice.status_transitions && invoice.status_transitions.paid_at) || invoice.created;
+    const items = (sub && sub.items && sub.items.data) || [];
+    const nextTs = (sub && sub.current_period_end) || (items[0] && items[0].current_period_end) || 0;
+    const currency = invoice.currency || 'eur';
+    const lines = ((invoice.lines && invoice.lines.data) || []).map((l) => ({
+      label: l.description || plan_label,
+      amount: this._money(l.amount, l.currency || currency),
+    }));
+    let app_link = '';
+    try { app_link = this.input.homepath(); } catch (e) { app_link = ''; }
+    const subject = `Your Drumee ${plan_label} plan is active — receipt ${invoice.number || ''}`.trim();
+    const msg = new Messenger({ subject, recipient, handler: this.exception && this.exception.email });
+    const tpl = resolve(__dirname, '..', 'private', 'templates', 'butler', 'payment-receipt.html');
+    const html = msg.renderFrom(tpl, {
+      plan_label,
+      cycle_label,
+      seats: Number(seat_total) || 0,
+      next_billing_date: nextTs ? this._longDate(nextTs) : '',
+      amount: this._money(invoice.amount_paid, currency),
+      paid_date_long: this._longDate(paidTs),
+      invoice_number: invoice.number || invoice.id || '',
+      invoice_url: invoice.hosted_invoice_url || '',
+      receipt_url: invoice.invoice_pdf || '',
+      lines,
+      total: this._money(invoice.amount_paid, currency),
+      features: PLAN_FEATURES[plan] || [],
+      app_link,
+      support_email: 'contact@drumee.org',
+    });
+    const text = [
+      `Your Drumee ${plan_label} plan is active.`,
+      ``,
+      `Receipt from Drumee: ${this._money(invoice.amount_paid, currency)} — paid ${this._longDate(paidTs)}.`,
+      `Invoice number: ${invoice.number || invoice.id || ''}`,
+      ...(nextTs ? [`Next billing date: ${this._longDate(nextTs)}`] : []),
+      ...(invoice.hosted_invoice_url ? [``, `Download invoice: ${invoice.hosted_invoice_url}`] : []),
+      ``,
+      `Need help? contact@drumee.org`,
+      `drumee.org · Privacy Policy: https://drumee.com/privacy/`,
+    ].join('\n');
+    await sendButlerMail(msg, { recipient, subject, html, text });
+  }
+
   // Classify subscription line items: the base plan item (quantity = seats for
   // org) vs add-on items (entity_type='addon' in yp.plan) — storage add-ons sum
   // disk * quantity into extra_disk (P4); pro_seat add-ons sum seat * quantity
@@ -151,6 +241,15 @@ class __public_stripe_webhook extends Entity {
               const seat_total = await this._seatTotal(smd.entity_type || 'user', smd.plan || 'pro', smd.period || 'month', seats, extra_seats);
               await this.yp.await_proc('payment_apply_entitlement', eid, smd.plan || 'pro', pend, smd.entity_type || 'user', seat_total, extra_disk);
               await this.notify_user(eid, { service: 'payment.plan_updated', plan: smd.plan, status: 'active' });
+              // Payment-receipt email (initial payment AND every renewal both
+              // arrive as invoice.paid). A mail failure must never fail the
+              // webhook — the entitlement above is already applied and Stripe
+              // would re-deliver the whole event on a 500.
+              try {
+                await this._sendReceiptEmail(obj, sub, smd, { seat_total });
+              } catch (e4) {
+                this.error(`receipt email failed for ${event.id}: ${e4.message}`);
+              }
             } else {
               // Payment failed -> keep entitlement during Stripe's smart retries
               // (grace); final failure downgrades via customer.subscription.deleted.


### PR DESCRIPTION
## Bug
User upgraded to Pro but never received an invoice email.

## Root cause (two layers)
1. **The app never sent one.** The Stripe webhook's `invoice.paid` case only re-applied the entitlement and pushed a WS notification — there was no mailer anywhere in the payment path. The Figma invoice-email design (2803-1288) existed as design only.
2. **Stripe doesn't cover it either**: test/sandbox mode never emails customers, and live-mode receipts are a dashboard opt-in. The app has to own this email.

## Fix
- **`service/lib/butler-mail.js`** — shared butler sender (multipart text+html via the configured MTA, display-name From, `msg.send()` fallback when no MTA). Extracted from the `contact.js` pattern for reuse; contact.js can migrate later.
- **`templates/butler/payment-receipt.html`** — receipt email per Figma 2803-1288: purple header, check badge, "Your Drumee {Plan} plan is active", plan/seats/next-billing rows, amount + Download invoice/receipt links (`hosted_invoice_url`/`invoice_pdf`), invoice-number/payment-date box, line items + total, per-plan "What's unlocked", Open Drumee CTA. Conditional blocks only render with real data.
- **`stripe_webhook.js`** `invoice.paid` — after entitlement + WS notify, send the receipt to `invoice.customer_email` (fallback `payment_get_payer` for user entities). Initial payments AND renewals both arrive as `invoice.paid` → one hook covers both. Mail failure logs and never fails the webhook.

## Verification
- `node --check` clean on both JS files; template renders with full sample data.
- Deployed to the vudangnt endpoint and sent a real preview receipt through the exact Messenger/butler-mail/template path — MTA accepted (`{recipient: cuocsongthanhbinh49@gmail.com, error: null}`); recipient confirmed receipt by inbox.
- Webhook glue fires on the next real `invoice.paid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
