### PR TITLE
fix(task): scope column get/update/delete to the board they belong to

### DIFF
--- a/acl/task.json
+++ b/acl/task.json
@@ -929,7 +929,7 @@
       ]
     },
     "column_update": {
-      "doc": "Rename and/or re-theme a custom column. Omit a field to keep it.",
+      "doc": "Rename and/or re-theme a column on one board. Omit a field to keep it.",
       "scope": "hub",
       "permission": {
         "src": "write"
@@ -939,6 +939,11 @@
           "type": "string",
           "required": true,
           "doc": "Column id"
+        },
+        "nid": {
+          "type": "string",
+          "required": false,
+          "doc": "Folder scope the column belongs to. Built-in ids are stored once per folder, so without it the rename would hit every board"
         },
         "name": {
           "type": "string",
@@ -969,7 +974,7 @@
       ]
     },
     "column_delete": {
-      "doc": "Delete a custom column. Its tasks are moved back to the built-in 'todo' column (never lost).",
+      "doc": "Delete a column from one board. Its tasks are re-homed onto the first surviving column of that same board (never lost).",
       "scope": "hub",
       "permission": {
         "src": "write"
@@ -979,6 +984,11 @@
           "type": "string",
           "required": true,
           "doc": "Column id to delete"
+        },
+        "nid": {
+          "type": "string",
+          "required": false,
+          "doc": "Folder scope the column belongs to. Built-in ids are stored once per folder, so without it the delete would hit every board"
         }
       },
       "returns": {

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -63,23 +63,28 @@ class __private_task extends Entity {
 
   /**
    * A status key is valid when it's one of the built-in columns or the id of
-   * an existing custom column (task_column row) in this hub.
+   * an existing column (task_column row) in the SAME folder scope.
+   *
+   * The scope matters: built-in ids are literal status keys stored once per
+   * scope, so an unscoped lookup would accept a key that only exists on some
+   * other board.
    */
-  async _isValidStatus(status) {
+  async _isValidStatus(status, nid) {
     if (VALID_STATUSES.includes(status)) return true;
     if (!status || !/^[A-Za-z0-9_-]{1,32}$/.test(status)) return false;
-    const col = await this.db.await_proc('task_column_get', status);
+    const col = await this.db.await_proc('task_column_get_v2', status, nid);
     return !isEmpty(col);
   }
 
   /**
-   * Whether a status/column key is a "done" column (is_done = 1). Completion is
-   * column-driven now, so this replaces the old literal `status === 'complete'`
-   * checks — a renamed or user-created done column still counts as complete.
+   * Whether a status/column key is a "done" column (is_done = 1) in this
+   * folder scope. Completion is column-driven, so this replaces the old
+   * literal `status === 'complete'` checks — a renamed or user-created done
+   * column still counts as complete.
    */
-  async _isDoneColumn(status) {
+  async _isDoneColumn(status, nid) {
     try {
-      const col = await this.db.await_proc('task_column_get', status);
+      const col = await this.db.await_proc('task_column_get_v2', status, nid);
       const row = Array.isArray(col) ? col[0] : col;
       return !!(row && Number(row.is_done));
     } catch (e) {
@@ -405,7 +410,7 @@ class __private_task extends Entity {
     const assignees = (await this._validateAssignees(this._readAssignees() || []));
     if (assignees == null) return; // invalid assignee — exception already raised
 
-    if (!(await this._isValidStatus(status))) status = 'todo';
+    if (!(await this._isValidStatus(status, nid))) status = 'todo';
     if (!VALID_PRIORITIES.includes(priority)) priority = 'medium';
 
     const id = await this.yp.await_func('uniqueId');
@@ -489,14 +494,22 @@ class __private_task extends Entity {
     const id = this.input.need(Attr.id);
     let status = this.input.need(Attr.status);
 
-    if (!(await this._isValidStatus(status))) {
+    // Capture the source column BEFORE the move so its watchers are told the
+    // task left, in addition to the destination column's watchers. This also
+    // yields the task's folder, which the status check needs: column ids are
+    // scoped, so a key must be validated against THIS task's board rather than
+    // any board in the workspace.
+    const prev = await this._taskColMeta(id);
+    if (!prev) {
+      // Same code the proc would have produced below; resolved earlier now
+      // that the task row is read up front.
+      return this.exception.user('TASK_NOT_FOUND');
+    }
+    const prevStatus = prev.status;
+
+    if (!(await this._isValidStatus(status, prev.nid))) {
       return this.exception.user('INVALID_STATUS');
     }
-
-    // Capture the source column BEFORE the move so its watchers are told the
-    // task left, in addition to the destination column's watchers.
-    const prev = await this._taskColMeta(id);
-    const prevStatus = prev && prev.status;
 
     const data = await this.db.await_proc('task_update_status', id, status);
     if (isEmpty(data)) {
@@ -505,7 +518,9 @@ class __private_task extends Entity {
     const row = Array.isArray(data) ? data[0] : data;
     await this._logActivity(
       id,
-      (await this._isDoneColumn(status)) ? 'complete' : 'status',
+      // nid is unchanged by a column move, so the task's folder still scopes
+      // the done-column lookup correctly.
+      (await this._isDoneColumn(status, prev.nid)) ? 'complete' : 'status',
       { title: row && row.title, status },
     );
     await this._broadcast('task.update_status', data);
@@ -833,11 +848,17 @@ class __private_task extends Entity {
   }
 
   /**
-   * Rename and/or re-theme a custom column.
-   * Params: id (required); name / theme (optional — omit to keep).
+   * Rename and/or re-theme a column.
+   * Params: id (required); nid (folder scope, nullable); name / theme
+   * (optional — omit to keep).
+   *
+   * Scoped: built-in ids are literal status keys stored once per folder, so
+   * an unscoped update would rename that built-in on EVERY board in the
+   * workspace. Each board's columns are independent.
    */
   async column_update() {
     const id = this.input.need(Attr.id);
+    const nid = this.input.use('nid', null);
     let name = this.input.use('name', null);
     if (name != null) {
       name = String(name).trim().slice(0, 100);
@@ -847,8 +868,8 @@ class __private_task extends Entity {
     if (theme != null && !VALID_THEMES.includes(theme)) theme = 'default';
 
     const data = await this.db.await_run(
-      'CALL task_column_update(?, ?, ?)',
-      [id, name, theme]
+      'CALL task_column_update_v2(?, ?, ?, ?)',
+      [id, nid, name, theme]
     );
     if (isEmpty(data)) {
       return this.exception.user('COLUMN_NOT_FOUND');
@@ -858,18 +879,25 @@ class __private_task extends Entity {
   }
 
   /**
-   * Delete a custom column. Its tasks are moved back to the built-in 'todo'
-   * column by the proc (never lost); the response carries moved_tasks so the
-   * client re-fetches its task list when non-zero.
+   * Delete a column. Its tasks are re-homed onto the first surviving column of
+   * the SAME board by the proc (never lost); the response carries moved_tasks
+   * so the client re-fetches its task list when non-zero.
+   * Params: id (required); nid (folder scope, nullable).
+   *
+   * Scoped for the same reason as column_update: deleting a built-in without
+   * the folder would remove it from every board in the workspace.
    */
   async column_delete() {
     const id = this.input.need(Attr.id);
-    const data = await this.db.await_proc('task_column_delete', id);
+    const nid = this.input.use('nid', null);
+    const data = await this.db.await_proc('task_column_delete_v2', id, nid);
     const row = Array.isArray(data) ? data[0] : data;
     await this._broadcast('task.column_delete', {
       id,
+      nid,
       affected: row && row.affected,
       moved_tasks: row && row.moved_tasks,
+      moved_to: row && row.moved_to,
     });
     this.output.data(row);
   }


### PR DESCRIPTION
Server half of the task_column scope fix. Pairs with **drumee/schemas#74** and **drumee/ui-team#340**.

## Why

`task_column` is keyed on `(id)` alone, but `task_column_list` seeds the four built-ins **per folder scope** using their literal status keys as ids. Only the first scope opened can hold them; every later scope's `INSERT IGNORE` silently stores nothing yet still writes its `task_column_init` marker, so it is never seeded again. Those boards hide every task in a built-in status — 79 of 137 on one production board.

schemas#74 makes the key `(id, nid)`. Under that key an unscoped `WHERE id = _id` would rename or delete a built-in on **every** board in the workspace, so the procs gain `_v2` forms taking the scope and the server must pass it.

## Changes

- `column_update` / `column_delete` read `nid` and call `task_column_update_v2` / `task_column_delete_v2`.
- `_isValidStatus` / `_isDoneColumn` take the folder and call `task_column_get_v2`, so a status key is validated against the task's own board rather than any board in the hub.
- `update_status` reads the task row before validating, since the task's `nid` is what scopes the check. A missing task now returns `TASK_NOT_FOUND` from that read instead of from the proc below it — **same error code**, resolved earlier.
- `column_create` / `column_list` / `column_reorder` already passed `nid` and their proc signatures are unchanged — untouched.
- `acl/task.json`: documents the new `nid` param on both services (docs only, no runtime effect). Verified valid JSON with no duplicate keys.

## Deploy order

1. **schemas#74 `_v2` procs** — additive, nothing calls them yet.
2. **this PR + ui#340**.
3. **`alter_task_column_scope_pk.sql`** — by then nothing calls the old procs.

The scope procs compare `IFNULL(nid,'')`, so they are correct before **and** after the migration. No step can break the one before it, and each is independently revertible.

## Semantics worth confirming

These changes assume **each board's columns are independent** — renaming or deleting "To do" on one board leaves other boards untouched. That follows from the per-scope seeding design, but it is a product decision, so flagging it explicitly rather than deciding silently.

## Not deployed

Nothing applied to prod. `node --check` clean.