### PR TITLE
feat(env): billing_upgrade switch in the platform payload

### DIFF
--- a/service/lib/env.js
+++ b/service/lib/env.js
@@ -123,6 +123,23 @@ function platform() {
   }
   platform.intl = this.supportedLanguage();
   platform.arch = global.myDrumee.arch || "pod";
+  // Explicit on/off switch for the billing "upgrade plan" affordances
+  // (desk sidebar entry + admin-console CTAs), set in
+  // /etc/drumee/conf.d/myDrumee.json as `billing_upgrade`.
+  //
+  //   omitted -> the client derives it (arch 'cloud' + a live payment
+  //              service), i.e. the behaviour every existing install
+  //              already has; nothing to set to keep things as they are.
+  //   0/false -> force OFF everywhere (kill switch).
+  //   1/true  -> force ON, overriding the arch check — for a pod that does
+  //              have Stripe configured.
+  //
+  // Deliberately passed through untouched (no ~~/Boolean coercion): the
+  // client must be able to tell "unset" from "explicitly 0", and those two
+  // mean different things.
+  if (global.myDrumee.billing_upgrade !== undefined) {
+    platform.billing_upgrade = global.myDrumee.billing_upgrade;
+  }
   platform.cdnHost = global.myDrumee.cdnHost;
   platform.version = global.VERSION;
   platform.TfaMethods = TfaMethods;


### PR DESCRIPTION
Ops needs to turn the billing **upgrade** affordances on/off per deployment without editing code or unloading the payment module.

Forwards the `billing_upgrade` key from `/etc/drumee/conf.d/myDrumee.json` — the same env file that already carries `arch` / `isPublic` / `useEmail` — into the platform payload the client reads at bootstrap.

```jsonc
// /etc/drumee/conf.d/myDrumee.json
{
  "arch": "cloud",
  "billing_upgrade": 0    // 0/false = off · 1/true = on · omit = derive from arch
}
```

Passed through **untouched and only when present** — no `~~` / `Boolean` coercion — because the client must distinguish *unset* (derive from `arch`, i.e. exactly today's behaviour, nothing to set on any existing install) from an explicit `0`.

Consumers: drumee/ui-team `libs/billing` (sidebar entry + `upgrade-plan` handler) and drumee/admin-console `toolkit/billing` (the four storage/upsell CTAs).

⚠️ The value is read from the config at process start, so flipping it needs a service restart to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)