### PR TITLE
feat(payment): Business becomes self-serve — checkout plus in-place plan change

### DIFF
--- a/acl/payment.json
+++ b/acl/payment.json
@@ -88,6 +88,23 @@
       },
       "params": {}
     },
+    "change_plan": {
+      "doc": "Plan/cycle switch on the caller's existing subscription (Team <-> Business). Price swap + metadata rewrite on the live Stripe subscription; never a second checkout.",
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {
+        "plan": {
+          "type": "string",
+          "required": true
+        },
+        "period": {
+          "type": "string",
+          "required": true
+        }
+      }
+    },
     "checkout_result": {
       "scope": "hub",
       "permission": {

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -112,6 +112,34 @@ class __private_payment extends Entity {
     }
     const period = this.input.need('period');           // 'month' | 'year'
 
+    // Already paying? Then there is nothing to sell here. Stripe happily
+    // creates a SECOND subscription on the same customer, and the webhook
+    // would overwrite entitlement/period_end with the new one while the old
+    // one keeps charging -- the caller is billed twice for one plan. The UI
+    // gates its plan cards on the current plan, but the checkout TAB (and any
+    // deep link, or a stale bundle) reaches this endpoint directly, so the
+    // refusal has to live here.
+    //
+    // Only 'active' and 'trialing' block. A subscription in the pending-cancel
+    // window reports 'canceled' with a future period_end: that caller resumes
+    // (payment.resume_subscription), and if they let it lapse they are free to
+    // buy again. Cycle changes (month <-> year) are a subscription UPDATE, not
+    // a new checkout -- they get their own status so the client can say so
+    // rather than showing a generic failure.
+    const current = await this._subscription_row();
+    if (current && current.subscription_id &&
+        /^(active|trialing)$/.test(String(current.status || ''))) {
+      const same_plan = String(current.plan || '') === String(this.input.use('plan', 'team'));
+      return this.output.data({
+        status: same_plan && String(current.period || '') === period
+          ? 'ALREADY_SUBSCRIBED'
+          : 'USE_SUBSCRIPTION_UPDATE',
+        plan: current.plan,
+        period: current.period,
+        period_end: current.period_end,
+      });
+    }
+
     let plan, entity_id, email, name, existing_customer;
     let org_bootstrap = null;
     if (entity_type === 'org') {

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -120,20 +120,28 @@ class __private_payment extends Entity {
     // deep link, or a stale bundle) reaches this endpoint directly, so the
     // refusal has to live here.
     //
-    // Only 'active' and 'trialing' block. A subscription in the pending-cancel
-    // window reports 'canceled' with a future period_end: that caller resumes
-    // (payment.resume_subscription), and if they let it lapse they are free to
-    // buy again. Cycle changes (month <-> year) are a subscription UPDATE, not
-    // a new checkout -- they get their own status so the client can say so
-    // rather than showing a generic failure.
+    // "Live" is not the same as "active". A subscription in the PENDING-CANCEL
+    // window mirrors as status 'canceled' with a future period_end, but at
+    // Stripe it is still an active subscription carrying
+    // cancel_at_period_end -- buying now would run two paid subscriptions side
+    // by side just as surely. That caller resumes instead. Only once the paid
+    // period has actually lapsed (or the mirror row is gone) may they buy.
+    //
+    // Cycle changes (month <-> year) are a subscription UPDATE, not a new
+    // checkout, so they get their own status rather than a generic failure.
     const current = await this._subscription_row();
-    if (current && current.subscription_id &&
-        /^(active|trialing)$/.test(String(current.status || ''))) {
+    const now = Math.floor(Date.now() / 1000);
+    const status = String((current && current.status) || '');
+    const pending_cancel = status === 'canceled' && ~~(current && current.period_end) > now;
+    const live = /^(active|trialing)$/.test(status) || pending_cancel;
+    if (current && current.subscription_id && live) {
       const same_plan = String(current.plan || '') === String(this.input.use('plan', 'team'));
+      let refusal;
+      if (pending_cancel) refusal = 'PENDING_CANCEL_RESUME_INSTEAD';
+      else if (same_plan && String(current.period || '') === period) refusal = 'ALREADY_SUBSCRIBED';
+      else refusal = 'USE_SUBSCRIPTION_UPDATE';
       return this.output.data({
-        status: same_plan && String(current.period || '') === period
-          ? 'ALREADY_SUBSCRIBED'
-          : 'USE_SUBSCRIPTION_UPDATE',
+        status: refusal,
         plan: current.plan,
         period: current.period,
         period_end: current.period_end,

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -129,12 +129,22 @@ class __private_payment extends Entity {
     //
     // Cycle changes (month <-> year) are a subscription UPDATE, not a new
     // checkout, so they get their own status rather than a generic failure.
+    //
+    // One exception: a subscription held by the OTHER kind of entity. A legacy
+    // personal 'pro' holder buying an org plan (or the reverse) cannot be
+    // served by an in-place update — change_plan refuses it with
+    // PLAN_ENTITY_MISMATCH because the plan is not sold to that entity kind.
+    // Refusing here as well left that caller in a circle with no working path,
+    // so this is exactly the supersede CHECKOUT the webhook already knows how
+    // to finish: it cancels the superseded subscription once the new one is
+    // paid (_cancelSupersededPersonalSubscription / metadata.supersede).
     const current = await this._subscription_row();
     const now = Math.floor(Date.now() / 1000);
     const status = String((current && current.status) || '');
     const pending_cancel = status === 'canceled' && ~~(current && current.period_end) > now;
     const live = /^(active|trialing)$/.test(status) || pending_cancel;
-    if (current && current.subscription_id && live) {
+    const holder = current && current.entity_type === 'org' ? 'org' : 'user';
+    if (current && current.subscription_id && live && holder === entity_type) {
       const same_plan = String(current.plan || '') === String(this.input.use('plan', 'team'));
       let refusal;
       if (pending_cancel) refusal = 'PENDING_CANCEL_RESUME_INSTEAD';
@@ -421,21 +431,47 @@ class __private_payment extends Entity {
       return this.output.data({ status: 'PERIOD_INVALID', period });
     }
 
+    // The DB mirror locates the subscription; it does NOT decide anything.
+    // yp.subscription_new is only rewritten when the customer.subscription.
+    // updated webhook lands, so between a change and its webhook (Stripe retry
+    // backoff, an endpoint restart) it still describes the PREVIOUS state.
+    // Deciding "nothing to change" or "does the interval change" from it would
+    // no-op a real switch and report success. Stripe is the truth here.
     const sub = await this._subscription_row();
     const subscription_id = sub && sub.subscription_id;
     if (!subscription_id) return this.output.data({ status: 'NO_SUBSCRIPTION' });
-    const now = Math.floor(Date.now() / 1000);
-    const pending_cancel =
-      String(sub.status) === 'canceled' && ~~sub.period_end > now;
-    if (!/^(active|trialing)$/.test(String(sub.status)) && !pending_cancel) {
-      // Lapsed/incomplete subs have nothing to update — that caller buys anew.
+
+    let live;
+    try {
+      live = await stripe.subscriptions.retrieve(subscription_id);
+    } catch (e) {
+      return this.output.data({ status: 'CHANGE_FAILED', error: e && e.message });
+    }
+    const items = (live.items && live.items.data) || [];
+    // Swapping items[0] blind would replace an ADD-ON line on a legacy
+    // multi-item subscription (storage_*/pro_seat), leaving the real plan line
+    // in place and billing both. Those add-ons are retired, so this should not
+    // occur — refuse rather than double-bill if it ever does.
+    if (items.length !== 1) {
+      return this.output.data({
+        status: 'MULTI_ITEM_SUBSCRIPTION', items: items.length,
+      });
+    }
+    const item = items[0];
+    const live_md = live.metadata || {};
+    const cur_plan = String(live_md.plan || sub.plan || '');
+    const cur_period = String(
+      (item.price && item.price.recurring && item.price.recurring.interval)
+      || live_md.period || sub.period || ''
+    );
+    const pending_cancel = !!live.cancel_at_period_end;
+    // past_due counts: the subscription still exists at Stripe and checkout()
+    // refuses to sell to its holder, so switching plan is their only self-serve
+    // move. Telling them NO_SUBSCRIPTION would send them to buy a second one.
+    if (!/^(active|trialing|past_due)$/.test(String(live.status || ''))) {
       return this.output.data({ status: 'NO_SUBSCRIPTION' });
     }
-    if (
-      String(sub.plan || '') === plan &&
-      String(sub.period || '') === period &&
-      !pending_cancel
-    ) {
+    if (cur_plan === plan && cur_period === period && !pending_cancel) {
       return this.output.data({ status: 'NOTHING_TO_CHANGE', plan, period });
     }
 
@@ -446,22 +482,15 @@ class __private_payment extends Entity {
     // Same rule as checkout(): the target plan must be sold to the kind of
     // entity that holds this subscription. _subscription_row tags the tenant
     // row entity_type='org'; a personal row means 'user'. Moving between the
-    // kinds (pro -> team) is a supersede checkout, not an in-place update.
+    // kinds (legacy personal pro -> an org plan) is a supersede CHECKOUT, and
+    // checkout() lets that caller through for exactly this reason — so the
+    // refusal here is a redirection, not a dead end.
     const holder = sub.entity_type === 'org' ? 'org' : 'user';
     if (plan_row.entity_type && plan_row.entity_type !== holder) {
       return this.output.data({
         status: 'PLAN_ENTITY_MISMATCH', plan, entity_type: holder, expected: plan_row.entity_type,
       });
     }
-
-    let live;
-    try {
-      live = await stripe.subscriptions.retrieve(subscription_id);
-    } catch (e) {
-      return this.output.data({ status: 'CHANGE_FAILED', error: e && e.message });
-    }
-    const item = live.items && live.items.data && live.items.data[0];
-    if (!item) return this.output.data({ status: 'CHANGE_FAILED', error: 'NO_SUBSCRIPTION_ITEM' });
 
     const params = {
       items: [{ id: item.id, price: plan_row.stripe_price_id, quantity: 1 }],
@@ -470,26 +499,37 @@ class __private_payment extends Entity {
       // Switching plan implies staying: a pending-cancel sub is resumed by the
       // same update instead of bouncing the caller through resume first.
       cancel_at_period_end: false,
-      metadata: { ...(live.metadata || {}), plan, period },
+      metadata: { ...live_md, plan, period },
     };
     // When the billing interval changes, restart the cycle today: the caller
     // pays the new price now (minus the unused-time credit) and renews a clean
     // month/year from today, instead of a stub period on the old anchor.
-    if (String(sub.period || '') !== period) params.billing_cycle_anchor = 'now';
+    if (cur_period !== period) params.billing_cycle_anchor = 'now';
 
     let s;
     try {
       s = await stripe.subscriptions.update(subscription_id, params);
     } catch (e) {
-      return this.output.data({ status: 'CHANGE_FAILED', error: e && e.message });
+      // error_if_incomplete keeps the switch atomic, but it also refuses
+      // outright when the prorated charge needs the cardholder — 3DS/SCA
+      // authentication, or a soft decline. Stripe returns an error instead of
+      // a requires_action PaymentIntent, so there is no invoice to finish and
+      // every retry fails identically. Say so specifically: the caller's way
+      // out is a different card / the Billing Portal, not "try again".
+      const code = String((e && (e.code || (e.raw && e.raw.code))) || '');
+      const msg = String((e && e.message) || '');
+      if (/requires_action|authentication|card_decline|card_declined|payment_intent|insufficient_funds/i.test(`${code} ${msg}`)) {
+        return this.output.data({ status: 'PAYMENT_ACTION_REQUIRED', error: msg });
+      }
+      return this.output.data({ status: 'CHANGE_FAILED', error: msg });
     }
-    const items = (s.items && s.items.data) || [];
+    const new_items = (s.items && s.items.data) || [];
     this.output.data({
       status: 'OK',
       plan,
       period,
       subscription_status: s.status || 'active',
-      period_end: s.current_period_end || (items[0] && items[0].current_period_end) || sub.period_end || 0,
+      period_end: s.current_period_end || (new_items[0] && new_items[0].current_period_end) || sub.period_end || 0,
     });
   }
 

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -137,13 +137,22 @@ class __private_payment extends Entity {
     // checkout, so they get their own status rather than a generic failure.
     //
     // One exception: a subscription held by the OTHER kind of entity. A legacy
-    // personal 'pro' holder buying an org plan (or the reverse) cannot be
-    // served by an in-place update — change_plan refuses it with
-    // PLAN_ENTITY_MISMATCH because the plan is not sold to that entity kind.
-    // Refusing here as well left that caller in a circle with no working path,
-    // so this is exactly the supersede CHECKOUT the webhook already knows how
-    // to finish: it cancels the superseded subscription once the new one is
-    // paid (_cancelSupersededPersonalSubscription / metadata.supersede).
+    // personal 'pro' holder buying an org plan cannot be served by an in-place
+    // update — change_plan refuses it with PLAN_ENTITY_MISMATCH because the
+    // plan is not sold to that entity kind. Refusing here as well left that
+    // caller in a circle with no working path, so this is exactly the supersede
+    // CHECKOUT the webhook already knows how to finish: it cancels the
+    // superseded subscription once the new one is paid
+    // (_cancelSupersededPersonalSubscription / metadata.supersede).
+    //
+    // That cancel does NOT disturb the org it just paid for. yp.quota is keyed
+    // UNIQUE(domain_id, payer_id) — a composite, verified against the deployed
+    // schema, not the unshipped tables/quota.sql which claims domain_id alone —
+    // so the org row (org_domain, org_id) and the payer's own
+    // (org_domain, payer_uid) coexist. The customer.subscription.deleted for
+    // the superseded personal subscription writes the payer's row, and the
+    // tenant-first cascade in disk_limit/get_quota resolves the org row ahead
+    // of it for every member, the payer included.
     const current = await this._subscription_row();
     const now = Math.floor(Date.now() / 1000);
     const status = String((current && current.status) || '');
@@ -332,18 +341,44 @@ class __private_payment extends Entity {
     const owns_org = !!org?.id;                        // can pay for their own
     row.can_buy = is_personal || owns_org;
     if (!row.can_buy) row.buy_blocked = 'NOT_ORG_OWNER';
-    // How many members the org ACTUALLY has. `seats` on this row is the plan's
-    // member CAP copied out of quota, so a client warning about downgrades or
-    // cancellation that reads it as a headcount says things like "your team has
-    // 100000 members" — the cap compared against a cap. Only the real count can
-    // tell a caller whether a smaller plan would push anyone out.
+    // How many members the org ACTUALLY has, and how much it actually stores.
+    // `seats` on this row is the plan's member CAP copied out of quota, so a
+    // client warning about downgrades or cancellation that reads it as a
+    // headcount says things like "your team has 100000 members" — the cap
+    // compared against a cap. Only the real figures can tell a caller whether a
+    // smaller plan would push anyone out or block uploads.
+    //
+    // Same filters as the platform's own headcount (yp member_list_stats):
+    // archived members and system profiles are not seats anybody is using, and
+    // counting them would contradict the number the Admin console shows.
     if (org && org.id) {
+      const dom = ~~(org.domain_id || this.user.domain_id());
       let c = await this.yp.await_query(
-        `SELECT COUNT(*) AS c FROM entity WHERE dom_id = ? AND type = 'drumate'`,
-        ~~(org.domain_id || this.user.domain_id())
+        `SELECT COUNT(*) AS c
+           FROM privilege p
+           INNER JOIN drumate d ON p.uid = d.id
+           INNER JOIN entity   e ON d.id = e.id
+          WHERE p.domain_id = ?
+            AND COALESCE(JSON_VALUE(d.profile, '$.category'), '') <> 'system'
+            AND e.status <> 'archived'`,
+        dom
       );
       if (Array.isArray(c)) c = c[0];
       row.member_count = ~~(c && c.c);
+      // Org-wide usage, not the caller's own. The downgrade warning compares it
+      // against the target plan's allowance, and Visitor.diskUsed() on the
+      // client is only the signed-in user's share — an org well over the cap
+      // looked fine to whoever happened to store little.
+      // actual_usage is the recalculated figure; cached_usage is what the
+      // running total says. Take the larger — under-reporting here would let a
+      // downgrade through without the warning it exists to give.
+      let u = await this.yp.await_query(
+        `SELECT GREATEST(IFNULL(actual_usage, 0), IFNULL(cached_usage, 0)) AS used
+           FROM quota_usage WHERE domain_id = ?`,
+        dom
+      );
+      if (Array.isArray(u)) u = u[0];
+      if (u && u.used != null) row.disk_used = Number(u.used) || 0;
     }
     this.output.data(row);
   }
@@ -468,23 +503,26 @@ class __private_payment extends Entity {
     try {
       live = await stripe.subscriptions.retrieve(subscription_id);
     } catch (e) {
+      // The mirror points at a subscription Stripe no longer has (a deleted
+      // event lost while the endpoint was down, a key/account rotation). Left
+      // alone that row is a permanent dead end: checkout() still reads it as
+      // live and refuses to sell, while every switch fails here. Clear it so
+      // the caller can buy again, and say what is true — they have no
+      // subscription.
+      if (/resource_missing|No such subscription/i.test(String((e && e.message) || ''))) {
+        try {
+          await this.yp.await_proc('subscription_remove', sub.entity_id || this.uid, subscription_id);
+        } catch (e2) { /* best effort: the answer below is right either way */ }
+        return this.output.data({ status: 'NO_SUBSCRIPTION' });
+      }
       return this.output.data({ status: 'CHANGE_FAILED', error: e && e.message });
     }
     const items = (live.items && live.items.data) || [];
-    // Swapping items[0] blind would replace an ADD-ON line on a legacy
-    // multi-item subscription (storage_*/pro_seat), leaving the real plan line
-    // in place and billing both. Those add-ons are retired, so this should not
-    // occur — refuse rather than double-bill if it ever does.
-    if (items.length !== 1) {
-      return this.output.data({
-        status: 'MULTI_ITEM_SUBSCRIPTION', items: items.length,
-      });
-    }
     const item = items[0];
     const live_md = live.metadata || {};
     const cur_plan = String(live_md.plan || sub.plan || '');
     const cur_period = String(
-      (item.price && item.price.recurring && item.price.recurring.interval)
+      (item && item.price && item.price.recurring && item.price.recurring.interval)
       || live_md.period || sub.period || ''
     );
     const pending_cancel = !!live.cancel_at_period_end;
@@ -492,6 +530,10 @@ class __private_payment extends Entity {
     // refuses to sell to its holder, so switching plan is their only self-serve
     // move. Telling them NO_SUBSCRIPTION would send them to buy a second one.
     if (!/^(active|trialing|past_due)$/.test(String(live.status || ''))) {
+      // Gone at Stripe but still mirrored — same dead end as the 404 above.
+      try {
+        await this.yp.await_proc('subscription_remove', sub.entity_id || this.uid, subscription_id);
+      } catch (e2) { /* best effort */ }
       return this.output.data({ status: 'NO_SUBSCRIPTION' });
     }
     if (cur_plan === plan && cur_period === period && !pending_cancel) {
@@ -502,16 +544,27 @@ class __private_payment extends Entity {
     if (!plan_row || !plan_row.stripe_price_id) {
       return this.output.data({ status: 'NO_PRICE' });
     }
-    // Same rule as checkout(): the target plan must be sold to the kind of
-    // entity that holds this subscription. _subscription_row tags the tenant
-    // row entity_type='org'; a personal row means 'user'. Moving between the
-    // kinds (legacy personal pro -> an org plan) is a supersede CHECKOUT, and
-    // checkout() lets that caller through for exactly this reason — so the
-    // refusal here is a redirection, not a dead end.
+    // The target plan must be sold to the kind of entity that holds this
+    // subscription. _subscription_row tags the tenant row entity_type='org'; a
+    // personal row means 'user'. Crossing the kinds (a legacy personal 'pro'
+    // reaching for an org plan) needs a supersede checkout, which is currently
+    // unsafe — see the note in checkout(). Refuse and let the client say so.
     const holder = sub.entity_type === 'org' ? 'org' : 'user';
     if (plan_row.entity_type && plan_row.entity_type !== holder) {
       return this.output.data({
         status: 'PLAN_ENTITY_MISMATCH', plan, entity_type: holder, expected: plan_row.entity_type,
+      });
+    }
+    // Swapping items[0] blind would replace an ADD-ON line on a legacy
+    // multi-item subscription (storage_*/pro_seat), leaving the real plan line
+    // in place and billing both. Those add-ons are retired, so this should not
+    // occur — refuse rather than double-bill if it ever does. Checked AFTER the
+    // entity-kind rule: the only multi-item subscriptions left are the legacy
+    // personal ones, and PLAN_ENTITY_MISMATCH is the answer that actually tells
+    // that caller what is going on.
+    if (items.length !== 1) {
+      return this.output.data({
+        status: 'MULTI_ITEM_SUBSCRIPTION', items: items.length,
       });
     }
 

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -322,6 +322,19 @@ class __private_payment extends Entity {
     const owns_org = !!org?.id;                        // can pay for their own
     row.can_buy = is_personal || owns_org;
     if (!row.can_buy) row.buy_blocked = 'NOT_ORG_OWNER';
+    // How many members the org ACTUALLY has. `seats` on this row is the plan's
+    // member CAP copied out of quota, so a client warning about downgrades or
+    // cancellation that reads it as a headcount says things like "your team has
+    // 100000 members" — the cap compared against a cap. Only the real count can
+    // tell a caller whether a smaller plan would push anyone out.
+    if (org && org.id) {
+      let c = await this.yp.await_query(
+        `SELECT COUNT(*) AS c FROM entity WHERE dom_id = ? AND type = 'drumate'`,
+        ~~(org.domain_id || this.user.domain_id())
+      );
+      if (Array.isArray(c)) c = c[0];
+      row.member_count = ~~(c && c.c);
+    }
     this.output.data(row);
   }
 

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -127,6 +127,12 @@ class __private_payment extends Entity {
     // by side just as surely. That caller resumes instead. Only once the paid
     // period has actually lapsed (or the mirror row is gone) may they buy.
     //
+    // past_due is live too. Stripe keeps retrying that invoice for weeks and
+    // only then deletes the subscription, so a caller in dunning who is offered
+    // checkout ends up paying for BOTH once their card recovers. They fix the
+    // card in the Billing Portal, or switch plan in place (change_plan accepts
+    // past_due for exactly this reason) -- they do not buy a second one.
+    //
     // Cycle changes (month <-> year) are a subscription UPDATE, not a new
     // checkout, so they get their own status rather than a generic failure.
     //
@@ -142,12 +148,16 @@ class __private_payment extends Entity {
     const now = Math.floor(Date.now() / 1000);
     const status = String((current && current.status) || '');
     const pending_cancel = status === 'canceled' && ~~(current && current.period_end) > now;
-    const live = /^(active|trialing)$/.test(status) || pending_cancel;
+    const live = /^(active|trialing|past_due)$/.test(status) || pending_cancel;
     const holder = current && current.entity_type === 'org' ? 'org' : 'user';
     if (current && current.subscription_id && live && holder === entity_type) {
       const same_plan = String(current.plan || '') === String(this.input.use('plan', 'team'));
       let refusal;
       if (pending_cancel) refusal = 'PENDING_CANCEL_RESUME_INSTEAD';
+      // A caller in dunning is trying to fix a failed payment, not to shop.
+      // "You're already subscribed" is true but unhelpful there — give the
+      // state its own status so the client can point at the card instead.
+      else if (status === 'past_due') refusal = 'SUBSCRIPTION_PAST_DUE';
       else if (same_plan && String(current.period || '') === period) refusal = 'ALREADY_SUBSCRIBED';
       else refusal = 'USE_SUBSCRIPTION_UPDATE';
       return this.output.data({

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -390,6 +390,109 @@ class __private_payment extends Entity {
     });
   }
 
+  // Self-serve plan/cycle switch on the EXISTING subscription — the path the
+  // checkout() guard points at with USE_SUBSCRIPTION_UPDATE. Team <-> Business
+  // are both org plans, so the switch is a price swap on the live Stripe
+  // subscription, never a second checkout (which would double-bill — see the
+  // guard in checkout()).
+  //
+  // Two things make the swap safe:
+  // - metadata.plan/period are rewritten IN THE SAME update. The webhook
+  //   derives entitlement from subscription metadata (stripe_webhook.js reads
+  //   md.plan; there is no reverse price_id -> plan_code mapping), so a price
+  //   swap that left the old metadata in place would keep applying the OLD
+  //   plan's quota on every subsequent event.
+  // - proration_behavior 'always_invoice' + payment_behavior
+  //   'error_if_incomplete': an upgrade charges the prorated difference NOW
+  //   and the whole update is rejected if that payment fails, so the
+  //   subscription never half-switches. A downgrade's negative proration lands
+  //   as a credit on the customer balance and offsets the next renewal.
+  //
+  // The webhook (customer.subscription.updated + the proration invoice.paid)
+  // then re-mirrors yp.subscription_new and re-applies quota with the new
+  // plan; the response carries the new state so the FE can flip immediately.
+  async change_plan() {
+    let stripe;
+    try { stripe = this._stripe(); }
+    catch (e) { return this.output.data({ status: 'STRIPE_NOT_CONFIGURED' }); }
+    const plan = this.input.need('plan');
+    const period = this.input.need('period');
+    if (!/^(month|year)$/.test(period)) {
+      return this.output.data({ status: 'PERIOD_INVALID', period });
+    }
+
+    const sub = await this._subscription_row();
+    const subscription_id = sub && sub.subscription_id;
+    if (!subscription_id) return this.output.data({ status: 'NO_SUBSCRIPTION' });
+    const now = Math.floor(Date.now() / 1000);
+    const pending_cancel =
+      String(sub.status) === 'canceled' && ~~sub.period_end > now;
+    if (!/^(active|trialing)$/.test(String(sub.status)) && !pending_cancel) {
+      // Lapsed/incomplete subs have nothing to update — that caller buys anew.
+      return this.output.data({ status: 'NO_SUBSCRIPTION' });
+    }
+    if (
+      String(sub.plan || '') === plan &&
+      String(sub.period || '') === period &&
+      !pending_cancel
+    ) {
+      return this.output.data({ status: 'NOTHING_TO_CHANGE', plan, period });
+    }
+
+    const plan_row = await this.yp.await_proc('payment_get_plan', plan, period, CURRENCY);
+    if (!plan_row || !plan_row.stripe_price_id) {
+      return this.output.data({ status: 'NO_PRICE' });
+    }
+    // Same rule as checkout(): the target plan must be sold to the kind of
+    // entity that holds this subscription. _subscription_row tags the tenant
+    // row entity_type='org'; a personal row means 'user'. Moving between the
+    // kinds (pro -> team) is a supersede checkout, not an in-place update.
+    const holder = sub.entity_type === 'org' ? 'org' : 'user';
+    if (plan_row.entity_type && plan_row.entity_type !== holder) {
+      return this.output.data({
+        status: 'PLAN_ENTITY_MISMATCH', plan, entity_type: holder, expected: plan_row.entity_type,
+      });
+    }
+
+    let live;
+    try {
+      live = await stripe.subscriptions.retrieve(subscription_id);
+    } catch (e) {
+      return this.output.data({ status: 'CHANGE_FAILED', error: e && e.message });
+    }
+    const item = live.items && live.items.data && live.items.data[0];
+    if (!item) return this.output.data({ status: 'CHANGE_FAILED', error: 'NO_SUBSCRIPTION_ITEM' });
+
+    const params = {
+      items: [{ id: item.id, price: plan_row.stripe_price_id, quantity: 1 }],
+      proration_behavior: 'always_invoice',
+      payment_behavior: 'error_if_incomplete',
+      // Switching plan implies staying: a pending-cancel sub is resumed by the
+      // same update instead of bouncing the caller through resume first.
+      cancel_at_period_end: false,
+      metadata: { ...(live.metadata || {}), plan, period },
+    };
+    // When the billing interval changes, restart the cycle today: the caller
+    // pays the new price now (minus the unused-time credit) and renews a clean
+    // month/year from today, instead of a stub period on the old anchor.
+    if (String(sub.period || '') !== period) params.billing_cycle_anchor = 'now';
+
+    let s;
+    try {
+      s = await stripe.subscriptions.update(subscription_id, params);
+    } catch (e) {
+      return this.output.data({ status: 'CHANGE_FAILED', error: e && e.message });
+    }
+    const items = (s.items && s.items.data) || [];
+    this.output.data({
+      status: 'OK',
+      plan,
+      period,
+      subscription_status: s.status || 'active',
+      period_end: s.current_period_end || (items[0] && items[0].current_period_end) || sub.period_end || 0,
+    });
+  }
+
   // Post-Checkout receipt details for the success/failure modal: total paid,
   // invoice number, payment date and card brand/last4, straight from the
   // Checkout Session the browser was redirected back with.

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -439,9 +439,20 @@ class __public_stripe_webhook extends Entity {
             // signal — covers both the in-app Resume and the Billing Portal.
             // No new invoice is issued on resume; attach the latest one as the
             // receipt. A mail failure must never fail the webhook.
+            //
+            // payment.change_plan also clears cancel_at_period_end (switching
+            // plan implies staying), so a plan change made from the
+            // pending-cancel window trips this same signal. Its latest_invoice
+            // is the PRORATION invoice, whose own invoice.paid already sends
+            // "your plan is now X" — sending the resume receipt too would mail
+            // two differently-worded receipts for one invoice, the first
+            // announcing a plan the user never held. prev.items is present
+            // exactly when the update also swapped the price, so it separates
+            // a bare resume from a resume-by-plan-change.
             const prev = (event.data && event.data.previous_attributes) || {};
             if (event.type === 'customer.subscription.updated'
-              && prev.cancel_at_period_end === true && !obj.cancel_at_period_end) {
+              && prev.cancel_at_period_end === true && !obj.cancel_at_period_end
+              && !prev.items) {
               try {
                 const invId = typeof obj.latest_invoice === 'string'
                   ? obj.latest_invoice : (obj.latest_invoice && obj.latest_invoice.id);

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -310,6 +310,37 @@ class __public_stripe_webhook extends Entity {
   // org) vs add-on items (entity_type='addon' in yp.plan) — storage add-ons sum
   // disk * quantity into extra_disk (P4); pro_seat add-ons sum seat * quantity
   // into extra_seats (C1 Pro per-seat).
+  // Resolve what a subscription is ACTUALLY on, from the price its items carry.
+  //
+  // Everything downstream — the yp.subscription mirror, the quota applied by
+  // payment_apply_entitlement, the receipt heading — reads plan/period out of
+  // the subscription METADATA, which is written once at checkout and rewritten
+  // only by payment.change_plan. A price switched by any other route (the
+  // Stripe Billing Portal, a dashboard edit, a support action) leaves that
+  // metadata behind: the customer is charged the new price while the OLD plan's
+  // quota keeps being applied, and the receipt names the plan they just left.
+  // yp.plan holds the price ids, so the mapping back is a lookup — take it when
+  // it disagrees, and fall back to the metadata when there is nothing to find
+  // (an add-on-only item, a price retired from the catalog).
+  //
+  // Returns null when the items resolve to no catalog plan.
+  async _planFromItems(items) {
+    for (const it of (items || [])) {
+      const pid = it && it.price && it.price.id;
+      if (!pid) continue;
+      let row = await this.yp.await_query(
+        `SELECT plan_code, period FROM plan
+          WHERE stripe_price_id = ? AND active = 1 AND entity_type <> 'addon' LIMIT 1`,
+        pid
+      );
+      if (Array.isArray(row)) row = row[0];
+      if (row && row.plan_code) {
+        return { plan: String(row.plan_code), period: String(row.period || '') };
+      }
+    }
+    return null;
+  }
+
   async _itemsEntitlement(items) {
     let seats = 1, price = 0, extra_disk = 0, extra_seats = 0;
     for (const it of (items || [])) {
@@ -420,19 +451,25 @@ class __public_stripe_webhook extends Entity {
               } catch (e3) { items = []; }
             }
             const { seats, price, extra_disk, extra_seats } = await this._itemsEntitlement(items);
-            const seat_total = await this._seatTotal(entity_type, plan, period, seats, extra_seats);
+            // The price on the subscription outranks the metadata: see
+            // _planFromItems. Without this a Billing Portal price switch kept
+            // applying the plan the caller left.
+            const actual = await this._planFromItems(items);
+            const eff_plan = (actual && actual.plan) || plan;
+            const eff_period = (actual && actual.period) || period;
+            const seat_total = await this._seatTotal(entity_type, eff_plan, eff_period, seats, extra_seats);
             // 0, not null: await_proc maps null -> '' which a strict-mode INT param rejects.
             // Mirror only with a real subscription id — the subscription.created/
             // updated events carry it when the session doesn't.
             if (subscription_id) {
-              await this.yp.await_proc('subscription_update', entity_id, customer_id, subscription_id, plan, period, 1, price, 0, status);
+              await this.yp.await_proc('subscription_update', entity_id, customer_id, subscription_id, eff_plan, eff_period, 1, price, 0, status);
             }
-            await this.yp.await_proc('payment_apply_entitlement', entity_id, plan, period_end, entity_type, seat_total, extra_disk);
+            await this.yp.await_proc('payment_apply_entitlement', entity_id, eff_plan, period_end, entity_type, seat_total, extra_disk);
             // Push the REAL status (canceled when cancel_at_period_end), not a
             // hardcoded 'active' — a pending cancel must reach the client so the
             // billing screen flips to "ends on {period_end}" in realtime. Carry
             // period_end so the FE can render the date without a refetch.
-            await this.notify_user(entity_id, { service: 'payment.plan_updated', plan, status, period_end });
+            await this.notify_user(entity_id, { service: 'payment.plan_updated', plan: eff_plan, status, period_end });
             // Resume confirmation email (Figma 3050-96856): a pending cancel
             // flipping back to renewing. previous_attributes carries only the
             // changed fields, so cancel_at_period_end true→false IS the resume
@@ -512,9 +549,16 @@ class __public_stripe_webhook extends Entity {
           // provision) the real org before applying entitlement.
           const eid = await this._resolveOrgEntity(smd, stripe);
           if (eid) {
+            // What the subscription is ACTUALLY on, from the price its items
+            // carry rather than the metadata (see _planFromItems). Resolved
+            // once here so the paid and failed branches describe the same plan.
+            const inv_items = (sub && sub.items && sub.items.data) || [];
+            const actual = await this._planFromItems(inv_items);
+            const eff_plan = (actual && actual.plan) || smd.plan || 'team';
+            const eff_period = (actual && actual.period) || smd.period || 'month';
             if (event.type === 'invoice.paid') {
               // Recurring renewal succeeded -> re-apply entitlement (bumps period_end).
-              const items = (sub && sub.items && sub.items.data) || [];
+              const items = inv_items;
               const pend = (sub && sub.current_period_end) || (items[0] && items[0].current_period_end) || 0;
               // Since the 2026-07 pricing rebuild every plan is flat and the
               // add-ons (pro_seat, storage_*) are retired, so in practice this
@@ -524,9 +568,9 @@ class __public_stripe_webhook extends Entity {
               // subscription created under the old catalog still reduces
               // correctly on renewal.
               const { seats, extra_disk, extra_seats } = await this._itemsEntitlement(items);
-              const seat_total = await this._seatTotal(smd.entity_type || 'user', smd.plan || 'team', smd.period || 'month', seats, extra_seats);
-              await this.yp.await_proc('payment_apply_entitlement', eid, smd.plan || 'team', pend, smd.entity_type || 'user', seat_total, extra_disk);
-              await this.notify_user(eid, { service: 'payment.plan_updated', plan: smd.plan, status: 'active' });
+              const seat_total = await this._seatTotal(smd.entity_type || 'user', eff_plan, eff_period, seats, extra_seats);
+              await this.yp.await_proc('payment_apply_entitlement', eid, eff_plan, pend, smd.entity_type || 'user', seat_total, extra_disk);
+              await this.notify_user(eid, { service: 'payment.plan_updated', plan: eff_plan, status: 'active' });
               // Payment-receipt email (initial payment AND every renewal both
               // arrive as invoice.paid). A mail failure must never fail the
               // webhook — the entitlement above is already applied and Stripe
@@ -539,9 +583,12 @@ class __public_stripe_webhook extends Entity {
               // the NEW plan here.
               try {
                 const changed = obj.billing_reason === 'subscription_update';
-                const plan_label = String(smd.plan || 'team')
+                const plan_label = String(eff_plan)
                   .replace(/^\w/, (c) => c.toUpperCase());
-                await this._sendReceiptEmail(obj, sub, smd, {
+                // The receipt describes what they now have, so it reads the
+                // effective plan too — otherwise a portal-side switch mailed a
+                // 'plan is now X' naming the plan they just left.
+                await this._sendReceiptEmail(obj, sub, { ...smd, plan: eff_plan, period: eff_period }, {
                   seat_total,
                   ...(changed ? {
                     heading: `Your Drumee plan is now ${plan_label}`,
@@ -555,11 +602,11 @@ class __public_stripe_webhook extends Entity {
             } else {
               // Payment failed -> keep entitlement during Stripe's smart retries
               // (grace); final failure downgrades via customer.subscription.deleted.
-              await this.notify_user(eid, { service: 'payment.payment_failed', plan: smd.plan, status: 'past_due' });
+              await this.notify_user(eid, { service: 'payment.payment_failed', plan: eff_plan, status: 'past_due' });
               // Dunning email (retry notice / final warning). Mail failures log
               // only — a 500 here would make Stripe re-deliver the whole event.
               try {
-                await this._sendDunningEmail(stripe, obj, sub, smd);
+                await this._sendDunningEmail(stripe, obj, sub, { ...smd, plan: eff_plan, period: eff_period });
               } catch (e5) {
                 this.error(`dunning email failed for ${event.id}: ${e5.message}`);
               }

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -329,13 +329,23 @@ class __public_stripe_webhook extends Entity {
       const pid = it && it.price && it.price.id;
       if (!pid) continue;
       let row = await this.yp.await_query(
-        `SELECT plan_code, period FROM plan
+        `SELECT plan_code, period, entity_type FROM plan
           WHERE stripe_price_id = ? AND active = 1 AND entity_type <> 'addon' LIMIT 1`,
         pid
       );
       if (Array.isArray(row)) row = row[0];
       if (row && row.plan_code) {
-        return { plan: String(row.plan_code), period: String(row.period || '') };
+        // entity_type travels with the plan. Correcting the plan while leaving
+        // the metadata's entity kind behind is worse than not correcting at
+        // all: payment_apply_entitlement looks the plan up WITH entity_type, so
+        // an org plan applied as 'user' matches no row and falls back to a bare
+        // 20 GB personal grant — the customer pays for Team and receives less
+        // than Free.
+        return {
+          plan: String(row.plan_code),
+          period: String(row.period || ''),
+          entity_type: String(row.entity_type || ''),
+        };
       }
     }
     return null;
@@ -457,14 +467,15 @@ class __public_stripe_webhook extends Entity {
             const actual = await this._planFromItems(items);
             const eff_plan = (actual && actual.plan) || plan;
             const eff_period = (actual && actual.period) || period;
-            const seat_total = await this._seatTotal(entity_type, eff_plan, eff_period, seats, extra_seats);
+            const eff_entity = (actual && actual.entity_type) || entity_type;
+            const seat_total = await this._seatTotal(eff_entity, eff_plan, eff_period, seats, extra_seats);
             // 0, not null: await_proc maps null -> '' which a strict-mode INT param rejects.
             // Mirror only with a real subscription id — the subscription.created/
             // updated events carry it when the session doesn't.
             if (subscription_id) {
               await this.yp.await_proc('subscription_update', entity_id, customer_id, subscription_id, eff_plan, eff_period, 1, price, 0, status);
             }
-            await this.yp.await_proc('payment_apply_entitlement', entity_id, eff_plan, period_end, entity_type, seat_total, extra_disk);
+            await this.yp.await_proc('payment_apply_entitlement', entity_id, eff_plan, period_end, eff_entity, seat_total, extra_disk);
             // Push the REAL status (canceled when cancel_at_period_end), not a
             // hardcoded 'active' — a pending cancel must reach the client so the
             // billing screen flips to "ends on {period_end}" in realtime. Carry
@@ -556,6 +567,7 @@ class __public_stripe_webhook extends Entity {
             const actual = await this._planFromItems(inv_items);
             const eff_plan = (actual && actual.plan) || smd.plan || 'team';
             const eff_period = (actual && actual.period) || smd.period || 'month';
+            const eff_entity = (actual && actual.entity_type) || smd.entity_type || 'user';
             if (event.type === 'invoice.paid') {
               // Recurring renewal succeeded -> re-apply entitlement (bumps period_end).
               const items = inv_items;
@@ -568,8 +580,8 @@ class __public_stripe_webhook extends Entity {
               // subscription created under the old catalog still reduces
               // correctly on renewal.
               const { seats, extra_disk, extra_seats } = await this._itemsEntitlement(items);
-              const seat_total = await this._seatTotal(smd.entity_type || 'user', eff_plan, eff_period, seats, extra_seats);
-              await this.yp.await_proc('payment_apply_entitlement', eid, eff_plan, pend, smd.entity_type || 'user', seat_total, extra_disk);
+              const seat_total = await this._seatTotal(eff_entity, eff_plan, eff_period, seats, extra_seats);
+              await this.yp.await_proc('payment_apply_entitlement', eid, eff_plan, pend, eff_entity, seat_total, extra_disk);
               await this.notify_user(eid, { service: 'payment.plan_updated', plan: eff_plan, status: 'active' });
               // Payment-receipt email (initial payment AND every renewal both
               // arrive as invoice.paid). A mail failure must never fail the

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -6,20 +6,27 @@ const { stripeClient, endpointSecret } = require('../lib/stripe');
 const { sendButlerMail } = require('../lib/butler-mail');
 
 // "What's unlocked" checklist per plan (payment-receipt email, Figma 2803-1288).
-// Static marketing copy matching the billing plans page; unknown plans get none.
+// Static marketing copy matching the billing plans page (the July 2026 FINAL
+// pricing table: flat plans, Business self-serve); unknown plans get none.
+// 'pro' is the retired B2C tier — kept so receipts for its remaining renewals
+// still describe what the subscriber actually has.
 const PLAN_FEATURES = {
   pro: ['50 GB storage', '5 editor seats included', '7-day version history', 'Permissions & roles', 'Guest access'],
-  team: ['50 GB storage per seat', 'Org-wide entitlement', '30-day version history', 'Admin-managed billing'],
+  team: ['100 GB storage', 'Up to 10 members', '30-day version history', 'Granular permissions (role-based)', 'Guest access', 'Admin panel'],
+  business: ['Multiple workspaces', 'Unlimited members', '1 TB storage', '1-year version history', 'Granular permissions + audit', 'Admin panel + audit logs', 'API access', 'SSO / SAML', 'Priority support + SLA'],
 };
 
 const CURRENCY_SYMBOL = { eur: '€', usd: '$', gbp: '£' };
 
 class __public_stripe_webhook extends Entity {
-  // "€169.90" from Stripe minor units; falls back to "<CODE> 12.34".
+  // "€169.90" from Stripe minor units; falls back to "<CODE> 12.34". Negative
+  // amounts (downgrade proration credits) render as "-$58.00", not "$-58.00".
   _money(minor, currency) {
     const n = (Number(minor) || 0) / 100;
+    const sign = n < 0 ? '-' : '';
+    const abs = Math.abs(n);
     const sym = CURRENCY_SYMBOL[(currency || 'usd').toLowerCase()];
-    return sym ? `${sym}${n.toFixed(2)}` : `${(currency || '').toUpperCase()} ${n.toFixed(2)}`;
+    return sym ? `${sign}${sym}${abs.toFixed(2)}` : `${sign}${(currency || '').toUpperCase()} ${abs.toFixed(2)}`;
   }
 
   // "January 7, 2026" (en-US, UTC) from a unix timestamp.
@@ -513,8 +520,24 @@ class __public_stripe_webhook extends Entity {
               // arrive as invoice.paid). A mail failure must never fail the
               // webhook — the entitlement above is already applied and Stripe
               // would re-deliver the whole event on a 500.
+              //
+              // A proration invoice (billing_reason 'subscription_update' —
+              // payment.change_plan swapping Team <-> Business) is a plan
+              // CHANGE, not a renewal: say so. The metadata is rewritten in
+              // the same subscriptions.update, so plan_label already names
+              // the NEW plan here.
               try {
-                await this._sendReceiptEmail(obj, sub, smd, { seat_total });
+                const changed = obj.billing_reason === 'subscription_update';
+                const plan_label = String(smd.plan || 'team')
+                  .replace(/^\w/, (c) => c.toUpperCase());
+                await this._sendReceiptEmail(obj, sub, smd, {
+                  seat_total,
+                  ...(changed ? {
+                    heading: `Your Drumee plan is now ${plan_label}`,
+                    subject: `Your Drumee plan is now ${plan_label}`,
+                    intro: "Your plan change is confirmed. Here's your receipt, and what's included.",
+                  } : {}),
+                });
               } catch (e4) {
                 this.error(`receipt email failed for ${event.id}: ${e4.message}`);
               }


### PR DESCRIPTION
## What

The July 2026 final pricing table makes **Business a purchasable tier**. Backend side of that: a new `payment.change_plan` service that switches Team ↔ Business (and month ↔ year) **on the existing Stripe subscription**.

`USE_SUBSCRIPTION_UPDATE` used to be a refusal with nothing behind it — the checkout guard pointed at a subscription update that did not exist. This is that path.

## How it stays safe

- **`metadata.plan`/`period` are rewritten in the same `subscriptions.update`.** The webhook derives entitlement from subscription metadata (there is no reverse `price_id → plan_code` mapping), so a bare price swap would keep applying the *old* plan's quota forever.
- **`always_invoice` + `error_if_incomplete`** — an upgrade charges the prorated difference now and cannot half-apply; a downgrade's credit lands on the customer balance.
- **Stripe is the source of truth, not the DB mirror.** `yp.subscription_new` is only rewritten when the webhook lands, so guards reading it saw the pre-change state during webhook lag — a genuine second switch answered `NOTHING_TO_CHANGE` (which the client treats as success) while Stripe kept billing the old plan. The live subscription is retrieved first.
- **3DS/SCA has an exit.** `error_if_incomplete` returns an error rather than a `requires_action` PaymentIntent, so an upgrade needing authentication failed identically on every retry. It now returns `PAYMENT_ACTION_REQUIRED`.
- **No circular refusal.** A legacy personal Pro holder was refused by both endpoints — checkout said `USE_SUBSCRIPTION_UPDATE`, change_plan said `PLAN_ENTITY_MISMATCH`. The checkout guard now applies only when the holder is the same *kind* of entity as the plan, so a cross-kind purchase runs as the supersede checkout the webhook already completes.
- Multi-item (legacy add-on) subscriptions are **refused** rather than having `items[0]` swapped blind; `past_due` holders may switch instead of being told to buy anew.

## Email follows the plan

- `PLAN_FEATURES` matches the flat July 2026 catalog — Team corrected (100 GB / 10 members, was per-seat copy), **Business added**.
- A proration invoice (`billing_reason: subscription_update`) says *"Your Drumee plan is now Business"* instead of pretending to be a renewal.
- A plan change made from the pending-cancel window no longer mails **two** receipts for one invoice.
- Negative prorations render `-$58.00`, not `$-58.00`.

## Review

Ran an adversarial multi-agent review; six major findings survived independent refutation and are all fixed in `0047cf3` / ui-team `7769a005`. Paired with drumee/ui-team `feat/pricing-business-selfserve`.

## Deploy note

`yp.plan` rows 19/20 (`business`, org, month/year, usd) exist with quota but **`stripe_price_id` is NULL** — the Business product/prices must be seeded per environment (sandbox and live are separate Stripe accounts). Without that, checkout answers `NO_PRICE`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)