### PR TITLE
fix(task): task notifications point at the task's own folder; a reply is not a mention

### DIFF
--- a/acl/task.json
+++ b/acl/task.json
@@ -682,6 +682,11 @@
           "required": false,
           "doc": "Root comment id when this is a reply; omit/null for a top-level comment"
         },
+        "reply_to_uid": {
+          "type": "string",
+          "required": false,
+          "doc": "Author of the comment this reply answers, when it is a child comment. Notified as a reply, not a mention."
+        },
         "mention_uids": {
           "type": "array",
           "required": false,

--- a/service/private/activity.js
+++ b/service/private/activity.js
@@ -93,6 +93,10 @@ function flattenTaskFields(rows) {
       // it (and nid, when the task carries one) from the task meta.
       if (meta.hub_id != null) r.hub_id = meta.hub_id;
       if (r.nid == null && meta.nid != null) r.nid = meta.nid;
+      // A reply to your comment rides the same row with kind='reply'; surfacing
+      // it lets the item say "replied to your comment in" instead of the
+      // (untrue) "mentioned you in". Absent on real @-mentions.
+      if (r.task_kind == null && meta.kind != null) r.task_kind = meta.kind;
     }
   }
   return rows;

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -1929,6 +1929,12 @@ class __private_channel extends Entity {
 
     // Include task @-mentions (logged by task._notifyMentions) for mention/all.
     // `name` carries the task title so the item renders "mentioned you in <task>".
+    // NULLIF on the JSON reads: JSON_UNQUOTE(JSON_EXTRACT(...)) returns the 4-char
+    // STRING 'null' for a JSON null, not SQL NULL. The client then navigated to
+    // nid='null', which matches no node → "the file you requested does not exist".
+    // Collapsing it back to a real NULL makes a nid-less row fall back to the
+    // workspace root instead of erroring. `task_kind` distinguishes a reply
+    // ('reply') from a true @-mention so the item can render the right sentence.
     if (type === "mention" || type === "all") {
       try {
         const taskMentions = toArray(
@@ -1936,7 +1942,8 @@ class __private_channel extends Entity {
             `SELECT ca.id, ca.timestamp AS ctime, ca.uid AS author_id,
               JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.task_id')) AS task_id,
               JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.hub_id')) AS hub_id,
-              JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.nid')) AS nid,
+              NULLIF(JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.nid')), 'null') AS nid,
+              NULLIF(JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.kind')), 'null') AS task_kind,
               JSON_UNQUOTE(JSON_EXTRACT(ca.data, '$.title')) AS name,
               CONCAT('["', ca.target_uid, '"]') AS mention_ids,
               COALESCE(CONCAT(d.firstname, ' ', d.lastname), d.email, '') AS fullname,

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -111,8 +111,11 @@ class __private_task extends Entity {
    * mentioned users' sockets so their activity badge updates immediately.
    * Mirrors the chat/channel mention path. `mentionUids` is the set to notify —
    * create() passes all tagged uids, update() passes only the newly-added ones.
+   * `kind` marks a non-mention variant carried by the same row (currently only
+   * 'reply' — a reply to your comment); omitted for real @-mentions, so their
+   * stored data stays exactly as before.
    */
-  async _notifyMentions(data, mentionUids) {
+  async _notifyMentions(data, mentionUids, kind = null) {
     const uids = toArray(mentionUids).filter((u) => u && u !== this.uid);
     if (isEmpty(uids)) return;
     const hub_id = this.hub && this.hub.get(Attr.id);
@@ -125,6 +128,7 @@ class __private_task extends Entity {
       title: (data && data.title) || '',
       nid: (data && data.nid) || null,
     };
+    if (kind) meta.kind = kind;
     for (const target_uid of uids) {
       try {
         await this.yp.await_proc(
@@ -689,22 +693,26 @@ class __private_task extends Entity {
 
   /**
    * Notify members @-mentioned in a comment body. Reuses _notifyMentions with a
-   * task-shaped context ({ id: task_id, title }) so the activity reads
-   * "mentioned you in <task>". Best-effort.
-   * (Watcher notifications — assignee/creator on every comment — are a planned
-   * follow-up; they need distinct "commented on" activity copy.)
+   * task-shaped context ({ id: task_id, title, nid }) so the activity reads
+   * "mentioned you in <task>". Best-effort. `kind` is forwarded as-is ('reply'
+   * for a reply to someone's comment).
+   * The task's `nid` (its folder) MUST travel with the notification: without it
+   * the click can only fall back to the workspace root instead of opening the
+   * folder the task actually lives in.
    */
-  async _notifyCommentMentions(task_id, mentionUids) {
+  async _notifyCommentMentions(task_id, mentionUids, kind = null) {
     if (isEmpty(toArray(mentionUids))) return;
     let title = '';
+    let nid = null;
     try {
-      const rows = await this.db.await_run('SELECT title FROM task WHERE id = ?', [task_id]);
+      const rows = await this.db.await_run('SELECT title, nid FROM task WHERE id = ?', [task_id]);
       const t = toArray(rows)[0];
       title = (t && t.title) || '';
+      nid = (t && t.nid) || null;
     } catch (e) {
       this.warn('[task._notifyCommentMentions] title lookup failed:', e && e.message);
     }
-    await this._notifyMentions({ id: task_id, title }, mentionUids);
+    await this._notifyMentions({ id: task_id, title, nid }, mentionUids, kind);
   }
 
   /**
@@ -736,19 +744,25 @@ class __private_task extends Entity {
     const row = Array.isArray(data) ? data[0] : data;
     await this._logActivity(task_id, 'comment', {});
     await this._broadcast('task.comment_create', row);
-    // Notify @-mentioned members; on a reply, also notify the parent author.
-    let notify = toArray(this.input.use('mention_uids', null));
+    // Notify @-mentioned members. On a reply, the parent author is notified too
+    // — but as a 'reply', NOT a mention: they were never @-mentioned, and
+    // labelling it "mentioned you" is what the notification wrongly claimed.
+    const mentions = [...new Set(toArray(this.input.use('mention_uids', null)).filter(Boolean))];
+    await this._notifyCommentMentions(task_id, mentions);
     if (parent_id) {
       try {
         const p = toArray(
           await this.db.await_run('SELECT author_uid FROM task_comment WHERE id = ?', [parent_id])
         )[0];
-        if (p && p.author_uid) notify = notify.concat(p.author_uid);
+        // Already @-mentioned in the same comment → one notification, not two.
+        // (_notifyMentions drops self, so replying to yourself notifies nobody.)
+        if (p && p.author_uid && !mentions.includes(p.author_uid)) {
+          await this._notifyCommentMentions(task_id, [p.author_uid], 'reply');
+        }
       } catch (e) {
         this.warn('[task.comment_create] parent lookup failed:', e && e.message);
       }
     }
-    await this._notifyCommentMentions(task_id, [...new Set(notify)]);
     // Notify watchers of the commented task's column.
     const tmeta = await this._taskColMeta(task_id);
     if (tmeta) await this._notifyColumnWatchers(tmeta, tmeta.status);

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -744,24 +744,40 @@ class __private_task extends Entity {
     const row = Array.isArray(data) ? data[0] : data;
     await this._logActivity(task_id, 'comment', {});
     await this._broadcast('task.comment_create', row);
-    // Notify @-mentioned members. On a reply, the parent author is notified too
-    // — but as a 'reply', NOT a mention: they were never @-mentioned, and
-    // labelling it "mentioned you" is what the notification wrongly claimed.
+    // Notify @-mentioned members. Repliers are notified too — but as a 'reply',
+    // NOT a mention: they were never @-mentioned, and labelling it "mentioned
+    // you" is what the notification wrongly claimed.
     const mentions = [...new Set(toArray(this.input.use('mention_uids', null)).filter(Boolean))];
-    await this._notifyCommentMentions(task_id, mentions);
+    // Threads are flattened to one level (parent_id is always the ROOT), so when
+    // the client answers a CHILD comment it names that child's author here — the
+    // person the reply is actually addressed to, who is otherwise invisible to
+    // this endpoint. They are a replier, so take them out of the mention set.
+    // (The client also still lists them in mention_uids, so a server without
+    // this parameter keeps notifying them exactly as before — which makes the
+    // two deploys independent, in either order.)
+    const replyTo = this.input.use('reply_to_uid', null);
+    const mentionSet = new Set(mentions);
+    if (replyTo) mentionSet.delete(replyTo);
+    await this._notifyCommentMentions(task_id, [...mentionSet]);
+    // Everyone who gets the "replied to your comment" copy: the author of the
+    // comment being answered, plus the root author of the thread. Deduped, and
+    // never someone already notified as a genuine @-mention, so one person gets
+    // exactly one notification per comment. (_notifyMentions drops self, so
+    // replying to yourself notifies nobody.)
+    const repliers = new Set();
+    if (replyTo && !mentionSet.has(replyTo)) repliers.add(replyTo);
     if (parent_id) {
       try {
         const p = toArray(
           await this.db.await_run('SELECT author_uid FROM task_comment WHERE id = ?', [parent_id])
         )[0];
-        // Already @-mentioned in the same comment → one notification, not two.
-        // (_notifyMentions drops self, so replying to yourself notifies nobody.)
-        if (p && p.author_uid && !mentions.includes(p.author_uid)) {
-          await this._notifyCommentMentions(task_id, [p.author_uid], 'reply');
-        }
+        if (p && p.author_uid && !mentionSet.has(p.author_uid)) repliers.add(p.author_uid);
       } catch (e) {
         this.warn('[task.comment_create] parent lookup failed:', e && e.message);
       }
+    }
+    if (repliers.size) {
+      await this._notifyCommentMentions(task_id, [...repliers], 'reply');
     }
     // Notify watchers of the commented task's column.
     const tmeta = await this._taskColMeta(task_id);


### PR DESCRIPTION
Hotfix off `preview`. Verified on drumee.in (test) by Duy. **No schema change — nothing to apply to any DB.**

## Issues

Reported by Lexis, reproduced and root-caused against the prod/stage DBs.

**1. A task-comment notification opened the wrong folder.** Clicking a "mentioned you in a comment" notification for a task in the subfolder *Round 2 Bugs* opened the workspace root instead. `_notifyCommentMentions` built its task context from `{ id, title }` only, so every comment-sourced `task_mention` was logged with `nid: null` even though the task row has a real `nid`; the client then fell back to `nid=0`, which the ACL resolves to the hub root.

**2. Some notifications failed outright** with *"Ooops … The file you requested does not exist or has been deleted."* `JSON_UNQUOTE(JSON_EXTRACT(...))` returns the 4-character **string** `'null'` for a JSON null, not SQL NULL (verified on the prod server: `LENGTH()=4`, `IS NULL = 0`). The client navigated to `nid='null'`, which matches no node. `NULLIF` collapses it back to a real NULL, so a nid-less row degrades to the workspace root instead of erroring — this also repairs the rows already stored, with no data migration.

**3. Replying to a comment claimed "mentioned you in".** `comment_create` notified the parent author through the same `task_mention` path. The reply now carries `kind:'reply'` in the same row (no new event, no new stored procedure); `activity.js` surfaces the flag and `channel.list_notifications` returns it as `task_kind`.

**4. Replying to a reply still said "mentioned you".** Threads are flattened to one level, so the backend only ever sees `parent_id = the root`. To notify the person actually being answered, the client had listed that child's author in `mention_uids` — so the reply-to-a-reply went down the mention path. The client now names them in a new optional `reply_to_uid`; the server notifies them as a reply and removes them from the mention set. `reply_to_uid` and the thread's root author are deduped and never collide with a genuine at-mention, so each person gets exactly one notification with the right wording.

## Deploy-order safety (issue 4)

The replied-to author stays in `mention_uids` as well, so a server without `reply_to_uid` keeps notifying them exactly as before. All four client/server combinations were simulated: the three transitional states are byte-identical to today's behaviour; the fix only activates once both sides are deployed, in either order.

## Notes

- `comment_update` calls `_notifyCommentMentions` with two arguments; the new third parameter defaults to `null`.
- Real at-mention rows are stored exactly as before — `kind` is only added when set.
- Paired UI change: drumee/ui-team#350.
