### PR TITLE
fix(activity): storage alerts never reached the Unread notification feed

### DIFF
--- a/service/private/activity.js
+++ b/service/private/activity.js
@@ -376,13 +376,21 @@ class MfsActivity extends Entity {
           if (r.timestamp == null) r.timestamp = r.ctime;
           result.push(r);
         }
-        // Task @-mentions / assignments live in yp.contact_activity → under
-        // Unread OFF they already come from activity_get_feed_all; merge their
-        // UNREAD rows only under Unread ON so they show in the default view
-        // without double-showing under OFF. Each proc is independently
-        // best-effort so a missing/failing one never sinks the others.
+        // Task @-mentions / assignments and admin-console storage alerts live
+        // in yp.contact_activity → under Unread OFF they already come from
+        // activity_get_feed_all; merge their UNREAD rows only under Unread ON
+        // so they show in the default view without double-showing under OFF.
+        // Every new contact_activity event needs its own *_unread proc here —
+        // storage_alert was added without one, so recipients got the email but
+        // no in-app notification (the panel opens on Unread ON). Each proc is
+        // independently best-effort so a missing/failing one never sinks the
+        // others.
         if (unreadOnly) {
-          for (const proc of ['contact_task_assigned_unread', 'contact_task_mention_unread']) {
+          for (const proc of [
+            'contact_task_assigned_unread',
+            'contact_task_mention_unread',
+            'contact_storage_alert_unread',
+          ]) {
             try {
               const rows = toArray(await this.yp.await_proc(proc, this.uid));
               for (const r of rows) {


### PR DESCRIPTION
## Problem

Admin console → Storage → *Send storage alert*: the recipient **got the email but no in-app notification**.

## Root cause

`get_feed` is asymmetric by design:

- `unread_only=0` → `activity_get_feed_all`, which **includes** `yp.contact_activity`
- `unread_only=1` → `mfs_get_activity_feed`, which reads `yp.mfs_changelog` **only**

To bridge that, the unread branch merges per-event `*_unread` procs for contact rows — currently `contact_task_assigned_unread` and `contact_task_mention_unread`. `storage_alert` was added to `contact_activity` by the admin-api plugin without its matching proc, so it only ever showed under *All activity* — never in the panel's **default** Unread view.

## Change

Add `contact_storage_alert_unread` to the merge list, and note in the comment that every new `contact_activity` event needs one. The loop is already per-proc best-effort, so this degrades gracefully if the SQL has not landed yet.

Requires schemas PR #70 (the proc + manifest entry).

## Verification (live, drumee.in, endpoint vudangnt)

Sent an alert from `test.owner1@drumee.com` → `vu@drumee.org`:

| | Before | After |
|---|---|---|
| `get_feed(unread_only=1)` | 10 rows, **no** storage_alert | 12 rows, **storage_alert present** |
| `get_feed(unread_only=0)` | had it | unchanged (no double-show) |
| Panel default view | nothing | "Test Owner1 sent you a storage alert…" |

## Known gap, not fixed here

`get_unread_count` still returns 0 — `mfs_get_unread_count` also reads only `mfs_changelog`, so **no** contact event (including the existing task_assigned) feeds the bell badge. Pre-existing and wider than this ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)