### PR TITLE
fix(payment): resolve collation mismatch in org-ident vhost/domain check

### DIFF
--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -57,9 +57,15 @@ class __private_payment extends Entity {
     }
     // The org URL is `${ident}.${main_domain()}` (domain_create convention) —
     // reject when the fqdn or domain row already exists.
+    // COLLATE utf8mb4_general_ci on both CONCATs: the bound `?` parameter
+    // gives the expression a "NONE" collation derivation (driver binds it
+    // without the connection's collation), which clashes with vhost.fqdn /
+    // domain.name's column collation (utf8mb4_general_ci, "IMPLICIT") on
+    // comparison — ER_CANT_AGGREGATE_2COLLATIONS (1267), confirmed live on
+    // prod 2026-07-23. Forcing the expression's collation resolves it.
     let rows = await this.yp.await_query(
-      `SELECT (SELECT COUNT(*) FROM vhost  WHERE fqdn = CONCAT(?, '.', main_domain()))
-            + (SELECT COUNT(*) FROM domain WHERE name = CONCAT(?, '.', main_domain())) AS c`,
+      `SELECT (SELECT COUNT(*) FROM vhost  WHERE fqdn = CONCAT(?, '.', main_domain()) COLLATE utf8mb4_general_ci)
+            + (SELECT COUNT(*) FROM domain WHERE name = CONCAT(?, '.', main_domain()) COLLATE utf8mb4_general_ci) AS c`,
       ident, ident
     );
     if (Array.isArray(rows)) rows = rows[0];


### PR DESCRIPTION
**Root cause (confirmed live on prod, read-only investigation 2026-07-23):** `_validateOrgIdent`'s raw availability query compares `vhost.fqdn` / `domain.name` (both `utf8mb4_general_ci`, confirmed on prod) against `CONCAT(?, '.', main_domain())`. The bound `?` parameter gives that expression a 'NONE' collation derivation — MariaDB refuses to auto-coerce that against the column's 'IMPLICIT' collation, throwing `ER_CANT_AGGREGATE_2COLLATIONS` (1267). This blocked **every** TEAM-plan org-ident check on prod, before checkout could even start (confirmed via prod error logs, 4× in 60s for ident 'lexis').

**Fix:** `COLLATE utf8mb4_general_ci` on both `CONCAT` expressions, forcing them to match the column collation. `ident_exists` (called just above, a stored proc) was unaffected by the same bug — proc-declared params don't hit this client-side binding quirk.

**Companion (already applied directly to prod `yp` DB, read-only-confirmed missing beforehand):** `org_provision` and `contact_storage_alert_unread` procs — both existed on stage but were never promoted to prod, found during the same investigation. `org_provision` in particular was blocking the Stripe webhook from ever completing TEAM-plan organisation provisioning post-payment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)