### PR TITLE
ci: add advisory Claude QC review workflow

### DIFF
--- a/.github/workflows/claude-qc.yml
+++ b/.github/workflows/claude-qc.yml
@@ -1,0 +1,137 @@
+name: Claude QC
+
+# Advisory AI quality-control review on PRs into the mainline branches. Posts a
+# structured QC report (bugs/regressions, impact analysis, test recommendations,
+# Drumee rule violations) as a PR comment; continue-on-error keeps it non-blocking
+# and it never touches the deploy pipeline (deploy.yml). Auth uses the
+# CLAUDE_CODE_OAUTH_TOKEN repo secret (generated via `claude setup-token`).
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches: [test, preview, main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-qc-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    name: AI QC report (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          track_progress: true
+          prompt: |
+            You are the quality-control reviewer for this pull request. The checkout
+            is the PR merge commit, so `git diff HEAD^1 HEAD` is the exact change
+            set of this PR against its base branch — use that as the diff (do NOT
+            diff against origin/branch names; they can lack a merge base after a
+            force-push). Analyze it together with the surrounding code. Write
+            everything in English.
+
+            Your PRIMARY goal is regression detection: finding OTHER functions and
+            features — ones NOT edited in this PR — whose behavior can change
+            because of it. A finding of the form "this PR can break a feature it
+            never touched" is worth more than anything else in your report. Spend
+            most of your effort on task 2, especially 2c.
+
+            Perform these tasks in order:
+
+            1. BUGS & POTENTIAL REGRESSIONS — logic errors, unhandled promise
+               rejections, missing permission checks, and behavior changes that can
+               break existing callers or stored-procedure contracts.
+            2. IMPACT ANALYSIS — map the ripple effect of the change onto the rest
+               of the codebase, not just the edited lines:
+               a. Direct callers: search the repository for every call site of each
+                  added/changed/removed function and list them.
+               b. Transitive impact: follow the callers up to their entry points —
+                  service endpoints (acl/*.json), workers (offline/), push-router
+                  events — and list every entry point whose behavior can change.
+               c. Shared-state siblings: list OTHER functions that are NOT in the
+                  diff but share state with the changed code — same stored
+                  procedure, same table, same Redis key/channel, same global or
+                  cache — and can therefore change behavior without being edited.
+               d. Contract changes: if a function's parameters, return shape, or
+                  thrown errors changed, verify EVERY call site still matches and
+                  flag each one that does not.
+            3. TEST RECOMMENDATIONS — based on the impact analysis, name the exact
+               functions that should be tested before merging, each with concrete
+               test cases (input -> expected outcome), highest risk first.
+            4. DRUMEE RULES — flag violations of:
+               - ACL contract: service methods added or renamed under service/ must
+                 be declared in the matching acl/<module>.json (and vice versa);
+                 the REST router refuses undeclared methods.
+               - CommonJS only: no dependency change to a pure-ESM version (a
+                 previous ESM bump of mariadb took production down).
+               - No raw SQL in service code: all DB operations go through stored
+                 procedures via await_proc / await_func.
+               - User-visible strings must be translation keys, never hardcoded.
+
+            Then publish the report by updating your tracking comment on the pull
+            request (use the update_claude_comment tool) — one single report, do
+            not create additional comments. The MAIN audience is QA testers who
+            do not read code: translate every finding into the user-facing feature
+            it belongs to (meetings, chat, file sharing, sign-up, quota, admin
+            console, ...) using the acl/*.json service names as a guide, and avoid
+            developer jargon (no "promise", "stored procedure", "endpoint",
+            "callback") outside the technical appendix. Use exactly this structure:
+
+            ## Claude QC Report
+            **Verdict:** either "PASS - safe to test as usual" or "N things need attention"
+
+            ### What this change does
+            2-4 plain-language sentences describing the change from the user's
+            point of view.
+
+            ### Affected features - what QC should test
+            | Priority | Feature | What could break | How to test (steps -> expected result) |
+            Feature is the user-facing name, not a function name. "How to test"
+            is concrete manual steps anyone can follow in the app, e.g.
+            "Create a meeting for tomorrow -> both participants receive a
+            reminder notification 15 minutes before it starts".
+
+            ### Other features at risk (NOT changed in this PR)
+            The regression radar - features this PR never touched but that share
+            data or plumbing with the change and can therefore break silently:
+            | Feature | Why it can be affected | How to check it still works (steps -> expected result) |
+            If the analysis found none, write "None - the change is self-contained"
+            and say in one sentence why you are confident.
+
+            ### Possible bugs (plain language)
+            One bullet per bug: what the user would experience, how serious it is
+            (critical / major / minor), and in which feature.
+
+            <details>
+            <summary>Technical appendix (for developers)</summary>
+
+            - Bugs with file:line and the technical cause.
+            - Impact table: | Changed function | Affected function / endpoint /
+              worker | How affected (caller / transitive / shared state /
+              contract) | Risk |
+            - Drumee rule violations with file:line.
+
+            </details>
+
+            Rules for the report: write "None" instead of an empty table or empty
+            section; in the appendix reference only real file paths and line
+            numbers from this repository; keep the part above the appendix under
+            500 words; do not modify any files.
+          claude_args: |
+            --model claude-sonnet-5
+            --max-turns 25
+            --allowedTools "Bash(git diff:*),Bash(git log:*),Bash(git show:*)"


### PR DESCRIPTION
Adds an advisory Claude-powered QC review that runs on every PR into test/preview/main.

- Posts a QA-oriented report as a PR comment: what the change does, affected features with manual test steps, a regression radar for features NOT touched by the PR, and a technical appendix for developers.
- Non-blocking (continue-on-error) and independent from the deploy pipeline.
- Auth via the CLAUDE_CODE_OAUTH_TOKEN repo secret.

This PR will trigger the workflow on itself as a first live test.