### PR TITLE
fix(media): thumb endpoints reply 204 (not 404) when no thumb can be served

### DIFF
--- a/service/media.js
+++ b/service/media.js
@@ -53,6 +53,7 @@ const {
   MfsTools,
 } = require("@drumee/server-core");
 const { remove_dir, mv } = MfsTools;
+const { get_node_content } = require("@drumee/server-core/lib/utils/mfs");
 
 const {
   mkdirSync,
@@ -1654,25 +1655,67 @@ class __media extends Mfs {
   galery() { }
 
   /**
-   * 
+   * Thumb-class assets (vignette/thumb/card/preview/slide) are best-effort:
+   * they are generated on demand from the original file, so when the source
+   * is gone from disk (orphan DB row, lost content) there is nothing to
+   * build. Reply 204 instead of 404 in that case — browsers log a console
+   * error for every 404 fetch, so a desk full of orphan tiles used to flood
+   * the console on every load; the UI falls back to the filetype icon on
+   * both codes.
+   */
+  async _send_thumb(format) {
+    const node = this.source_granted();
+    if (node) {
+      const orig = get_node_content(node);
+      if (orig && existsSync(orig)) {
+        // Pre-run the (idempotent) generator: it swallows gm/convert
+        // failures and returns nothing, after which FileIo would X-Accel
+        // a nonexistent path and nginx would emit the 404. The thumb is
+        // served ONLY when the output file actually exists after the
+        // attempt — a corrupted/truncated source, a missing generator for
+        // this filetype, or an unresolvable output path all degrade to 204.
+        const output = get_node_content(node, format, "png");
+        const g =
+          Generator[`create_${node.filetype}_${format}`] ||
+          Generator[`create_${node.category}_${format}`];
+        if (isFunction(g) && output) {
+          try {
+            g(output, orig, node);
+          } catch (e) {
+            this.debug(`thumb generation failed nid=${node.id}:`, e.message);
+          }
+        }
+        if (!output || !existsSync(output)) {
+          this.output.head({ "Cache-Control": "no-store" }, 204);
+          return;
+        }
+        await this.send_media(node, format);
+        return;
+      }
+    }
+    this.output.head({ "Cache-Control": "no-store" }, 204);
+  }
+
+  /**
+   *
    */
   async vignette() {
     //const nid = this.input.need(Attr.nid);
-    await this.send_media(this.source_granted(), VIGNETTE);
+    await this._send_thumb(VIGNETTE);
   }
 
   /**
-   * 
+   *
    */
   async thumb() {
-    await this.send_media(this.source_granted(), THUMBNAIL);
+    await this._send_thumb(THUMBNAIL);
   }
 
   /**
-   * 
+   *
    */
   async card() {
-    await this.send_media(this.source_granted(), CARD);
+    await this._send_thumb(CARD);
   }
 
   /**
@@ -1707,14 +1750,14 @@ class __media extends Mfs {
    *
    */
   async slide() {
-    await this.send_media(this.source_granted(), SLIDE);
+    await this._send_thumb(SLIDE);
   }
 
   /**
    *
    */
   async preview() {
-    await this.send_media(this.source_granted(), PREVIEW);
+    await this._send_thumb(PREVIEW);
   }
 
   /**


### PR DESCRIPTION
## Vấn đề
Mỗi lần load desk, console trình duyệt ngập lỗi `GET .../file/vignette/... 404` — một dòng đỏ cho MỖI tile mà thumbnail không tạo được, lặp lại mỗi lần render.

## Root cause (2 nhánh, đều ra 404)
`vignette/thumb/card/preview/slide` được generate on-demand từ file gốc:
1. **File gốc mất trên disk** (row DB mồ côi) → `FileIo.not_found()` → 404.
2. **File gốc có nhưng không xử lý được** (vd png cụt 70 bytes): `generate()` nuốt lỗi gm và trả nothing → FileIo vẫn `X-Accel-Redirect` tới path không tồn tại → **nginx** trả 404 (vì vậy service log trống).

## Fix
`_send_thumb()`: pre-run generator (idempotent), chỉ serve khi file output **thực sự tồn tại**; mọi trường hợp khác trả **204** — browser không log console error cho 204, UI fallback icon theo filetype y như cũ. Kèm fix ui-core (`c7ac07c` trên branch `fix/image-smart-load-error`): `fetchFile` map 204 → nhánh missing-asset (204 là `response.ok` nên không có nhánh này sẽ crash vì content-type null).

## Lưu ý topology (quan trọng khi deploy)
nginx rewrite `/-/<endpoint>/file/<fmt>/<nid>/<hub>` → `/-/svc/media.<fmt>` — URI mới **thoát khỏi** location block của endpoint → các route `file/*` **luôn do service MAIN phục vụ**, kể cả khi URL mang prefix endpoint khác. Fix này chỉ có hiệu lực khi **main** được redeploy (hot-patch main bị chặn theo quy trình — cần CD/approve).

## Verified
- Logic verify tĩnh trên cả 2 nhánh lỗi (nid `3ac2dccf3ac2dcd4` = up-b.png 70 bytes, corrupted → nginx 404 empty-body đã trace được đầy đủ).
- Đã cherry-pick sang `test` (79d987a).

🤖 Generated with [Claude Code](https://claude.com/claude-code)