### PR TITLE
fix(i18n): deterministic English page render; no Accept-Language auto-adoption

### DIFF
--- a/client/bootstrap.js
+++ b/client/bootstrap.js
@@ -8,6 +8,7 @@ const { isEmpty, isObject, values, template } = require('lodash');
 const { Attr } = require('@drumee/server-essentials');
 
 const { RuntimeEnv } = require('@drumee/server-core');
+const pageLanguage = require('./page-language');
 
 //########################################
 class BootstrapPage extends RuntimeEnv {
@@ -27,8 +28,11 @@ class BootstrapPage extends RuntimeEnv {
 
     const TPL_BASE = "templates";
     const tpl = resolve(__dirname, TPL_BASE, 'index.tpl');;
-    const lang = this.user.language() || this.input.app_language();
+    // Deterministic page language: stored profile choice or English — see
+    // client/page-language.js (no Accept-Language auto-adoption).
+    const lang = pageLanguage(this);
     let data = await this.getRuntimeEnv();
+    data.language = lang;
     if ((!isEmpty(md.description)) && isObject(md.description)) {
       data.description = md.description[lang] || values(description)[0] || data.description;
     }

--- a/client/page-language.js
+++ b/client/page-language.js
@@ -1,0 +1,27 @@
+/**
+ * Language for server-rendered pages — product default: ENGLISH.
+ *
+ * Only the signed-in user's stored profile choice selects another language.
+ * The browser's Accept-Language is deliberately NOT auto-adopted here: doing
+ * so rendered <html lang="fr"> (and the inline bootstrap lang the client's
+ * Visitor.pagelang() trusts) for any visitor whose OS/browser lists French,
+ * flipping whole sessions to French for users who never chose it. An
+ * explicit ?lang= deep-link is honored client-side by pagelang(), which
+ * reads the URL ahead of everything else, so the page render doesn't need
+ * to look at request params — the ones it would see (x-param-lang) are
+ * echoes of the client's own possibly-poisoned state anyway.
+ */
+const SUPPORTED = /^(en|fr|es|km|ru|zh)$/;
+
+module.exports = function pageLanguage(svc) {
+  let lang = null;
+  try {
+    const profile = svc.user && svc.user.get("profile");
+    if (profile) lang = profile.lang;
+  } catch (e) {
+    lang = null;
+  }
+  lang = String(lang || "en").toLowerCase().split(/[-_.]/)[0];
+  if (!SUPPORTED.test(lang)) lang = "en";
+  return lang;
+};

--- a/client/page.js
+++ b/client/page.js
@@ -12,6 +12,7 @@ const { READ } = Permission;
 const { main_domain, endpoint_path, server_dir } = sysEnv();
 
 const TPL_BASE = "templates";
+const pageLanguage = require("./page-language");
 class MainPage extends RuntimeEnv {
   /**
    * Propert isServingPage tells to Acl to grant access, since we
@@ -159,10 +160,17 @@ class MainPage extends RuntimeEnv {
    *
    */
   async start(opt) {
-    const lang = this.user.language() || this.input.app_language();
+    // Deterministic page language: stored profile choice or English — see
+    // client/page-language.js. The old chain ended in Accept-Language, so a
+    // browser listing French got a French-rendered page (html lang +
+    // bootstrap lang) even in an English account.
+    const lang = pageLanguage(this);
     let lex = DrumeeCache.lex(lang);
     const env = await this.getRuntimeEnv();
     let data = { ...lex, ...this.hub.toJSON(), ...env, ...opt };
+    // getRuntimeEnv computes its own language via the Accept-Language
+    // chain — override it so the template renders the deterministic one.
+    data.language = lang;
     if (data.ws_port && !/^:/.test(data.ws_port)) {
       data.ws_port = `:${data.ws_port}`
     }

--- a/service/block.js
+++ b/service/block.js
@@ -100,7 +100,7 @@ class __block extends Entity {
     }.bind(this);
     let l = lang;
     if(_.isArray(lang)){
-      l = lang[0] || 'fr';
+      l = lang[0] || 'en';
     }
     this.db.call_proc('block_get', pagename, device, l, cb);
   }

--- a/service/lang.js
+++ b/service/lang.js
@@ -67,7 +67,7 @@ class __lang extends Entity {
    */
   get_pages() {
     const i = this.input;
-    const locale      = i.get(Attr.locale) || i.language() || i.app_language() || 'fr';
+    const locale      = i.get(Attr.locale) || i.language() || i.app_language() || 'en';
     const published   = i.need(Attr.published);
     const name        = i.get(Attr.name) || "";
     const sort_by     = i.get(Attr.sort_by) || Attr.date;

--- a/service/private/block.js
+++ b/service/private/block.js
@@ -539,7 +539,7 @@ class __private_block extends Block {
   // ========================
   list_by() {
     const i = this.input;
-    const locale = i.get(_a.locale) || i.language() || i.app_language() || 'fr';
+    const locale = i.get(_a.locale) || i.language() || i.app_language() || 'en';
     const published = i.need(_a.published);
     const name = i.get(_a.name) || "";
     const sort_by = i.get(_a.sort_by) || _a.date;

--- a/service/private/drumate.js
+++ b/service/private/drumate.js
@@ -1010,7 +1010,15 @@ class __private_drumate extends Entity {
    * 
    */
   set_lang() {
-    let lang = this.supportedLanguage(this.input.get('Xlang'));
+    // supportedLanguage(falsy) returns the whole supported-language ARRAY —
+    // storing that into profile.lang corrupts the value every page render
+    // and every outgoing notification reads. Refuse a call without Xlang
+    // instead of persisting garbage.
+    const xlang = this.input.get('Xlang');
+    if (!xlang) {
+      return this.output.data({ status: 'LANG_REQUIRED' });
+    }
+    let lang = this.supportedLanguage(xlang);
     this.yp.call_proc('drumate_set_lang', this.user_id(), lang, this.output.data);
   }
 

--- a/service/private/lang.js
+++ b/service/private/lang.js
@@ -70,7 +70,7 @@ class __private_lang extends Lang {
    * @returns 
    */
   add() {
-    const lang_code = this.input.use("locale") || this.input.use("lang_code") || "fr";
+    const lang_code = this.input.use("locale") || this.input.use("lang_code") || "en";
     return this.db.call_proc("language_add_next", lang_code, this.output.data);
   }
 
@@ -204,7 +204,7 @@ class __private_lang extends Lang {
    * */    
   add_default_blocks(hashtag, lang) {
     const id = '0';
-    lang = this.input.use("locale") || this.input.use("lang_code") || "fr"; //@input.use(Attr.locale) ||  @input.use(Attr.locale) 
+    lang = this.input.use("locale") || this.input.use("lang_code") || "en"; //@input.use(Attr.locale) ||  @input.use(Attr.locale) 
     const editor = 'creator';
     const type = 'block';
     const device = this.input.use(Attr.device, Attr.desktop);


### PR DESCRIPTION
Server side of the random-French root-cause fix (companion: ui-team `fix/locale-default-english`, schemas `fix/entity-default-lang-en`, ui-core `fix/language-default-english`).

The served page's `<html lang>` and inline `bootstrap` lang came from `profile.lang` falling back to the request's **Accept-Language** — any visitor whose browser lists French got a French-rendered page, which the client then trusted ahead of the user's own stored English choice. Verified live before the fix: `Accept-Language: vi,fr;q=0.8,en;q=0.7` (common on Vietnamese machines) rendered `<html lang="fr">`.

- **`client/page-language.js`** — one policy for server-rendered pages: the signed-in user's stored profile choice, else **English**. Accept-Language is deliberately not consulted; an explicit `?lang=` deep-link is already honored client-side ahead of everything else.
- **`client/page.js` + `client/bootstrap.js`** — use it for lex selection and override the runtimeEnv-computed language before templating.
- **CMS fallbacks** — five hardcoded `'fr'` defaults (`lang.js`, `private/lang.js` ×2, `private/block.js`, `block.js`) → `'en'`.
- **`private/drumate.js` `set_lang`** — `supportedLanguage(falsy)` returns the whole supported-language **array**; a call without `Xlang` persisted that array into `profile.lang`, corrupting the value every page render and every outgoing notification reads. Refuse with `LANG_REQUIRED` instead.

Verified on stage (vudangnt endpoint): anonymous + `Accept-Language: fr` → `<html lang="en">`, `bootstrap lang: "en"`; signed-in profile lang still wins.

Known follow-up (out of scope here): server-generated recipient-facing strings (hub invites, meeting `room.scheduled` titles, contact-accept chat messages, email fan-out) are localized once in the SENDER's language — a French counterpart still injects French text into an English user's feed. Needs per-recipient localization by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
