### PR TITLE
feat(reward): private track endpoint for the claim-reward flow

### DIFF
--- a/acl/reward.json
+++ b/acl/reward.json
@@ -1,0 +1,18 @@
+{
+  "modules": {
+    "private": "service/private/reward"
+  },
+  "services": {
+    "track": {
+      "doc": "Record how far the caller got in the claim-reward flow (ui-team builtins/widget/reward-flow). One row per user in yp.reward_claim; status and step only ever advance, so a re-post can never undo a completion. Fire-and-forget from the widget.",
+      "scope": "hub",
+      "permission": { "src": "owner" },
+      "params": {
+        "status": { "type": "string", "required": true, "description": "started | dropped | done" },
+        "step": { "type": "string", "required": false, "description": "step1 | step2 | step3 — the card step the user is on" },
+        "campaign": { "type": "string", "required": false, "description": "utm_campaign, defaults to free-storage" }
+      },
+      "returns": { "type": "object", "properties": { "ok": { "type": "boolean" }, "status": { "type": "string" }, "step": { "type": "string" } } }
+    }
+  }
+}

--- a/service/private/reward.js
+++ b/service/private/reward.js
@@ -1,0 +1,53 @@
+/**
+ * Claim-reward campaign tracking.
+ *
+ * The reward onboarding flow (ui-team builtins/widget/reward-flow) kept all of
+ * its progress in localStorage, so nothing outside that one browser knew who
+ * finished and who walked away. `track` is the single write the widget makes,
+ * fired on each step transition and on the terminal outcomes.
+ *
+ * The row is the caller's own — uid comes from the session, never from the
+ * request — and yp.reward_claim_track advances status/step by rank, so a
+ * duplicated or out-of-order post is harmless.
+ *
+ * Read side: analytics-server reward_tracking().
+ */
+const { Entity } = require('@drumee/server-core');
+
+const CAMPAIGN = 'free-storage';
+/** Terminal and in-flight states the client may report. 'emailed' is NOT here:
+ *  it is seeded at send time by analytics-server, never claimed by a browser. */
+const STATUS = ['started', 'dropped', 'done'];
+const STEPS = ['step1', 'step2', 'step3'];
+
+class __reward extends Entity {
+
+  /**
+   * Record the caller's progress in the claim-reward flow.
+   *
+   * Unknown values are rejected rather than stored: the funnel is only useful
+   * if every row reads as one of the known states, and the widget is the only
+   * caller, so anything else is a bug or a poke at the endpoint.
+   */
+  async track() {
+    const status = String(this.input.need('status') || '').trim();
+    if (!STATUS.includes(status)) {
+      return this.output.data({ ok: false, error: 'invalid status' });
+    }
+    // Step is optional — 'dropped' is posted without one when the user quits
+    // from a transient state, and the proc keeps whatever it already had.
+    const step = String(this.input.use('step', '') || '').trim();
+    const campaign = String(this.input.use('campaign', CAMPAIGN) || CAMPAIGN).trim();
+
+    await this.yp.await_proc(
+      'reward_claim_track',
+      this.uid,
+      campaign || CAMPAIGN,
+      status,
+      STEPS.includes(step) ? step : ''
+    );
+    this.output.data({ ok: true, status, step });
+  }
+}
+
+module.exports = __reward;


### PR DESCRIPTION
The reward onboarding flow kept its progress in localStorage only, so nothing outside the user's own browser knew who finished and who walked away. SERVICE.reward.track is the single write the widget makes, on each step transition and on the terminal outcomes.

permission: owner, and the row is keyed on the SESSION uid rather than anything in the request, so a user can only ever write their own funnel row. Unknown status/step values are rejected instead of stored: the table is only useful if every row reads as a known state, and the widget is its only legitimate caller.

Needs yp.reward_claim + reward_claim_track (schemas repo).