### PR TITLE
feat(reward): being mailed is an invitation, not an entitlement

### DIFF
--- a/acl/reward.json
+++ b/acl/reward.json
@@ -4,7 +4,7 @@
   },
   "services": {
     "get_state": {
-      "doc": "Claim-reward gate for the desk. Returns { eligible, step } for the CALLER, read from yp.reward_claim: eligible=1 when the row's status is 'emailed' or 'started'. This replaces the browser's localStorage latch, so the answer follows the user across devices and a re-send re-arms them.",
+      "doc": "Claim-reward gate for the desk. Returns { eligible, step } for the CALLER, read from yp.reward_claim: eligible=1 when the row's status is 'clicked' or 'started' — being MAILED is an invitation, not an entitlement, so the user must have followed the campaign link. This replaces the browser's localStorage latch, so the answer follows the user across devices and a re-send re-arms them.",
       "scope": "hub",
       "permission": { "src": "owner" },
       "returns": { "type": "object", "properties": { "eligible": { "type": "integer" }, "step": { "type": "string" } } }
@@ -14,7 +14,7 @@
       "scope": "hub",
       "permission": { "src": "owner" },
       "params": {
-        "status": { "type": "string", "required": true, "description": "started | dropped | done" },
+        "status": { "type": "string", "required": true, "description": "clicked | started | dropped | done" },
         "step": { "type": "string", "required": false, "description": "step1 | step2 | step3 — the card step the user is on" },
         "campaign": { "type": "string", "required": false, "description": "utm_campaign, defaults to free-storage" }
       },

--- a/service/private/reward.js
+++ b/service/private/reward.js
@@ -16,13 +16,23 @@ const { Entity } = require('@drumee/server-core');
 const { toArray } = require('@drumee/server-essentials');
 
 const CAMPAIGN = 'free-storage';
-/** Statuses that mean "this user still owes us a run". Terminal states (done,
- *  dropped) are excluded; a later send re-arms the row back to 'emailed'
- *  (see yp.reward_claim_emailed), which is what makes a re-send a real reset. */
-const OPEN = ['emailed', 'started'];
-/** Terminal and in-flight states the client may report. 'emailed' is NOT here:
- *  it is seeded at send time by analytics-server, never claimed by a browser. */
-const STATUS = ['started', 'dropped', 'done'];
+/**
+ * Statuses that open the flow.
+ *
+ * 'emailed' is deliberately NOT here. Being on the recipient list is an
+ * invitation, not an entitlement — the user has to follow the campaign link.
+ * Without that distinction anyone who was mailed got the walkthrough on their
+ * next login whether or not they ever clicked, which is the step this closes.
+ *
+ * Terminal states (done, dropped) are excluded; a later send re-arms the row to
+ * 'emailed', so a returning user has to click again before they are eligible.
+ */
+const OPEN = ['clicked', 'started'];
+/** States the client may report. 'clicked' is posted by the desk when it finds
+ *  campaign-arrival evidence relayed through login; the rest come from the
+ *  widget. 'emailed' is NOT here: it is seeded at send time by analytics-server
+ *  and must never be claimable by a browser, or anyone could invite themselves. */
+const STATUS = ['clicked', 'started', 'dropped', 'done'];
 const STEPS = ['step1', 'step2', 'step3'];
 
 class __reward extends Entity {

--- a/service/private/reward.js
+++ b/service/private/reward.js
@@ -27,12 +27,12 @@ const CAMPAIGN = 'free-storage';
  * Terminal states (done, dropped) are excluded; a later send re-arms the row to
  * 'emailed', so a returning user has to click again before they are eligible.
  */
-const OPEN = ['clicked', 'started'];
+const OPEN = new Set(['clicked', 'started']);
 /** States the client may report. 'clicked' is posted by the desk when it finds
  *  campaign-arrival evidence relayed through login; the rest come from the
  *  widget. 'emailed' is NOT here: it is seeded at send time by analytics-server
  *  and must never be claimable by a browser, or anyone could invite themselves. */
-const STATUS = ['clicked', 'started', 'dropped', 'done'];
+const STATUS = new Set(['clicked', 'started', 'dropped', 'done']);
 const STEPS = ['step1', 'step2', 'step3'];
 
 class __reward extends Entity {
@@ -57,7 +57,7 @@ class __reward extends Entity {
     const row = toArray(await this.yp.await_query(
       `SELECT status, step FROM reward_claim WHERE uid=?`, this.uid
     ))[0];
-    const eligible = !!(row && OPEN.includes(row.status));
+    const eligible = !!(row && OPEN.has(row.status));
     this.output.data({
       eligible: eligible ? 1 : 0,
       step: (eligible && row.step) || '',
@@ -73,7 +73,7 @@ class __reward extends Entity {
    */
   async track() {
     const status = String(this.input.need('status') || '').trim();
-    if (!STATUS.includes(status)) {
+    if (!STATUS.has(status)) {
       return this.output.data({ ok: false, error: 'invalid status' });
     }
     // Step is optional — 'dropped' is posted without one when the user quits


### PR DESCRIPTION
get_state treated 'emailed' as eligible, so anyone on the recipient list got the walkthrough on their next login whether or not they ever followed the campaign link. The click was a missing step.

'emailed' leaves the OPEN set; eligibility is now 'clicked' or 'started'. The desk posts 'clicked' when it finds campaign-arrival evidence relayed through login, which is what turns an invitation into an entitlement.

'clicked' joins the statuses a client may report, alongside started / dropped / done. 'emailed' deliberately stays unreportable — it is seeded at send time by analytics-server, and letting a browser claim it would let anyone invite themselves.

Needs the matching rank in yp.reward_claim_track (schemas repo).