### PR TITLE
fix(activity): pass upload file name (item_filename) to the client

### DIFF
--- a/service/private/activity.js
+++ b/service/private/activity.js
@@ -55,6 +55,10 @@ function mapNotificationRow(r) {
     item.filetype = firstValue(r.target_filetype, r.filetype, 'folder');
     item.target_filetype = item.filetype;
     item.item_filetype = firstValue(r.item_filetype, r.uploaded_filetype, r.src_filetype);
+    // The uploaded file's own name (notification_center_next surfaces it as
+    // item_filename) so a single-file upload rollup can show the file name
+    // instead of its destination folder/workspace. Absent for multi-file rollups.
+    item.item_filename = r.item_filename;
     item.filename = targetName;
     item.link_label = targetName;
     item.author_id = firstValue(r.author_id, r.owner_id, r.drumate_id);


### PR DESCRIPTION
Pairs with schemas PR #79 and the ui PR of the same branch name (`hotfix/upload-noti-filename`).

`notification_center_next` now surfaces the uploaded file's own name (`item_filename`) so a single-file upload rollup can show the file name instead of its destination folder. This forwards it through `mapNotificationRow`'s media branch — one line.

Deploy-order-safe: `item_filename` is undefined for multi-file rollups and every non-media row, and undefined when the SP hasn't been applied yet (old DB), in which case the client falls back to the existing name — no behaviour change. The existing `targetName`/surname fallback chain is untouched.