### PR TITLE
fix(billing): Stripe Portal return bounces same-site (fixes logout on return)

### DIFF
--- a/acl/callback.json
+++ b/acl/callback.json
@@ -23,6 +23,15 @@
         "fast_check": "public-api"
       },
       "params": {}
+    },
+    "portal_return": {
+      "doc": "Stripe Billing Portal return. UX-only same-site bounce: redirects the browser to the desk so the SameSite=Strict session cookie survives the cross-site return (avoids apparent logout).",
+      "scope": "hub",
+      "permission": {
+        "src": "read",
+        "fast_check": "public-api"
+      },
+      "params": {}
     }
   },
   "modules": {

--- a/service/callback.js
+++ b/service/callback.js
@@ -35,6 +35,20 @@ class __callback extends Entity {
     const flag = sid ? `?checkout=success&session_id=${sid}` : '?checkout=success';
     this.output.html(`<script> window.location.href = '${this.input.homepath()}${flag}#/desk/' </script>`);
   }
+
+  // Stripe Billing Portal return. The portal's return_url points HERE (a
+  // same-origin /svc endpoint) rather than straight at the desk, on purpose:
+  // the session cookie is SameSite=Strict, so it is withheld on the FIRST
+  // request of a cross-site top-level navigation (the browser coming back from
+  // billing.stripe.com). Landing directly on the SPA would boot it without the
+  // cookie → yp.get_env sees a guest → the user appears logged out. This tiny
+  // HTML bounce turns the return into a SAME-SITE navigation (drumee.in's own
+  // script setting location), so the cookie IS sent on the desk load and the
+  // session survives — the exact mechanism the checkout success/cancel returns
+  // already rely on.
+  async portal_return() {
+    this.output.html(`<script> window.location.href = '${this.input.homepath()}#/desk/' </script>`);
+  }
 }
 
 module.exports = __callback;

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -225,9 +225,16 @@ class __private_payment extends Entity {
     const sub = await this._subscription_row();
     const customer_id = sub && sub.customer_id;
     if (!customer_id) return this.output.data({ status: 'NO_CUSTOMER' });
+    // Return through a same-origin /svc bounce (callback.portal_return), not
+    // straight at the desk: the session cookie is SameSite=Strict and is
+    // withheld on the first request of the cross-site return from Stripe, so a
+    // direct return lands the SPA as a guest → apparent logout. The bounce
+    // makes the final desk navigation same-site, so the cookie is sent. Same
+    // pattern as the checkout success/cancel URLs above.
+    const return_url = this.input.homepath().replace(/\/+$/, '') + '/svc/?service=callback.portal_return';
     const session = await stripe.billingPortal.sessions.create({
       customer: customer_id,
-      return_url: this.input.homepath() + '#/desk/',
+      return_url,
     });
     this.output.data({ url: session.url });
   }


### PR DESCRIPTION
## Report

> Returning from the Stripe billing surface logs the user out of their account.

## Root cause

The session cookie (`regsid`) is issued **`SameSite=Strict`**. A Strict cookie is withheld on the first request of a **cross-site top-level navigation** — including the browser coming back from `billing.stripe.com`. So a direct return from the Stripe Billing Portal loads the SPA with no session cookie → `yp.get_env` sees a guest → the user lands on sign-in ("logged out").

The **Checkout** success/cancel returns never had this problem: they point at a `/svc` callback (`callback.check_out_success` / `check_out_cancel`) that emits an HTML `<script>` redirect to the desk. That final hop is a **same-site** navigation (drumee.in's own script setting `location`), so the Strict cookie **is** sent and the session survives. The **Portal** `return_url`, by contrast, pointed straight at `homepath()#/desk/`, skipping that bounce.

## Fix

Add `callback.portal_return` — a one-line same-site bounce mirroring the checkout callbacks (public-api, so the unauthenticated cross-site return can reach it) — and point the Billing Portal `return_url` at it:

```
return_url = homepath()/svc/?service=callback.portal_return
   → <script> window.location.href = 'homepath#/desk/' </script>   // same-site → cookie sent
```

One tiny endpoint; the session now survives the Portal return. Same mechanism the checkout returns already rely on — no `SameSite` / session-wide change (which would be broad, un-persistable in this repo, and is contradicted by the working checkout return).

## Verified live (stage)

- `GET /-/vudangnt/svc/?service=callback.portal_return` → HTTP 200, body `<script> window.location.href = 'https://drumee.in/-/vudangnt/#/desk/' </script>`.
- `payment.portal` now issues a Stripe session whose `return_url` is the bounce endpoint.

Cherry-picked to `test` (deploys to stage `main` via CD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
