### PR TITLE
feat(billing): sell extra Team seats — volume-tiered add-on + Manage seats flow

### DIFF
--- a/acl/payment.json
+++ b/acl/payment.json
@@ -21,16 +21,7 @@
           "type": "string",
           "required": false
         },
-        "seats": {
-          "type": "integer",
-          "required": false,
-          "default": 1
-        },
         "entity_type": {
-          "type": "string",
-          "required": false
-        },
-        "bundle": {
           "type": "string",
           "required": false
         },
@@ -43,6 +34,12 @@
           "type": "string",
           "required": false,
           "doc": "Organisation display name (TEAM bootstrap)"
+        },
+        "extra_seats": {
+          "type": "integer",
+          "required": false,
+          "default": 0,
+          "doc": "Team only: members beyond the plan's included seats, billed as the volume-tiered team_seat add-on"
         }
       }
     },

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -168,13 +168,30 @@ class __private_payment extends Entity {
       const created = await stripe.customers.create({ email, name, metadata: { id: entity_id } });
       customer_id = created.id;
     }
-    // One line item, quantity 1. Every plan is FLAT since the 2026-07 pricing
-    // rebuild: Team is $29 for 100 GB and up to 10 members, not $x per seat, so
-    // the subscription quantity no longer carries the seat count — sending
-    // `seats` here would multiply the bill. The per-seat add-on (pro_seat) and
-    // the storage bundles (storage_*) are retired with the B2C Pro tier and
-    // deactivated in yp.plan, so there are no extra lines to add.
+    // The plan itself is FLAT: quantity 1 always. Team is $29 for 100 GB and
+    // its included members, not $x per seat, so putting a seat count in the
+    // base line's quantity would multiply the whole bill.
     const line_items = [{ price: plan_row.stripe_price_id, quantity: 1 }];
+
+    // Extra seats ride along as a SECOND recurring line whose quantity is the
+    // number of members beyond the plan's included ten. The price is
+    // volume-tiered in Stripe (under 10 extra $3.00 each, 10 or more $2.90),
+    // so the tier is resolved there — we only send how many.
+    //
+    // Only Team sells them: Free has no seats to extend and Business is
+    // already unlimited, so a seat line on either would be a charge for
+    // nothing. A missing team_seat price (an environment that hasn't seeded it)
+    // is skipped rather than failing the checkout — the buyer still gets the
+    // plan, and the alternative is a dead Upgrade button.
+    const extra_seats = Math.max(0, ~~this.input.use('extra_seats', 0));
+    if (extra_seats > 0 && plan === 'team') {
+      const seat_row = await this.yp.await_proc('payment_get_plan', 'team_seat', period, CURRENCY);
+      if (seat_row?.stripe_price_id) {
+        line_items.push({ price: seat_row.stripe_price_id, quantity: extra_seats });
+      } else {
+        this.warn?.('payment.checkout: team_seat price missing, seats not billed', period);
+      }
+    }
     // Build the return URLs from homepath (host-derived, endpoint-aware).
     // servicepath() resolves the endpoint segment to 'undefined' on dev
     // endpoints (/-/undefined/svc/...), which broke the post-payment redirect.

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -299,10 +299,11 @@ class __public_stripe_webhook extends Entity {
     return (org && org.id) ? org.id : md.entity_id;
   }
 
-  // Classify subscription line items: the base plan item (quantity = seats for
-  // org) vs add-on items (entity_type='addon' in yp.plan) — storage add-ons sum
-  // disk * quantity into extra_disk (P4); pro_seat add-ons sum seat * quantity
-  // into extra_seats (C1 Pro per-seat).
+  // Classify subscription line items: the base plan item vs add-on items
+  // (entity_type='addon' in yp.plan). Add-ons carrying $.seat — team_seat —
+  // sum seat * quantity into extra_seats; ones carrying $.disk sum into
+  // extra_disk. The base line's quantity is no longer a seat count: plans are
+  // flat, so it is always 1.
   async _itemsEntitlement(items) {
     let seats = 1, price = 0, extra_disk = 0, extra_seats = 0;
     for (const it of (items || [])) {
@@ -319,16 +320,25 @@ class __public_stripe_webhook extends Entity {
     return { seats, price, extra_disk, extra_seats };
   }
 
-  // Seat total to record on the entitlement. Org (team): the base line's
-  // quantity IS the seat count. Individual (pro): the plan includes
-  // quota.$.seat seats; purchased pro_seat add-ons extend that. Returning 0
-  // keeps the plan's default $.seat (guard in payment_apply_entitlement).
+  // Seats to hand payment_apply_entitlement.
+  //
+  // ORG: the procedure ADDS this to the plan's included count, so what it
+  // wants is the seats actually PURCHASED, not a total. Returning the base
+  // line's quantity (the old behaviour, back when that quantity was the seat
+  // count) would now write 1 — capping a Team org at eleven members however
+  // many seats they bought.
+  //
+  // Individual: unchanged legacy path — the proc treats _seats as a total
+  // there, so included + extras is correct.
   async _seatTotal(entity_type, plan, period, base_seats, extra_seats) {
-    if (entity_type === 'org') return base_seats;
+    if (entity_type === 'org') return extra_seats || 0;
     if (!extra_seats) return 0;
     let included = 0;
     try {
-      const row = await this.yp.await_proc('payment_get_plan', plan, period, 'eur');
+      // 'usd': the EUR rows were deactivated by the pricing rebuild, so the
+      // old hardcoded 'eur' matched nothing and silently reported no included
+      // seats.
+      const row = await this.yp.await_proc('payment_get_plan', plan, period, 'usd');
       // quota may be a parsed object or a JSON string — handle both.
       const q = row && row.quota;
       const obj = q && typeof q === 'object' ? q : JSON.parse(q || '{}');


### PR DESCRIPTION
Team is flat with ten included members, so an org that outgrew it had no route to an eleventh short of moving to Business — and nothing in the UI hinted otherwise. This adds the seat add-on back, attached to Team.

## Pricing

Volume-tiered, and the cheaper rate applies to the **whole** quantity:

| extra members | unit | total |
| :-- | :-- | :-- |
| 1 | $3.00 | $3.00 |
| 9 | $3.00 | $27.00 |
| **10** | **$2.90** | **$29.00** |
| 20 | $2.90 | $58.00 |

Verified against the live sandbox price (`billing_scheme=tiered`, `tiers_mode=volume`). Yearly is 11× monthly like the rest of the catalog.

## The flow

The current-plan pill is where an owner looks, so it doubles as the way in: **"Your current plan"** at rest, **"Manage seats"** on hover → opens the checkout on the plan they already have with the stepper primed at one. One element with two labels rather than two pills, so the card doesn't shift as the text changes.

Team only — Free has no seats to extend, Business is already unlimited — and non-owners are excluded by the same `_mayCheckout` rule that gates every other purchase.

## How the money is kept honest

- The **base plan line stays quantity 1**. Plans are flat; a seat count there would multiply the whole bill.
- Extra members are a **second recurring line** (`team_seat`), quantity = members beyond the included ten.
- Only the **count** goes over the wire. Stripe owns the tiered price, so the client can never disagree with the amount actually charged. `_seatUnitPrice` mirrors the tiers purely to total the panel before redirecting.
- The session metadata deliberately does **not** carry the seat count — the webhook reads it back from the real subscription line items, so an owner who changes the quantity in the Stripe portal still gets the right entitlement.

## Entitlement

`payment_apply_entitlement` now **adds** purchased seats to the plan's included count. It adds rather than assigns on purpose: writing the add-on quantity straight into `$.seat` would drop the included ten and leave a paying org **smaller** than one that bought nothing. `_seats` changes meaning with it — extra seats, not subscription quantity — so its default drops from 1 to 0, since leaving it at 1 would hand every org a free eleventh seat on every renewal.

## Two bugs found on the way

- **`_seatTotal` returned the base line's quantity for orgs.** That was right when the quantity *was* the seat count; now it is always 1, and since the procedure adds its argument to the included seats, every Team org would have been capped at eleven members no matter how many they bought.
- **The individual path looked plans up with a hardcoded `'eur'`.** The pricing rebuild deactivated every EUR row, so that matched nothing and silently reported zero included seats.

## Also cleaned up

The retired `seats` and `bundle` params are dropped from the checkout ACL — advertising inputs the service ignores invites callers to send values that quietly do nothing.

---

**Note for whoever merges:** `team_seat` needs a Stripe price seeded per environment before the seat line can be billed (sandbox is done: `prod_UwyifX6LCo57Dm`). A missing price is skipped with a warning rather than failing the checkout, so the buyer still gets their plan — but their seats won't be charged or granted until it's seeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
