### PR TITLE
fix(billing): refuse checkout while a subscription is live

### DIFF
--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -112,6 +112,34 @@ class __private_payment extends Entity {
     }
     const period = this.input.need('period');           // 'month' | 'year'
 
+    // Already paying? Then there is nothing to sell here. Stripe happily
+    // creates a SECOND subscription on the same customer, and the webhook
+    // would overwrite entitlement/period_end with the new one while the old
+    // one keeps charging -- the caller is billed twice for one plan. The UI
+    // gates its plan cards on the current plan, but the checkout TAB (and any
+    // deep link, or a stale bundle) reaches this endpoint directly, so the
+    // refusal has to live here.
+    //
+    // Only 'active' and 'trialing' block. A subscription in the pending-cancel
+    // window reports 'canceled' with a future period_end: that caller resumes
+    // (payment.resume_subscription), and if they let it lapse they are free to
+    // buy again. Cycle changes (month <-> year) are a subscription UPDATE, not
+    // a new checkout -- they get their own status so the client can say so
+    // rather than showing a generic failure.
+    const current = await this._subscription_row();
+    if (current && current.subscription_id &&
+        /^(active|trialing)$/.test(String(current.status || ''))) {
+      const same_plan = String(current.plan || '') === String(this.input.use('plan', 'team'));
+      return this.output.data({
+        status: same_plan && String(current.period || '') === period
+          ? 'ALREADY_SUBSCRIBED'
+          : 'USE_SUBSCRIPTION_UPDATE',
+        plan: current.plan,
+        period: current.period,
+        period_end: current.period_end,
+      });
+    }
+
     let plan, entity_id, email, name, existing_customer;
     let org_bootstrap = null;
     if (entity_type === 'org') {

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -120,20 +120,28 @@ class __private_payment extends Entity {
     // deep link, or a stale bundle) reaches this endpoint directly, so the
     // refusal has to live here.
     //
-    // Only 'active' and 'trialing' block. A subscription in the pending-cancel
-    // window reports 'canceled' with a future period_end: that caller resumes
-    // (payment.resume_subscription), and if they let it lapse they are free to
-    // buy again. Cycle changes (month <-> year) are a subscription UPDATE, not
-    // a new checkout -- they get their own status so the client can say so
-    // rather than showing a generic failure.
+    // "Live" is not the same as "active". A subscription in the PENDING-CANCEL
+    // window mirrors as status 'canceled' with a future period_end, but at
+    // Stripe it is still an active subscription carrying
+    // cancel_at_period_end -- buying now would run two paid subscriptions side
+    // by side just as surely. That caller resumes instead. Only once the paid
+    // period has actually lapsed (or the mirror row is gone) may they buy.
+    //
+    // Cycle changes (month <-> year) are a subscription UPDATE, not a new
+    // checkout, so they get their own status rather than a generic failure.
     const current = await this._subscription_row();
-    if (current && current.subscription_id &&
-        /^(active|trialing)$/.test(String(current.status || ''))) {
+    const now = Math.floor(Date.now() / 1000);
+    const status = String((current && current.status) || '');
+    const pending_cancel = status === 'canceled' && ~~(current && current.period_end) > now;
+    const live = /^(active|trialing)$/.test(status) || pending_cancel;
+    if (current && current.subscription_id && live) {
       const same_plan = String(current.plan || '') === String(this.input.use('plan', 'team'));
+      let refusal;
+      if (pending_cancel) refusal = 'PENDING_CANCEL_RESUME_INSTEAD';
+      else if (same_plan && String(current.period || '') === period) refusal = 'ALREADY_SUBSCRIBED';
+      else refusal = 'USE_SUBSCRIPTION_UPDATE';
       return this.output.data({
-        status: same_plan && String(current.period || '') === period
-          ? 'ALREADY_SUBSCRIBED'
-          : 'USE_SUBSCRIPTION_UPDATE',
+        status: refusal,
         plan: current.plan,
         period: current.period,
         period_end: current.period_end,


### PR DESCRIPTION
**Bug:** a Team subscriber reading *"Your subscription renews on Aug 24, 2026"* could open the Checkout tab and buy the plan again.

## What actually happened

Not just a UI annoyance — reproduced end to end on stage:

```
active: plan=team  sub_1TwlRoDjnMxCeY36a8F0GN7Z  renews Aug 24
POST payment.checkout  →  URL_ISSUED  cs_test_a1qM82...
```

Paying that session creates a **second Stripe subscription on the same customer**. The webhook overwrites entitlement/`period_end` with the new one while the old subscription keeps charging — the customer pays twice for one plan.

Three layers, only the first had a guard:

| Layer | State |
| :-- | :-- |
| Plan **cards** | ✅ already gated — the current plan renders a disabled `YOUR CURRENT PLAN` pill |
| Checkout **tab** | ❌ no guard at all: `case "checkout"` just set `currentTab` |
| `payment.checkout` | ❌ no guard: validated `entity_type`, price, plan/entity match, org ident — never asked whether the caller is already paying |

## The rule

The ladder is **free < team < (business | sovereign — both sales-led)**. A Team subscriber has no higher self-serve tier and no reason to re-buy the one they hold, so the Checkout tab has nothing legitimate to sell them.

"Already paying" means the subscription is **live at Stripe**, which is broader than `status === 'active'`:

| State | Checkout | Status returned |
| :-- | :-- | :-- |
| active / trialing, same plan+period | refused | `ALREADY_SUBSCRIBED` |
| active / trialing, different period | refused | `USE_SUBSCRIPTION_UPDATE` |
| **pending cancel** (mirror `canceled`, `period_end` in future) | refused | `PENDING_CANCEL_RESUME_INSTEAD` |
| lapsed / no subscription | allowed | — |

The pending-cancel case is easy to get wrong and I did on the first pass: the mirror says `canceled`, but Stripe still holds an active subscription carrying `cancel_at_period_end`. Buying there is the same double-billing. That caller resumes; once the paid period lapses they may buy again.

## Changes

- **server-team** — the refusal lives here, because the tab, a deep link and any stale bundle all reach the endpoint directly.
- **ui-team** — the Checkout tab is not rendered while a subscription is live, and the `checkout` action refuses too (a stale render or queued click cannot slip past). The **Free** card is a downgrade, not a purchase: it now opens the cancel confirm instead of a checkout for a $0 plan that answers `NO_PRICE`. The three statuses are spelled out (3 new keys × 6 locales) and re-sync the widget.

## Verified on stage

All three refusals confirmed live, no session issued in any of them; `resume` restores `active` afterwards.

## Known gap (unchanged)

There is still **no self-serve month ↔ year switch**. That is a Stripe subscription *update* with proration, not a new checkout — until it is built, `USE_SUBSCRIPTION_UPDATE` points the user at Manage billing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
