### PR TITLE
fix(lang): anonymous pages default to English, not French

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,15 @@ const HttpServer = require("http");
 const { server: SocketServer } = require("websocket");
 const Page = require("./client/page");
 
+// The accept-language singleton (used by server-core input.language()) parses
+// NOTHING until languages() is called — uninitialized, .get() returns null for
+// every header, so input.language() fell through to its hardcoded 'fr' and the
+// page shell served <html lang="fr"> to EVERY visitor regardless of browser
+// language (mixed fr/en UI). Initialize once per process; module is shared
+// with server-core through node's require cache. 'en' first = default for
+// missing/unsupported Accept-Language.
+require("accept-language").languages(["en", "fr", "es", "ru", "km", "zh"]);
+
 const configs = require("./configs");
 const env = configs.env();
 configs.load();

--- a/service.js
+++ b/service.js
@@ -2,6 +2,11 @@
 const { Cache, RedisStore, Events } = require("@drumee/server-essentials");
 const { Session, Input, Output } = require("@drumee/server-core");
 
+// Same init as index.js: without languages(), accept-language .get() returns
+// null for every header and input.language() falls back to hardcoded 'fr' —
+// wrong language for service-side lex/mail copy. 'en' first = default.
+require("accept-language").languages(["en", "fr", "es", "ru", "km", "zh"]);
+
 const { ERROR, START } = Events;
 const configs = require("./configs");
 const env = configs.env();


### PR DESCRIPTION
## Problem (tester report)

Opening Drumee in a new tab renders **French by default** — and since the desk's `LOCALE` bundle is English, the UI comes out **half French, half English** (many small buttons French).

## Root cause (two stacked defects, both proven live)

1. **The `accept-language` singleton is never initialized.** server-core's `input.language()` calls `Language.get(header)`, but nothing ever called `Language.languages([...])` — uninitialized, `.get()` returns `null` for **every** header (verified: `get('en-US,en;q=0.9') → null`). The code then falls into its hardcoded `'fr'` fallback → `<html lang="fr">` + `xia_lang='fr'` for **every anonymous visitor**, driving `bootstrap().lang` / `Visitor.pagelang()` French while `LOCALE` stays English → the mixed UI.
2. **`_parseHeader()` never ingests `accept-language`** (only `x-param-*` + `cookie`), so the header can't reach the resolver at all — browser-language auto-detection has never worked. Upstream server-core gap, see below.

## Fix

Initialize the shared singleton once per process (both the page and service entries), **'en' first** — with the header unavailable, `.get(undefined)` returns the list's first language (**English**) instead of tripping the French fallback. Signed-in users keep their profile language; `?lang=` still overrides.

## Verification (live, vudangnt endpoint)

| Request | Before | After |
|---|---|---|
| `Accept-Language: en-US` | `lang="fr"` | `lang="en"` |
| `Accept-Language: vi-VN` | `lang="fr"` | `lang="en"` |
| `Accept-Language: fr-FR` | `lang="fr"` (by accident) | `lang="en"` * |
| no header | `lang="fr"` | `lang="en"` |
| `?lang=fr` | fr | fr |

\* Known limitation: real browser-language detection (a French browser getting French automatically) requires the upstream server-core fix — one line in `_parseHeader` to copy `accept-language` into the input. Until then anonymous pages are uniformly English and users pick their language in preferences (persisted in their profile, honored on every page).

🤖 Generated with [Claude Code](https://claude.com/claude-code)