### PR TITLE
fix(payment): Pro→Team upgrade never sent the payment/receipt email

### DIFF
--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -42,6 +42,15 @@ class __public_stripe_webhook extends Entity {
    */
   async _sendReceiptEmail(invoice, sub, smd, { seat_total, heading, intro, subject } = {}) {
     let recipient = invoice.customer_email || null;
+    // Org (Team) subscriptions: the org's Stripe customer is created without
+    // an email when the organisation already exists (payment.checkout sets
+    // email only on the payer-keyed bootstrap customer), so customer_email
+    // can be null. payer_id always travels in the subscription metadata —
+    // fall back to the paying user's account email.
+    if (!recipient && smd.payer_id) {
+      const payer = await this.yp.await_proc('payment_get_payer', smd.payer_id);
+      recipient = (payer && payer.email) || null;
+    }
     if (!recipient && smd.entity_id && (smd.entity_type || 'user') !== 'org') {
       const payer = await this.yp.await_proc('payment_get_payer', smd.entity_id);
       recipient = (payer && payer.email) || null;
@@ -241,7 +250,16 @@ class __public_stripe_webhook extends Entity {
             // so the UI status line reads "will be canceled on {period_end}"
             // (the design's Settings-card copy). Entitlement stays until the
             // final customer.subscription.deleted.
-            const status = obj.cancel_at_period_end ? 'canceled' : (obj.status || 'active');
+            // checkout.session.completed carries the SESSION in obj, whose
+            // status is 'complete' — a session status, not a subscription one.
+            // subscription_new.status is a strict-mode ENUM of SUBSCRIPTION
+            // statuses, so mirroring 'complete' raised 1265 Data truncated on
+            // the shared yp handle and killed the CONCURRENT invoice.paid
+            // handler mid-flight — before its payment receipt email — which is
+            // why a Pro→Team upgrade paid fine but never emailed. A completed
+            // session means the subscription is live: mirror 'active'.
+            const status = obj.cancel_at_period_end ? 'canceled'
+              : (obj.object === 'checkout.session' ? 'active' : (obj.status || 'active'));
             const entity_type = md.entity_type || 'user';
             // Line items: the subscription object carries them; a checkout.session
             // does not, so retrieve the subscription to read base + add-ons.


### PR DESCRIPTION
## Problem

Switching Pro → Team: payment succeeds, the success modal shows, the plan activates — but **no email** about the successful Team payment ever arrives. (Pro purchases DO email.)

## Root cause

Not a missing email feature — the email exists and never got to run.

`checkout.session.completed` mirrors `obj.status` into `subscription_new.status`. But `obj` is the **checkout session** in that event, and a completed session's status is `'complete'` — a session status that does not exist in the column's strict-mode ENUM (`incomplete/active/canceled/…`). MariaDB raises **1265 Data truncated**, and that failure on the shared `yp` connection aborts the **concurrent `invoice.paid` handler** mid-`payment_apply_entitlement` — before its `_sendReceiptEmail`. The event is then consumed, so the email is permanently lost.

The plan still activates because `customer.subscription.created` (status `'active'`, valid) re-applies entitlement — which is exactly why the bug looked like "payment works, email missing".

Evidence (2026-07-20 03:24 UTC upgrade, invoice `in_1Tv7oe…`): Stripe delivered `invoice.paid` **with** `customer_email` set; service log shows the 1265 on `subscription_update(...,'complete')` and `Origin of error: payment_apply_entitlement` at the same instant; no receipt render, no 'skipped' warn.

## Changes

1. Map a completed **session** to `'active'` when mirroring status (never write a session status into a subscription enum).
2. Org receipts: fall back to the payer's account email via `metadata.payer_id` — an existing-org checkout creates the org's Stripe customer **without** an email, so `invoice.customer_email` can be null and the old fallback was explicitly non-org only.

## Verification (live, vudangnt endpoint, Stripe test mode)

Fresh account → bought **Pro** → upgraded **Team** (org bootstrap, real hosted checkout, card 4242):

| Check | Before | After |
|---|---|---|
| Team receipt email | never rendered | rendered `12:41:59` ("Team plan is active") |
| `subscription_update` 1265 | crashed invoice.paid | no failure; mirror row `team/active` |
| Pro receipt (regression) | worked | still works (`12:40:31`) |
| Superseded Pro sub | — | `canceled` in Stripe (no double-charge) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)