### PR TITLE
fix(activity): pass meeting_action for folder-chat meeting notifications

### DIFF
--- a/service/private/activity.js
+++ b/service/private/activity.js
@@ -38,6 +38,11 @@ function mapNotificationRow(r) {
     author_firstname: r.author_firstname,
     author_lastname: r.author_lastname,
     author_email: r.author_email,
+    // 'start' | 'end' for a team-chat rollup whose latest unread meeting event is
+    // a [[MEETING:...]] system message (notification_center_next). Lets the client
+    // render "started/ended a meeting in <folder>" instead of "posted in". Absent
+    // (undefined) for every other category — the client falls back to "posted in".
+    meeting_action: r.meeting_action,
   };
 
   if (r.category === 'media') {


### PR DESCRIPTION
Hotfix off preview. Batch 3 of the notification program (pairs with schemas + ui `hotfix/noti-teamchat-actor`).

`notification_center_next` now emits `meeting_action` (`start`|`end`) on a team-chat rollup whose latest unread event is a `[[MEETING:...]]` system message (meetings take priority over plain chat). Surface it in `mapNotificationRow` so the client can render **"started/ended a meeting in <folder>"** instead of "posted in". Undefined for every other category → falls back to "posted in".

One additive field, no behavior change elsewhere. The actor name + avatar for these rows come from `author_*`, which the SP now provides and this file already maps.

Depends on the schemas PR (the SP change). No prod deploy — bundled with the held notification work.