### PR TITLE
feat(payment): TEAM bootstrap — subdomain before checkout, org provisioned by webhook

### DIFF
--- a/acl/drumate.json
+++ b/acl/drumate.json
@@ -73,7 +73,9 @@
     "get_referral_code": {
       "doc": "Get or create the signed-in user's referral code and link.",
       "scope": "hub",
-      "permission": { "src": "owner" }
+      "permission": {
+        "src": "owner"
+      }
     },
     "change_password": {
       "doc": "Change user password with old password verification",
@@ -675,56 +677,6 @@
         {
           "code": "_ident_already_exists",
           "message": "Username is already taken in this domain",
-          "http_status": 409
-        }
-      ]
-    },
-    "hub_to_pro": {
-      "doc": "Upgrade free user account to Pro account with custom domain and organization",
-      "scope": "hub",
-      "permission": {
-        "src": "owner"
-      },
-      "params": {
-        "ident": {
-          "type": "string",
-          "required": true,
-          "doc": "Domain identifier (subdomain)"
-        },
-        "name": {
-          "type": "string",
-          "required": true,
-          "doc": "Organization name"
-        }
-      },
-      "returns": {
-        "id": {
-          "type": "string",
-          "doc": "Domain ID"
-        },
-        "name": {
-          "type": "string",
-          "doc": "Domain name (ident.drumee.com)"
-        },
-        "status": {
-          "type": "string",
-          "doc": "Status code (PRO_USER, NAME_NOT_AVAILABLE, or URL_NOT_AVAILABLE if failed)"
-        }
-      },
-      "errors": [
-        {
-          "code": "PRO_USER",
-          "message": "User is already a Pro account",
-          "http_status": 400
-        },
-        {
-          "code": "NAME_NOT_AVAILABLE",
-          "message": "Organization name is already taken",
-          "http_status": 409
-        },
-        {
-          "code": "URL_NOT_AVAILABLE",
-          "message": "Domain identifier is already taken",
           "http_status": 409
         }
       ]

--- a/acl/payment.json
+++ b/acl/payment.json
@@ -1,13 +1,132 @@
 {
   "services": {
-    "catalog":             { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
-    "checkout":            { "scope": "hub", "permission": { "src": "owner" }, "params": { "period": { "type": "string", "required": true }, "plan": { "type": "string", "required": false }, "seats": { "type": "integer", "required": false, "default": 1 }, "entity_type": { "type": "string", "required": false }, "bundle": { "type": "string", "required": false } } },
-    "subscription_status": { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
-    "portal":              { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
-    "cancel_subscription": { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
-    "resume_subscription": { "scope": "hub", "permission": { "src": "owner" }, "params": {} },
-    "checkout_result":     { "scope": "hub", "permission": { "src": "owner" }, "params": { "session_id": { "type": "string", "required": true } } },
-    "webhook":             { "scope": "hub", "permission": { "src": "read", "fast_check": "public-api" }, "method": "receive", "params": { "stripe-signature": { "type": "string", "required": true }, "raw_body": { "type": "string", "required": true } }, "errors": [{ "code": "WEBHOOK_ERROR", "http_status": 400 }] }
+    "catalog": {
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {}
+    },
+    "checkout": {
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {
+        "period": {
+          "type": "string",
+          "required": true
+        },
+        "plan": {
+          "type": "string",
+          "required": false
+        },
+        "seats": {
+          "type": "integer",
+          "required": false,
+          "default": 1
+        },
+        "entity_type": {
+          "type": "string",
+          "required": false
+        },
+        "bundle": {
+          "type": "string",
+          "required": false
+        },
+        "ident": {
+          "type": "string",
+          "required": false,
+          "doc": "Org subdomain label (TEAM bootstrap: no organisation yet)"
+        },
+        "org_name": {
+          "type": "string",
+          "required": false,
+          "doc": "Organisation display name (TEAM bootstrap)"
+        }
+      }
+    },
+    "validate_org_ident": {
+      "doc": "Pre-checkout validation of the TEAM org subdomain (ident). Bootstrap exception: scope hub/owner because the payer has no org-domain privilege yet.",
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {
+        "ident": {
+          "type": "string",
+          "required": true,
+          "doc": "Subdomain label to validate"
+        }
+      }
+    },
+    "subscription_status": {
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {}
+    },
+    "portal": {
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {}
+    },
+    "cancel_subscription": {
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {}
+    },
+    "resume_subscription": {
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {}
+    },
+    "checkout_result": {
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {
+        "session_id": {
+          "type": "string",
+          "required": true
+        }
+      }
+    },
+    "webhook": {
+      "scope": "hub",
+      "permission": {
+        "src": "read",
+        "fast_check": "public-api"
+      },
+      "method": "receive",
+      "params": {
+        "stripe-signature": {
+          "type": "string",
+          "required": true
+        },
+        "raw_body": {
+          "type": "string",
+          "required": true
+        }
+      },
+      "errors": [
+        {
+          "code": "WEBHOOK_ERROR",
+          "http_status": 400
+        }
+      ]
+    }
   },
-  "modules": { "private": "service/private/payment", "public": "service/public/stripe_webhook" }
+  "modules": {
+    "private": "service/private/payment",
+    "public": "service/public/stripe_webhook"
+  }
 }

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -194,8 +194,11 @@ class __private_payment extends Entity {
   // subscriptions by the ORGANISATION id, so when the personal row is empty
   // fall back to the org the caller owns — org owners see their team sub.
   async _subscription_row() {
-    let row = await this.yp.await_proc('payment_get_subscription', this.uid);
-    if (row && row.subscription_id) return row;
+    // Tenant-first: the ORG subscription outranks a leftover personal one —
+    // a pro→team upgrader owns both for a while, and the plan they're ON is
+    // the tenant's (the Billing page otherwise kept showing 'pro' after a
+    // successful TEAM upgrade). Mirrors the quota cascade fix in
+    // disk_limit/my_disk_limit/get_quota.
     const org = await this.yp.await_proc('payment_get_org', this.uid);
     if (org && org.id) {
       const orgRow = await this.yp.await_proc('payment_get_subscription', org.id);
@@ -205,6 +208,7 @@ class __private_payment extends Entity {
         return orgRow;
       }
     }
+    const row = await this.yp.await_proc('payment_get_subscription', this.uid);
     return row || {};
   }
 

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -33,6 +33,53 @@ class __private_payment extends Entity {
     this.output.data({ plans });
   }
 
+  // ── TEAM org bootstrap ────────────────────────────────────────────────
+  // The subdomain (org ident) is collected BEFORE Stripe Checkout (product
+  // decision 2026-07-17) and threaded through the session metadata; the
+  // webhook provisions the organisation atomically (yp org_provision) on
+  // checkout.session.completed. These helpers validate the ident up-front.
+
+  // Shared validation for the org ident (subdomain label).
+  async _validateOrgIdent(ident) {
+    ident = String(ident || '').trim().toLowerCase();
+    // DNS label: 2-63 chars, a-z 0-9 hyphen, no leading/trailing hyphen.
+    if (!/^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])$/.test(ident)) {
+      return { status: 'IDENT_INVALID', ident };
+    }
+    // Move-semantics membership: a payer already inside another domain
+    // cannot bootstrap a second organisation.
+    if (~~this.user.domain_id() > 1) {
+      return { status: 'ALREADY_IN_OTHER_DOMAIN', ident };
+    }
+    let taken = await this.yp.await_proc('ident_exists', ident);
+    if (Array.isArray(taken) ? taken.length : (taken && taken.id)) {
+      return { status: 'IDENT_NOT_AVAILABLE', ident };
+    }
+    // The org URL is `${ident}.${main_domain()}` (domain_create convention) —
+    // reject when the fqdn or domain row already exists.
+    let rows = await this.yp.await_query(
+      `SELECT (SELECT COUNT(*) FROM vhost  WHERE fqdn = CONCAT(?, '.', main_domain()))
+            + (SELECT COUNT(*) FROM domain WHERE name = CONCAT(?, '.', main_domain())) AS c`,
+      ident, ident
+    );
+    if (Array.isArray(rows)) rows = rows[0];
+    if (rows && ~~rows.c > 0) {
+      return { status: 'IDENT_NOT_AVAILABLE', ident };
+    }
+    let fqdn = await this.yp.await_query(
+      `SELECT CONCAT(?, '.', main_domain()) AS fqdn`, ident
+    );
+    if (Array.isArray(fqdn)) fqdn = fqdn[0];
+    return { status: 'OK', ident, fqdn: fqdn && fqdn.fqdn };
+  }
+
+  // Pre-checkout validation endpoint for the FE subdomain step.
+  async validate_org_ident() {
+    const ident = this.input.need('ident');
+    const res = await this._validateOrgIdent(ident);
+    this.output.data(res);
+  }
+
   // Hosted Checkout. entity_type 'user' (individual Free->Pro) or 'org' (team,
   // per-seat: Stripe quantity = seats, customer = the org the caller owns).
   async checkout() {
@@ -44,11 +91,30 @@ class __private_payment extends Entity {
     const seats = Math.max(1, ~~this.input.use('seats', 1));
 
     let plan, entity_id, email, name, existing_customer;
+    let org_bootstrap = null;
     if (entity_type === 'org') {
       plan = this.input.use('plan', 'team');
       const org = await this.yp.await_proc('payment_get_org', this.uid);
-      if (!org || !org.id) return this.output.data({ status: 'NOT_ORG_OWNER' });
-      entity_id = org.id; name = org.name; existing_customer = org.customer_id;
+      if (org && org.id) {
+        entity_id = org.id; name = org.name; existing_customer = org.customer_id;
+      } else {
+        // TEAM bootstrap: no organisation yet — the FE collected the
+        // subdomain; validate it now, thread it through the session
+        // metadata and let the webhook provision atomically after payment.
+        const ident = this.input.use('ident', '');
+        const org_name = this.input.use('org_name', '') || this.input.use('name', '');
+        if (!ident || !org_name) {
+          return this.output.data({ status: 'ORG_IDENT_REQUIRED' });
+        }
+        const v = await this._validateOrgIdent(ident);
+        if (v.status !== 'OK') return this.output.data(v);
+        org_bootstrap = { ident: v.ident, org_name: String(org_name).trim() };
+        // Stripe customer keyed by the PAYER while the org doesn't exist yet.
+        entity_id = this.uid;
+        const payer = await this.yp.await_proc('payment_get_payer', this.uid);
+        email = payer && payer.email; name = org_bootstrap.org_name;
+        existing_customer = payer && payer.customer_id;
+      }
     } else {
       plan = this.input.use('plan', 'pro');
       entity_id = this.uid;
@@ -104,7 +170,14 @@ class __private_payment extends Entity {
     const svcbase = this.input.homepath().replace(/\/+$/, '') + '/svc/?service=';
     const success_url = `${svcbase}callback.check_out_success&session_id={CHECKOUT_SESSION_ID}`;
     const cancel_url = `${svcbase}callback.check_out_cancel`;
-    const metadata = { entity_type, entity_id, plan, period };
+    // payer_id always travels with the subscription so the webhook can
+    // resolve/provision the organisation regardless of which event arrives
+    // first; org_ident/org_name are present only on the TEAM bootstrap.
+    const metadata = { entity_type, entity_id, plan, period, payer_id: this.uid };
+    if (org_bootstrap) {
+      metadata.org_ident = org_bootstrap.ident;
+      metadata.org_name = org_bootstrap.org_name;
+    }
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
       customer: customer_id,

--- a/service/private/templates/butler/payment-receipt.html
+++ b/service/private/templates/butler/payment-receipt.html
@@ -1,9 +1,12 @@
 <%
 // Payment receipt email — Figma 2803-1288 ("email invoice").
-// Vars: plan_label, cycle_label, seats (0 hides row), next_billing_date,
+// Vars: heading (headline + <title>), intro (one-liner under the headline),
+// plan_label, cycle_label, seats (0 hides row), next_billing_date,
 // amount, paid_date_long, invoice_number, invoice_url ('' hides link),
 // receipt_url ('' hides link), lines [{label, amount}], total,
 // features [string] ([] hides block), app_link, support_email.
+// The resume variant (Figma 3050-96856) reuses this shell with its own
+// heading/intro ("… plan is resumed").
 var FONT = "'Geist','SF Pro Display',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif";
 %><!DOCTYPE html>
 <html>
@@ -11,7 +14,7 @@ var FONT = "'Geist','SF Pro Display',-apple-system,BlinkMacSystemFont,'Segoe UI'
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="x-apple-disable-message-reformatting">
-  <title>Your Drumee <%= plan_label %> plan is active</title>
+  <title><%= heading %></title>
 </head>
 <body style="margin:0;padding:0;background:#fff;-webkit-font-smoothing:antialiased;font-family:'Geist','SF Pro Display',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#fff;">
@@ -40,8 +43,8 @@ var FONT = "'Geist','SF Pro Display',-apple-system,BlinkMacSystemFont,'Segoe UI'
                   </tr></table>
                 </td></tr>
                 <tr><td align="center">
-                  <h1 style="margin:0 0 8px 0;padding:0;font-family:<%= FONT %>;font-weight:600;font-size:24px;line-height:1.2;color:#0b0a21;">Your Drumee <%= plan_label %> plan is active</h1>
-                  <p style="margin:0;padding:0;font-family:<%= FONT %>;font-weight:400;font-size:14px;line-height:1.5;color:#65656c;">Your payment went through. Here's your receipt.</p>
+                  <h1 style="margin:0 0 8px 0;padding:0;font-family:<%= FONT %>;font-weight:600;font-size:24px;line-height:1.2;color:#0b0a21;"><%= heading %></h1>
+                  <p style="margin:0;padding:0;font-family:<%= FONT %>;font-weight:400;font-size:14px;line-height:1.5;color:#65656c;"><%= intro %></p>
                 </td></tr>
               </table>
 

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -93,6 +93,39 @@ class __public_stripe_webhook extends Entity {
     await sendButlerMail(msg, { recipient, subject, html, text });
   }
 
+  // TEAM bootstrap resolution: metadata for org subscriptions created before
+  // the org existed carries entity_id = payer uid plus payer_id (+ org_ident/
+  // org_name on the bootstrap checkout). Resolve the payer's organisation —
+  // provisioning it atomically on first contact (yp org_provision is
+  // idempotent: an existing org for this owner is returned untouched, so the
+  // session event and an early invoice.paid can race safely). A provisioning
+  // failure throws so the event returns 500 and Stripe retries instead of
+  // applying a mis-keyed entitlement.
+  async _resolveOrgEntity(md) {
+    if ((md.entity_type || 'user') !== 'org' || !md.payer_id) return md.entity_id;
+    let org = await this.yp.await_proc('payment_get_org', md.payer_id);
+    if ((!org || !org.id) && md.org_ident) {
+      const provisioned = await this.yp.await_proc(
+        'org_provision', md.payer_id, md.org_name || md.org_ident, md.org_ident
+      );
+      if (provisioned && provisioned.error) {
+        throw new Error(`org_provision failed: ${provisioned.error}`);
+      }
+      org = await this.yp.await_proc('payment_get_org', md.payer_id);
+      if (org && org.id) {
+        // Tell the payer's live session about its new home so the FE can
+        // transition (the next full bootstrap lands on the new domain anyway).
+        await this.notify_user(md.payer_id, {
+          service: 'payment.org_provisioned',
+          domain_id: org.domain_id,
+          ident: org.ident,
+          link: org.link,
+        });
+      }
+    }
+    return (org && org.id) ? org.id : md.entity_id;
+  }
+
   // Classify subscription line items: the base plan item (quantity = seats for
   // org) vs add-on items (entity_type='addon' in yp.plan) — storage add-ons sum
   // disk * quantity into extra_disk (P4); pro_seat add-ons sum seat * quantity
@@ -156,9 +189,12 @@ class __public_stripe_webhook extends Entity {
         case 'checkout.session.completed':
         case 'customer.subscription.created':
         case 'customer.subscription.updated': {
-          const entity_id = md.entity_id;
+          let entity_id = md.entity_id;
           const plan = md.plan || 'pro';
           const period = md.period || 'month';
+          // TEAM bootstrap: the organisation may not exist at checkout time —
+          // resolve (and provision if needed) before billing the ORG entity.
+          entity_id = await this._resolveOrgEntity(md);
           if (entity_id) {
             // Mirror the live subscription for the status panel + Billing Portal.
             const customer_id = obj.customer || null;
@@ -205,9 +241,16 @@ class __public_stripe_webhook extends Entity {
           break;
         }
         case 'customer.subscription.deleted': {
-          const entity_id = md.entity_id;
+          let entity_id = md.entity_id;
+          const etype = md.entity_type || 'user';
+          // Bootstrap-era org subscriptions carry entity_id = payer uid in
+          // their metadata (the org didn't exist at checkout) — resolve the
+          // real org so the cancel clears the ORG entitlement row.
+          if (etype === 'org' && md.payer_id) {
+            const org = await this.yp.await_proc('payment_get_org', md.payer_id);
+            if (org && org.id) entity_id = org.id;
+          }
           if (entity_id) {
-            const etype = md.entity_type || 'user';
             await this.yp.await_proc('subscription_remove', entity_id, obj.id || '');
             if (etype === 'org') {
               // Team cancel: DELETE the org entitlement row so every member
@@ -231,7 +274,10 @@ class __public_stripe_webhook extends Entity {
           let sub = null;
           if (subId) { try { sub = await stripe.subscriptions.retrieve(subId); } catch (e2) {} }
           const smd = (sub && sub.metadata) || {};
-          const eid = smd.entity_id;
+          // Bootstrap-era org subscriptions carry entity_id = payer uid —
+          // resolve (and, on an early invoice.paid racing the session event,
+          // provision) the real org before applying entitlement.
+          const eid = await this._resolveOrgEntity(smd);
           if (eid) {
             if (event.type === 'invoice.paid') {
               // Recurring renewal succeeded -> re-apply entitlement (bumps period_end).

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -36,8 +36,11 @@ class __public_stripe_webhook extends Entity {
    * Stripe never emails customers in test mode (and live receipts are a
    * dashboard opt-in), so the app owns this email. Callers must not let a
    * mail failure fail the webhook.
+   * heading/intro/subject override the default "plan is active" copy — the
+   * resume confirmation (Figma 3050-96856) sends the same receipt shell with
+   * "plan is resumed" copy.
    */
-  async _sendReceiptEmail(invoice, sub, smd, { seat_total } = {}) {
+  async _sendReceiptEmail(invoice, sub, smd, { seat_total, heading, intro, subject } = {}) {
     let recipient = invoice.customer_email || null;
     if (!recipient && smd.entity_id && (smd.entity_type || 'user') !== 'org') {
       const payer = await this.yp.await_proc('payment_get_payer', smd.entity_id);
@@ -60,10 +63,14 @@ class __public_stripe_webhook extends Entity {
     }));
     let app_link = '';
     try { app_link = this.input.homepath(); } catch (e) { app_link = ''; }
-    const subject = `Your Drumee ${plan_label} plan is active — receipt ${invoice.number || ''}`.trim();
+    heading = heading || `Your Drumee ${plan_label} plan is active`;
+    intro = intro || "Your payment went through. Here's your receipt.";
+    subject = subject || `${heading} — receipt ${invoice.number || ''}`.trim();
     const msg = new Messenger({ subject, recipient, handler: this.exception && this.exception.email });
     const tpl = resolve(__dirname, '..', 'private', 'templates', 'butler', 'payment-receipt.html');
     const html = msg.renderFrom(tpl, {
+      heading,
+      intro,
       plan_label,
       cycle_label,
       seats: Number(seat_total) || 0,
@@ -80,7 +87,7 @@ class __public_stripe_webhook extends Entity {
       support_email: 'contact@drumee.org',
     });
     const text = [
-      `Your Drumee ${plan_label} plan is active.`,
+      `${heading}.`,
       ``,
       `Receipt from Drumee: ${this._money(invoice.amount_paid, currency)} — paid ${this._longDate(paidTs)}.`,
       `Invoice number: ${invoice.number || invoice.id || ''}`,
@@ -237,6 +244,32 @@ class __public_stripe_webhook extends Entity {
             // billing screen flips to "ends on {period_end}" in realtime. Carry
             // period_end so the FE can render the date without a refetch.
             await this.notify_user(entity_id, { service: 'payment.plan_updated', plan, status, period_end });
+            // Resume confirmation email (Figma 3050-96856): a pending cancel
+            // flipping back to renewing. previous_attributes carries only the
+            // changed fields, so cancel_at_period_end true→false IS the resume
+            // signal — covers both the in-app Resume and the Billing Portal.
+            // No new invoice is issued on resume; attach the latest one as the
+            // receipt. A mail failure must never fail the webhook.
+            const prev = (event.data && event.data.previous_attributes) || {};
+            if (event.type === 'customer.subscription.updated'
+              && prev.cancel_at_period_end === true && !obj.cancel_at_period_end) {
+              try {
+                const invId = typeof obj.latest_invoice === 'string'
+                  ? obj.latest_invoice : (obj.latest_invoice && obj.latest_invoice.id);
+                if (invId) {
+                  const invoice = await stripe.invoices.retrieve(invId);
+                  const plan_label = plan.charAt(0).toUpperCase() + plan.slice(1);
+                  await this._sendReceiptEmail(invoice, obj, md, {
+                    seat_total,
+                    heading: `Your Drumee ${plan_label} plan is resumed`,
+                    subject: `Your Drumee ${plan_label} plan is resumed`,
+                    intro: "Your subscription has been resumed. Here's your receipt, and what's new.",
+                  });
+                }
+              } catch (e5) {
+                this.error(`resume email failed for ${event.id}: ${e5.message}`);
+              }
+            }
           }
           break;
         }


### PR DESCRIPTION
## New flow (target model + product decisions 2026-07-17)
- PRO: stays on domain 1, entitlement-only (unchanged).
- TEAM: the FE collects the subdomain BEFORE Stripe checkout → `payment.validate_org_ident` → `{ident, org_name}` travel in the session/subscription **metadata** → the webhook provisions the org atomically via the yp `org_provision` proc (schemas PR #67) → the payer becomes the org owner (privilege 63) and their personal hubs migrate into the org domain.
- ENTERPRISE: stays Contact-sales (no self-serve).

## Changes
- `payment.validate_org_ident` (new): DNS-label syntax, payer not already in another domain (move semantics), `ident_exists` + vhost/domain fqdn collision checks. Scope hub/owner — the bootstrap exception is documented in the docstring (the payer has no org-domain privilege yet).
- `checkout()`: `entity_type:'org'` is **no longer a NOT_ORG_OWNER dead-end** when no org exists — it requires `{ident, org_name}`, re-validates, keys the Stripe customer to the payer, and adds `payer_id` to the metadata (every checkout) plus `org_ident`/`org_name` (bootstrap only).
- `stripe_webhook`: new `_resolveOrgEntity(md)` helper — resolves the payer's org on every org-typed event and **provisions idempotently on first contact** (session.completed, subscription.created/updated, and an early invoice.paid); entitlement/mirror/notify target the ORG id; the payer receives WS `payment.org_provisioned {domain_id, ident, link}`. The `subscription.deleted` branch resolves only (never provisions) so a cancel clears the ORG's entitlement row. A provisioning failure throws → 500 → Stripe retries (no mis-keyed entitlement is ever applied).
- `_subscription_row()` is now **org-first**: when the caller owns an org with a live subscription, that row wins over their personal one — the banner/portal/cancel/resume all manage the TEAM sub.
- **Resume-subscription email** (Figma 3050-96856): `customer.subscription.updated` with `previous_attributes.cancel_at_period_end` true→false is the resume signal (covers both the in-app Resume and the Billing Portal); sends the receipt shell with "plan is resumed" copy and the latest invoice attached (no new invoice is issued on a resume). The `payment-receipt.html` template's heading/intro are now parameters (defaults keep the "plan is active" copy). A mail failure never fails the webhook.
- **acl: removed `drumate.hub_to_pro`** — the legacy PRO=own-domain path directly contradicts "PRO stays on domain 1" (code kept, unreachable).

## Verified on stage
- Full TEAM bootstrap E2E PASS (2026-07-17): checkout with subdomain → 4242 → webhook → `org_provision` → payer on the new org domain (privilege 63), entitlement + mirror keyed to the ORG; idempotent across multiple Stripe events.
- Plan-change matrix PASS: in-app cancel (mirror `canceled`, entitlement kept until period end) → resume (mirror `active`, confirmation email sent — no errors in the main-service logs, MTA configured) → org-customer Billing Portal → Team+storage-bundle checkout session creation.
- `validate_org_ident` live: a user already in another domain → `ALREADY_IN_OTHER_DOMAIN` ✓.

⚠️ NOTE: `acl/payment.json` was re-formatted by tooling — the diff is large but the content only adds `validate_org_ident` + the `ident`/`org_name` checkout params.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
