### PR TITLE
fix(media): _send_thumb follow-ups — unwrap acl_check grant row (review-confirmed regression)

### DIFF
--- a/service/media.js
+++ b/service/media.js
@@ -1664,9 +1664,31 @@ class __media extends Mfs {
    * both codes.
    */
   async _send_thumb(format) {
-    const node = this.source_granted();
+    let node = this.source_granted();
+    // Some grant flows hand back a MINIMAL row (id only — no ext/filetype/
+    // mfs_root); path resolution then fails and healthy thumbs would
+    // degrade to 204. Load the full node the same way send_media's
+    // string-arg path does before deciding anything.
+    if (node && !(node.target_mfs_root || node.mfs_root)) {
+      const nid = node.id || node.nid;
+      if (nid) {
+        try {
+          const full = await this.db.await_proc("mfs_node_attr", nid);
+          if (full && (full.id || full.nid)) node = full;
+        } catch (e) {
+          this.debug(`mfs_node_attr failed for ${nid}:`, e.message);
+        }
+      }
+    }
     if (node) {
-      const orig = get_node_content(node);
+      let orig = null;
+      try {
+        orig = get_node_content(node);
+      } catch (e) {
+        // Unresolvable shape — keep the legacy behavior untouched.
+        await this.send_media(node, format);
+        return;
+      }
       if (orig && existsSync(orig)) {
         // Pre-run the (idempotent) generator: it swallows gm/convert
         // failures and returns nothing, after which FileIo would X-Accel

--- a/service/media.js
+++ b/service/media.js
@@ -1664,11 +1664,14 @@ class __media extends Mfs {
    * both codes.
    */
   async _send_thumb(format) {
-    let node = this.source_granted();
-    // Some grant flows hand back a MINIMAL row (id only — no ext/filetype/
-    // mfs_root); path resolution then fails and healthy thumbs would
-    // degrade to 204. Load the full node the same way send_media's
-    // string-arg path does before deciding anything.
+    // source_granted() returns the raw acl_check row (id/hub_id/db_name/
+    // expiry/asked/privilege) with the REAL mfs node attached as .node —
+    // unwrap it exactly like send_media does, or path resolution sees no
+    // mfs_root/ext and healthy thumbs degrade to 204.
+    const granted = this.source_granted();
+    let node = granted && (granted.node || granted);
+    // Last-resort: a grant shape that still lacks a resolvable root gets
+    // the full row loaded the same way send_media's string-arg path does.
     if (node && !(node.target_mfs_root || node.mfs_root)) {
       const nid = node.id || node.nid;
       if (nid) {
@@ -1697,9 +1700,7 @@ class __media extends Mfs {
         // attempt — a corrupted/truncated source, a missing generator for
         // this filetype, or an unresolvable output path all degrade to 204.
         const output = get_node_content(node, format, "png");
-        const g =
-          Generator[`create_${node.filetype}_${format}`] ||
-          Generator[`create_${node.category}_${format}`];
+        const g = Generator[`create_${node.filetype}_${format}`];
         if (isFunction(g) && output) {
           try {
             g(output, orig, node);


### PR DESCRIPTION
## Follow-up cho #95 — regression tìm ra khi re-test + adversarial review (13 agents)

### Regression (CONFIRMED bởi 2 verifier độc lập + repro live)
`source_granted()` trả **raw acl_check row** (`{id, hub_id, db_name, expiry, asked, privilege}`) — node mfs thật nằm ở `.node` (server-core `acl.js check_source`). `send_media` unwrap `.node`, nhưng `_send_thumb` của #95 dùng row trực tiếp → `get_node_content()` không thấy `mfs_root` → **thumb của hub SHARE trả 204 dù file hoàn toàn lành** (desk own-hub không lộ vì flow đó mang full row). Verify cũ pass vì browser cache `max-age=31536000` che mất.

### Fix (2 commit)
1. `3c03c88`: reload full node qua `mfs_node_attr` khi row thiếu root + try/catch fallback `send_media` (hành vi legacy) — đã chặn đứng regression.
2. `760e376` (theo review): **unwrap `granted.node || granted`** như send_media — đúng gốc rễ, khỏi tốn 1 DB round-trip mỗi thumb; giữ `mfs_node_attr` chỉ làm last-resort. Bỏ fallback `create_${node.category}_*` (mfs_access_node không có cột `category` — lookup không bao giờ trúng).

### Verified live (stage main, sau CD)
- Share-hub preview/vignette: **200 + body thật** (28KB/11KB) — hết 204 sai.
- Desk: 15×200 + 9×204 (chỉ orphan/corrupted đúng nghĩa), **console 0 errors**.
- Image player mở bình thường.

### ⚠️ Coupled-deploy note (finding CONFIRMED thứ 3)
Bundle UI build với **ui-core ≤ 1.1.46** không có nhánh 204 trong `fetchFile`: 204 là `response.ok` nhưng `response.body === null` → `getReader()` throw → tile orphan hiện Ô TRỐNG (không icon fallback) + không negative-cache. Preview branch đang pin `^1.1.44` → các endpoint build từ preview cần **bump @drumee/ui-core ≥ 1.1.47** (ui-team PR #310 đã có bump trên nhánh fix) khi/ngay sau khi merge PR này lên môi trường tương ứng.

🤖 Generated with [Claude Code](https://claude.com/claude-code)