### PR TITLE
chore(deps): @drumee/server-core 1.1.80 — browser-language detection + English default

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.9.94",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
-        "@drumee/server-core": "^1.1.79",
+        "@drumee/server-core": "^1.1.80",
         "@drumee/server-essentials": "^1.3.1",
         "@drumee/ui-core": "^1.1.43",
         "@hyzyla/pdfium": "^2.1.9",
@@ -136,9 +136,9 @@
       }
     },
     "node_modules/@drumee/server-core": {
-      "version": "1.1.79",
-      "resolved": "https://registry.npmjs.org/@drumee/server-core/-/server-core-1.1.79.tgz",
-      "integrity": "sha512-Js/hG8GUb6ANmtU3t2BVxMeM21eo6mZnaPQz8KvJ1Dg6fR18YlGrIFXTJUIUfxvl1FcDPGTe7gQcxD6ImU+KwA==",
+      "version": "1.1.80",
+      "resolved": "https://registry.npmjs.org/@drumee/server-core/-/server-core-1.1.80.tgz",
+      "integrity": "sha512-sN0BG72kCaX3iTHsaffvzv78UvT82ZtiA11CpNBAnbuOOtuSBIvhXmUdAPeTR8dnjLsPLE9ce7ThLagB1e7B+w==",
       "license": "AGPL V3",
       "dependencies": {
         "@drumee/server-core": "^1.1.57",
@@ -221,7 +221,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
       "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2",
         "generic-pool": "3.9.0",
@@ -1005,6 +1004,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^2.0.3",
         "is-glob": "^4.0.3",
@@ -1046,6 +1046,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1066,6 +1067,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1086,6 +1088,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1106,6 +1109,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1126,6 +1130,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1146,6 +1151,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1166,6 +1172,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1186,6 +1193,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1206,6 +1214,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1226,6 +1235,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1246,6 +1256,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1266,6 +1277,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1286,6 +1298,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 10.0.0"
       },
@@ -1300,6 +1313,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1334,7 +1348,6 @@
       "resolved": "https://registry.npmjs.org/@redis/client/-/client-6.0.0.tgz",
       "integrity": "sha512-NS4iIT25r24sAjNQ2nSRdCW5jPJoV0rxkBee27oTeR+RXaOu89cjIsrww5rPBaYVGVdL1QCx9uz9141gZiSKdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cluster-key-slot": "1.1.2"
       },
@@ -1739,7 +1752,6 @@
       "resolved": "https://registry.npmjs.org/backbone/-/backbone-1.6.1.tgz",
       "integrity": "sha512-YQzWxOrIgL6BoFnZjThVN99smKYhyEXXFyJJ2lsF1wJLyo4t+QjmkLrH8/fN22FZ4ykF70Xq7PgTugJVR4zS9Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "underscore": ">=1.8.3"
       }
@@ -2134,6 +2146,7 @@
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
       "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readdirp": "^5.0.0"
       },
@@ -3947,7 +3960,8 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
       "integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/inflight": {
       "version": "1.0.6",
@@ -4053,6 +4067,7 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4072,6 +4087,7 @@
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -5694,6 +5710,7 @@
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
       "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 20.19.0"
       },
@@ -6857,8 +6874,7 @@
       "version": "1.13.8",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.8.tgz",
       "integrity": "sha512-DXtD3ZtEQzc7M8m4cXotyHR+FAS18C64asBYY5vqZexfYryNNnDc02W4hKg3rdQuqOYas1jkseX0+nZXjTXnvQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/undici-types": {
       "version": "7.24.6",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@drumee/schemas-utils": "^1.0.0",
-    "@drumee/server-core": "^1.1.79",
+    "@drumee/server-core": "^1.1.80",
     "@drumee/server-essentials": "^1.3.1",
     "@drumee/ui-core": "^1.1.43",
     "@hyzyla/pdfium": "^2.1.9",


### PR DESCRIPTION
Pulls the released upstream fix (drumee/server-core#2, published as **1.1.80**):

- `accept-language` singleton initialized ('en' first = default)
- the `accept-language` header whitelisted back into input ingestion (dropped by the cookie-only hardening)
- null-parse fallback `'fr'` → `defaultLanguage()` ('en')

Ends the QA-reported half-French half-English UI: anonymous pages now serve the visitor's browser language and default to English.

## Verification (vudangnt endpoint running 1.1.80 from npm)

| Accept-Language | Result |
|---|---|
| en-US | en |
| fr-FR | fr |
| ru-RU | ru |
| vi-VN (unsupported) | en |
| missing | en |
| fr-CH,fr;q=0.9,en;q=0.8 | fr |

Browser check: anonymous signin + signed-in desk render fully English for an en-US browser — zero French strings found (Paramètres/Envoyer/Annuler/Corbeille/… all absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)