### PR TITLE
fix(billing): email 'Open Drumee' lands signed-in — right host + same-site bounce

### DIFF
--- a/service/callback.js
+++ b/service/callback.js
@@ -36,18 +36,27 @@ class __callback extends Entity {
     this.output.html(`<script> window.location.href = '${this.input.homepath()}${flag}#/desk/' </script>`);
   }
 
-  // Stripe Billing Portal return. The portal's return_url points HERE (a
-  // same-origin /svc endpoint) rather than straight at the desk, on purpose:
+  // Same-site bounce into the desk. Used as the Stripe Billing Portal
+  // return_url AND as the "Open Drumee" target in outgoing emails, on purpose:
   // the session cookie is SameSite=Strict, so it is withheld on the FIRST
-  // request of a cross-site top-level navigation (the browser coming back from
-  // billing.stripe.com). Landing directly on the SPA would boot it without the
-  // cookie → yp.get_env sees a guest → the user appears logged out. This tiny
-  // HTML bounce turns the return into a SAME-SITE navigation (drumee.in's own
-  // script setting location), so the cookie IS sent on the desk load and the
-  // session survives — the exact mechanism the checkout success/cancel returns
-  // already rely on.
+  // request of a cross-site top-level navigation (coming back from
+  // billing.stripe.com, or clicking a link in Gmail). Landing directly on the
+  // SPA would boot it without the cookie → yp.get_env sees a guest → the user
+  // appears logged out. This tiny HTML bounce turns the arrival into a
+  // SAME-SITE navigation (our own script setting location), so the cookie IS
+  // sent on the desk load and the session survives.
+  //
+  // The redirect is RELATIVE (path only, no host): the session cookie is
+  // HOST-scoped — an org member's session lives on their org vhost
+  // (e.g. team.drumee.in), and homepath() on this cookie-less request resolves
+  // to the MAIN domain, which would jump off the vhost and land signed-out
+  // (verified live). Keeping only homepath's PATH preserves the endpoint
+  // segment (/-/<endpoint>/) while the browser keeps the host.
   async portal_return() {
-    this.output.html(`<script> window.location.href = '${this.input.homepath()}#/desk/' </script>`);
+    let path = '/';
+    try { path = new URL(this.input.homepath()).pathname || '/'; } catch (e) { }
+    if (!/\/$/.test(path)) path = `${path}/`;
+    this.output.html(`<script> window.location.href = '${path}#/desk/' </script>`);
   }
 }
 

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -70,8 +70,24 @@ class __public_stripe_webhook extends Entity {
       label: l.description || plan_label,
       amount: this._money(l.amount, l.currency || currency),
     }));
+    // "Open Drumee" must (a) target the RECIPIENT's host — the session cookie
+    // is host-scoped, so an org member's session lives on their org vhost and
+    // a main-domain link lands signed-out — and (b) go through the
+    // callback.portal_return same-site bounce: the cookie is SameSite=Strict,
+    // so it is withheld on the cross-site click from the mail client; the
+    // bounce re-enters same-site and the session survives (QA: "click Open
+    // Drumee → it requires sign in again").
     let app_link = '';
-    try { app_link = this.input.homepath(); } catch (e) { app_link = ''; }
+    try {
+      const home = new URL(this.input.homepath());
+      if ((smd.entity_type || 'user') === 'org' && smd.payer_id) {
+        const org = await this.yp.await_proc('payment_get_org', smd.payer_id);
+        if (org && org.link) home.host = org.link;
+      }
+      let path = home.pathname || '/';
+      if (!/\/$/.test(path)) path = `${path}/`;
+      app_link = `${home.protocol}//${home.host}${path}svc/?service=callback.portal_return`;
+    } catch (e) { app_link = ''; }
     heading = heading || `Your Drumee ${plan_label} plan is active`;
     intro = intro || "Your payment went through. Here's your receipt.";
     subject = subject || `${heading} — receipt ${invoice.number || ''}`.trim();


### PR DESCRIPTION
## Problem (QA)

Clicking **Open Drumee** in the billing/receipt email asks the user to sign in again, even though their session is alive.

## Two stacked causes (both reproduced live)

1. **SameSite=Strict**: the click from Gmail is a cross-site top-level navigation → the session cookie is withheld on the first request → the SPA boots as a guest. Same disease as the Stripe Billing Portal return (#99); same cure — route through the `callback.portal_return` same-site bounce.
2. **Host-scoped cookie**: an org member's session lives on their **org vhost** (`team.drumee.in`), while `app_link` pointed at the webhook host's `homepath()` (main domain). Even a same-site arrival on the main domain is signed-out for them. The link is now built on the **recipient's host** (`organisation.link` via `payment_get_org`, which returns it as of drumee/schemas#72), endpoint path preserved.

Bonus fix: `portal_return` itself redirected via `homepath()`, which on a cookie-less request resolves to the main domain — the bounce jumped **off** the org vhost and stranded on signin (verified live). It now redirects **relative** (path only), keeping the browser's host; the Stripe-portal flow is unchanged by construction (same host there).

## Verification (live, drumee.in vudangnt endpoint)

| Flow | Before | After |
|---|---|---|
| External site → old direct link (main domain) | signin page | — (link shape gone) |
| External site → old bounce on main | signin page | — |
| External site → **new link** (org vhost + bounce) | signin page | **signed-in desk** on `alertdemoteam.drumee.in`, uid intact |

Requires drumee/schemas#72 (`payment_get_org` + `link`/`ident`) — already applied to yp on drumee.in; degrades gracefully without it (falls back to the webhook homepath host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)