### PR TITLE
fix(desk): keep short searches clean — skip chat stage and system events

### DIFF
--- a/service/private/desk.js
+++ b/service/private/desk.js
@@ -24,6 +24,17 @@ const {
   RedisStore, uniqueId, sysEnv
 } = require("@drumee/server-essentials");
 
+// Desk search only looks at chat messages once the query is at least this long.
+// A single letter matches almost every message, which buries the file/folder
+// hits under hundreds of chat rows. Same threshold as channel.search().
+const MIN_MESSAGE_SEARCH_LENGTH = 2;
+
+// System events are stored in the channel as an `[[EVENT:payload]]` envelope
+// (e.g. `[[MEETING:start:{...}]]`) and rendered as activity rows, never typed
+// by a user. They must not surface as search hits: a query matching their
+// markup or embedded ids (`MEETING`, hub ids, ...) is a false positive.
+const SYSTEM_EVENT_MESSAGE = /^\s*\[\[[A-Z_]+:/;
+
 class __private_desk extends Media {
 
   /**
@@ -327,7 +338,10 @@ class __private_desk extends Media {
     // Message search across all active hubs owned by the current user
     let messageResults = [];
     try {
-      const hubs = toArray(
+      // A too-short query skips the chat stage entirely (no hub lookup, no
+      // channel_search) so file/folder hits are not buried — see
+      // MIN_MESSAGE_SEARCH_LENGTH. File search still runs for any length.
+      const hubs = pattern.length < MIN_MESSAGE_SEARCH_LENGTH ? [] : toArray(
         await this.yp.await_query(
           `SELECT e.id, e.db_name FROM entity e JOIN hub h ON h.id = e.id
            WHERE h.owner_id = ? AND e.type = 'hub' AND e.status = 'active'`,
@@ -342,6 +356,8 @@ class __private_desk extends Media {
             await this.yp.await_proc(`${hub.db_name}.channel_search`, pattern)
           );
           for (const row of rows) {
+            // System event envelopes are activity rows, not user text
+            if (SYSTEM_EVENT_MESSAGE.test(row.preview || '')) continue;
             row.hub_id      = hub.id;
             row.result_type = 'message';
             messageResults.push(row);


### PR DESCRIPTION
## Problem
Follow-up on the shipped desk-search fix. Typing a **single letter** ("t", "s", "a") returned a large, apparently unsorted pile that didn't look like keyword matches. From the **second letter** ("te", "ab") the list looked correct.

## Root cause — not the file search
A captured `desk.search` response for `"t"` proved the **file hits were already correct**: every returned `filename` contains "t", ordered `mtime` DESC. The noise came from the **message stage**:

- `desk.search()` merges `channel_search` hits from every owned hub.
- A single common letter matches inside **`[[MEETING:start|end:{…}]]` system-event envelopes** ("MEE**T**ING" contains "t") and the ids embedded in their payload, plus mention/link markup.
- Result: dozens of meaningless chat rows appended after the files. Because the payload is *file block (sorted by mtime) + message block (sorted by ctime)*, a large message block makes the whole list read as unsorted.
- At 2+ characters that markup mostly stops matching, so the noise disappears — hence "fine from the second letter".

Ruled out first, with evidence: `safe_string()` has no minimum length (a single char *does* reach the proc); the search Entry's `getValue()` reads the live DOM value; and `desk_search` itself returns only name-matching rows for a 1-char query.

## Fix (server-side only, `service/private/desk.js`)
1. **`MIN_MESSAGE_SEARCH_LENGTH = 2`** — queries shorter than 2 chars skip the chat stage entirely (no hub lookup, no `channel_search`). This is the **same threshold `channel.search()` already uses** ("queries shorter than 2 chars return []"), so it follows existing convention rather than inventing one.
2. **`SYSTEM_EVENT_MESSAGE = /^\s*\[\[[A-Z_]+:/`** — system-event envelopes are activity rows, never user text, and must not surface as search hits. `[[MEETING:` is the only such marker present in server-team or ui-team (grep-verified).

## No-regression notes
- **`desk_search` (the SP already live in prod) and its call site are untouched** — file/folder search still runs for *any* query length, including 1 char.
- The empty-query → workspaces-list branch is untouched.
- **`channel_search` is untouched.** It is shared: `channel.js` `list_thread_by_file` also calls it, so that feature is unaffected.
- `channel.search()` (chat-header search) is untouched.
- Per-hub `try/catch` failure tolerance preserved; short queries now also avoid one DB query.

## Verification
Unit-tested the filter against the real captured previews (12/12): MEETING events skipped; **@mentions, shared links and normal chat kept** (no legitimate results lost); null/empty previews and user-typed `[[hello]]` safe. Verified on drumee.in: single letter returns clean name-matched files only; 2+ chars still return files + messages; empty box still shows workspaces.

No DB change.
