### PR TITLE
fix(call): write p2p call logs to p2p_channel so they appear in chat

### DIFF
--- a/service/conference.js
+++ b/service/conference.js
@@ -553,47 +553,37 @@ class conference extends __yp {
 
     let peer_id = entity_id;
 
-    let acknowledge = {};
-    acknowledge.message_id = message_id;
-    acknowledge.entity_id = entity_id;
-    acknowledge.uid = author_id;
+    // P2P call logs must land in p2p_channel — the store chat.messages reads
+    // through p2p_list_messages. The legacy `channel` table this used to write
+    // to is no longer read by any p2p surface, so those rows were invisible in
+    // chat-p2p and bigchat alike.
+    //
+    // Like every other p2p message this is a SINGLE write in the caller's DB
+    // with peer_id = callee; p2p_list_messages unions both sides, so the callee
+    // reads the same row cross-DB. p2p_post_message also marks the author
+    // _seen_/_delivered_, which is what the old acknowledge_message call did.
+    //
+    // One shared row means `role` can no longer be baked per copy, so carry
+    // caller_id and let each side derive incoming-vs-outgoing. `role` stays for
+    // rows written before this change.
+    let metadata = {
+      message_type: msg_type,
+      call_status: event,
+      duration: duration,
+      role: "caller",
+      caller_id: author_id,
+    };
 
     let myinput = {
       message_id: message_id,
       author_id: author_id,
-      entity_id: entity_id,
-      metadata: {
-        message_type: msg_type,
-        call_status: event,
-        duration: duration,
-        role: "caller",
-      },
+      peer_id: peer_id,
+      metadata,
     };
 
     let mydata = await this.yp.await_proc(
-      `${author.db_name}.channel_post_message`,
+      `${author.db_name}.p2p_post_message`,
       myinput,
-      msg_type
-    );
-    await this.yp.await_proc(
-      `${author.db_name}.acknowledge_message`,
-      acknowledge
-    );
-
-    let hisinput = {
-      message_id: message_id,
-      author_id: author_id,
-      entity_id: author_id,
-      metadata: {
-        message_type: msg_type,
-        call_status: event,
-        duration: duration,
-        role: "callee",
-      },
-    };
-    let hisdata = await this.yp.await_proc(
-      `${peer.db_name}.channel_post_message`,
-      hisinput,
       msg_type
     );
 
@@ -612,23 +602,16 @@ class conference extends __yp {
       recipients = await this.yp.await_proc("user_sockets", author_id);
       await RedisStore.sendData(this.payload(mydata, { service }), recipients);
 
-      // this.pushLiveUpdate({
-      //   service: "chat.post",
-      //   dest: {
-      //     area: Attr.personal,
-      //     type: Attr.drumate,
-      //     hub_id: author_id
-      //   },
-      //   model: mydata,
-      //   keys: '*'
-      // });
-    }
-
-    if (!isEmpty(hisdata)) {
+      // Same row, second push. peer_id must name the OTHER party from each
+      // recipient's point of view — the chat widget matches it against its own
+      // peerId (chat/index.js onWsMessage → privateMach), so a payload without
+      // it (or with the callee's own id) is silently dropped and the call event
+      // only appears after a reload.
+      let hisdata = { ...mydata, peer_id: author_id };
       let hiscount = await this.yp.await_proc(
         `${peer.db_name}.count_yet_read_next`,
-        author_id,
-        peer_id
+        peer_id,
+        author_id
       );
       hisdata.entity = await this.contactInfo(peer.db_name, contact_id);
       hisdata.service = "chat.post";
@@ -637,17 +620,6 @@ class conference extends __yp {
       hisdata.to_id = peer_id;
       recipients = await this.yp.await_proc("user_sockets", peer_id);
       await RedisStore.sendData(this.payload(hisdata, { service }), recipients);
-
-      // this.pushLiveUpdate({
-      //   service: "chat.post",
-      //   dest: {
-      //     area: Attr.personal,
-      //     type: Attr.drumate,
-      //     hub_id: peer_id
-      //   },
-      //   model: hisdata,
-      //   keys: '*'
-      // });
     }
   }
 

--- a/service/signaling.js
+++ b/service/signaling.js
@@ -217,50 +217,28 @@ class __service_signaling extends Entity {
     my = author_id;
     his = entity_id;
 
-    let acknowledge = {};
-    acknowledge.message_id = message_id
-    acknowledge.entity_id = entity_id
-    acknowledge.uid = my
-
+    // Mirrors conference.writeLog — see the long note there. Single write into
+    // p2p_channel in the caller's DB (peer_id = callee); p2p_list_messages
+    // unions both sides so the callee reads the same row cross-DB. The legacy
+    // `channel` table this used to write to is not read by any p2p surface.
+    let metadata = {
+      message_type: msg_type,
+      call_status: type,
+      duration: duration,
+      role: 'caller',
+      caller_id: author_id
+    };
 
     let myinput = {
       message_id: message_id,
       author_id: author_id,
-      entity_id: entity_id,
-      metadata: {
-        message_type: msg_type,
-        call_status: type,
-        duration: duration,
-        role: 'caller'
-      }
+      peer_id: entity_id,
+      metadata
     };
 
     let mydata = await this.yp.await_proc('forward_proc', my,
-      'channel_post_message',
+      'p2p_post_message',
       `'${stringify(myinput)}','${msg_type}'`
-    );
-
-
-    let hisinput = {
-      message_id: message_id,
-      author_id: author_id,
-      entity_id: author_id,
-      metadata: {
-        message_type: msg_type,
-        call_status: type,
-        duration: duration,
-        role: 'callee'
-      }
-    };
-    //this.debug("AAAAA:383", hisinput);
-    let hisdata = await this.yp.await_proc('forward_proc', his,
-      'channel_post_message',
-      `'${stringify(hisinput)}','${msg_type}'`
-    );
-
-
-    await this.yp.await_proc('forward_proc', my, 'acknowledge_message',
-      `'${stringify(acknowledge)}'`
     );
 
     if (!isEmpty(mydata)) {
@@ -275,11 +253,13 @@ class __service_signaling extends Entity {
       mydata.to_id = my;
 
       recipients = await this.yp.await_proc('user_sockets', mydata.to_id);
-      await RedisStore.sendData(this.payload(mydata), recipients);
-    }
+      // The push must be tagged chat.post: the chat widget dispatches on
+      // options.service, so without this the payload arrives under the
+      // signaling.message service and never reaches onWsMessage's post branch.
+      await RedisStore.sendData(this.payload(mydata, { service: 'chat.post' }), recipients);
 
-
-    if (!isEmpty(hisdata)) {
+      // peer_id names the OTHER party per recipient — see conference.writeLog.
+      let hisdata = { ...mydata, peer_id: my };
       let hiscount = await this.yp.await_proc('forward_proc',
         his, 'count_yet_read_next', `'${his}','${my}'`
       );
@@ -289,7 +269,7 @@ class __service_signaling extends Entity {
       hisdata.total = hiscount.total
       hisdata.to_id = his;
       recipients = await this.yp.await_proc('user_sockets', hisdata.to_id);
-      await RedisStore.sendData(this.payload(hisdata), recipients);
+      await RedisStore.sendData(this.payload(hisdata, { service: 'chat.post' }), recipients);
     }
   }
 


### PR DESCRIPTION
Ending a p2p call logged the event into the legacy `channel` table via channel_post_message. No p2p surface reads that table any more: chat.messages goes through p2p_list_messages, which reads p2p_channel. The call event was therefore invisible in chat-p2p and bigchat alike, on reload as well as live.

- Replace the two channel_post_message writes (caller's DB + callee's DB) with a single p2p_post_message in the caller's DB, peer_id = callee. p2p_list_messages unions both sides, so the callee reads the same row cross-DB — the same shape chat._distributeMessage uses for every other p2p message.
- Drop the separate acknowledge_message call: p2p_post_message already stamps the author into _seen_/_delivered_.
- Carry metadata.caller_id. One shared row cannot bake `role` per copy, so each side derives incoming-vs-outgoing from caller_id instead.

The WS push could not match either. chat/index.js onWsMessage gates p2p posts on `this.peerId === data.peer_id`, and neither service put peer_id on the payload (channel_post_message does not return it), so the push was dropped and the event only ever appeared after a reload.

- Add peer_id to both pushes, naming the OTHER party per recipient.
- signaling: tag the pushes { service: 'chat.post' }. Without it they went out under signaling.message and never reached onWsMessage's post branch.
- Fix the callee's count_yet_read_next argument order: the proc takes (_uid, _peer_id) and ran in the peer's DB with the caller's id first.

No schema change: p2p_post_message and p2p_list_messages already expose message_type / call_status / call_duration.