### PR TITLE
Secure share: link-keyed access, per-recipient revoke, chat sender, invite-list leak

### DIFF
--- a/acl/secure_share.json
+++ b/acl/secure_share.json
@@ -184,6 +184,26 @@
         }
       }
     },
+    "revoke_email": {
+      "doc": "Cut one recipient off a secure share link while the link keeps working for everyone else. Adds the address to the token's deny list, which the DMZ gate refuses before any allow rule, drops that account's node-scoped grant, and pushes secure_share_revoked to that user's own sockets. Creator-scoped in the stored procedure. Access-event history is kept.",
+      "scope": "hub",
+      "permission": {
+        "src": "write"
+      },
+      "log": true,
+      "params": {
+        "token": {
+          "type": "string",
+          "required": true,
+          "doc": "Secure share token the recipient came through"
+        },
+        "email": {
+          "type": "string",
+          "required": true,
+          "doc": "Recipient email to cut off this link"
+        }
+      }
+    },
     "delete": {
       "doc": "Hard-delete a secure share token. Only succeeds when the token is already revoked or expired — active tokens are rejected.",
       "scope": "hub",

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -391,9 +391,15 @@ class __dmz extends Mfs {
       }
     }
 
-    // Both gates are behind us, so nothing downstream needs the deny list — and the
-    // success response below spreads `info` straight to the viewer. Drop it here so
-    // a recipient who passes the gate can never enumerate who the sender revoked.
+    // Both gates are behind us, so nothing downstream needs the recipient lists —
+    // and the success response below spreads `info` straight to the viewer. Drop
+    // them here so a recipient who passes the gate can enumerate neither who else
+    // was invited nor who the sender revoked.
+    //
+    // allowed_emails was already stripped from the gate responses (safeInfo) and
+    // from the unauthenticated info() probe, but NOT from this success path, so
+    // every recipient of a multi-address link received the whole invite list.
+    delete info.allowed_emails;
     delete info.denied_emails;
 
     // Valid access — log it and notify sender in real time.

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -33,7 +33,34 @@ try {
   _ssOwnerSecret = JSON.parse(require('fs').readFileSync(_secPath, 'utf8')).drumee || null;
 } catch (e) { /* owner_edit_token disabled when the secret is unavailable */ }
 
+// Recipients the sender cut off this link individually (secure_share.revoke_email).
+// Deny-only: it can refuse an address, never admit one, so it cannot widen access
+// however the allow rule was written. Kept separate from allowed_emails so the
+// sender's own configuration is never rewritten — and because emptying an
+// allow-list would make the gate below read it as "no restriction".
+function _isDeniedEmail(email, info) {
+  if (!email || !info || !info.denied_emails) return false;
+  let list = null;
+  try {
+    const parsed = typeof info.denied_emails === 'string'
+      ? JSON.parse(info.denied_emails)
+      : info.denied_emails;
+    if (Array.isArray(parsed) && parsed.length > 0) list = parsed;
+  } catch (e) {
+    // Malformed JSON: fail CLOSED is not an option (it would lock out every
+    // recipient of this link), so treat it as no denials — same posture as the
+    // allow-list parse below, which is the pre-existing behaviour.
+    return false;
+  }
+  if (!list) return false;
+  const target = String(email).toLowerCase().trim();
+  return list.some(entry => String(entry || '').toLowerCase().trim() === target);
+}
+
 function _emailMatchesAllowed(email, info) {
+  // A denied recipient is refused before any allow rule is considered — this is
+  // the single point both gate call sites (signed-in and anonymous) go through.
+  if (_isDeniedEmail(email, info)) return false;
   let allowedList = null;
   if (info.allowed_emails) {
     try {
@@ -189,6 +216,7 @@ class __dmz extends Mfs {
           // a viewer enumerate the allow-list before passing the gate.
           delete res.password_hash;
           delete res.allowed_emails;
+          delete res.denied_emails;
         }
       } catch (e) {
         this.warn('[dmz.info] secure_share_info lookup failed:', e && e.message);
@@ -272,6 +300,9 @@ class __dmz extends Mfs {
     const safeInfo = { ...info };
     delete safeInfo.password_hash;
     delete safeInfo.allowed_emails;
+    // Same reason as allowed_emails: who the sender revoked is sender-only data,
+    // and must never reach a viewer sitting at the gate.
+    delete safeInfo.denied_emails;
 
     // Email gate: active for restricted shares (require_email=1 via v2 allowed_emails,
     // or legacy recipient_email set). Skipped entirely for public shares.
@@ -359,6 +390,11 @@ class __dmz extends Mfs {
         }
       }
     }
+
+    // Both gates are behind us, so nothing downstream needs the deny list — and the
+    // success response below spreads `info` straight to the viewer. Drop it here so
+    // a recipient who passes the gate can never enumerate who the sender revoked.
+    delete info.denied_emails;
 
     // Valid access — log it and notify sender in real time.
     // Attribute the open to the viewer's OWN account ONLY when they are genuinely

--- a/service/lib/message-author.js
+++ b/service/lib/message-author.js
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2024 Thidima SA. All Rights Reserved.
+ * Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE, Version 3.
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+const { Attr } = require("@drumee/server-essentials");
+
+/**
+ * Stamp the author's display identity onto an outgoing chat payload (the
+ * real-time broadcast AND the poster's own echo).
+ *
+ * `channel_list_messages` resolves firstname/lastname/fullname/email for every
+ * listed row, but the posting paths only carried firstname + lastname — both
+ * NULL for an account that has an email and no name (the typical secure-share
+ * recipient). The chat item then fell through its whole fallback chain
+ * (firstname/lastname → fullname → name → email) and rendered the raw 16-char
+ * author id, with a "?" avatar. Keeping the same field set as the SP makes a
+ * live message render exactly like the same message after a reload.
+ *
+ * No new exposure: these are the very fields `channel_list_messages` already
+ * returns to the same audience (the hub's sockets) for the same message.
+ *
+ * `firstname`/`lastname` are written exactly as the call sites did before, so
+ * existing consumers see no change; the rest is added only when non-empty.
+ *
+ * @param {object} user  the session user (`this.user`)
+ * @param {object} data  outgoing message payload — mutated in place
+ * @returns {object} the same `data`
+ */
+function stampAuthorIdentity(user, data) {
+  if (!user || !data) return data;
+  const profile = user.get("profile") || {};
+  const firstname = user.attributes ? user.attributes.firstname : undefined;
+  const lastname = profile.lastname;
+  data.firstname = firstname;
+  data.lastname = lastname;
+
+  const name = [firstname, lastname].filter(Boolean).join(" ").trim();
+  const fullname = name || user.get(Attr.fullname) || "";
+  const email = user.get(Attr.email) || profile.email || "";
+  if (fullname) data.fullname = fullname;
+  if (email) data.email = email;
+  // The chat item derives its avatar initials from `surname` and also uses it
+  // as a firstname fallback — that is what `shareroom_contact_get` returns on
+  // the list path (the name when there is one, else the email).
+  const surname = name || fullname || email;
+  if (surname) data.surname = surname;
+  return data;
+}
+
+module.exports = { stampAuthorIdentity };

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -20,6 +20,7 @@ const {
 } = require("@drumee/server-essentials");
 const { Entity, MfsTools } = require("@drumee/server-core");
 const { remove_node, move_node, copy_node } = MfsTools;
+const { stampAuthorIdentity } = require("../lib/message-author");
 
 const { stringify, parse: jsonParse } = JSON;
 const { isEmpty } = require("lodash");
@@ -1153,9 +1154,7 @@ class __private_channel extends Entity {
       data.thread = await this.threadInfo(thread_id, this.hub.get(Attr.id));
     }
 
-    let profile = this.user.get("profile") || {};
-    data.firstname = this.user.attributes.firstname;
-    data.lastname = profile.lastname;
+    stampAuthorIdentity(this.user, data);
     data.hub_id = this.hub.get(Attr.id);
     if (nid) data.nid = nid;
     data.echoId = this.input.get("echoId");
@@ -1599,9 +1598,7 @@ class __private_channel extends Entity {
     if (!isEmpty(thread_id)) {
       data.thread = await this.threadInfo(thread_id, hub_id);
     }
-    const profile = this.user.get("profile") || {};
-    data.firstname = this.user.attributes.firstname;
-    data.lastname = profile.lastname;
+    stampAuthorIdentity(this.user, data);
     data.hub_id = hub_id;
     data.echoId = this.input.get("echoId");
     data.file_thread_id = file_thread_id;

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -390,6 +390,29 @@ class __secure_share extends Mfs {
   }
 
   /**
+   * Drop a recipient's node-scoped secure-share grant — the exact inverse of the
+   * permission_grant(node_id, uid, ...) issued in _grantHubMembership. Best-effort
+   * and safe to call with no uid (anonymous viewers never held one).
+   *
+   * permission_revoke deletes only the (node_id, uid) row, so a recipient who is
+   * ALSO a real workspace member keeps their '*' membership untouched.
+   *
+   * @returns {Promise<boolean>} true when a grant was actually revoked
+   */
+  async _revokeNodeGrant(hub_id, node_id, uid) {
+    if (!uid || !hub_id || !node_id) return false;
+    try {
+      const db_name = await this.yp.await_func('get_db_name', hub_id);
+      if (!db_name) return false;
+      await this.yp.await_proc(`${db_name}.permission_revoke`, node_id, uid);
+      return true;
+    } catch (e) {
+      this.warn('[secure_share] permission_revoke failed:', e && e.message);
+      return false;
+    }
+  }
+
+  /**
    * Revoke a single recipient's current access grant for this node and drop their
    * rows from the access-event log. "Revoke current grant only" — the email is NOT
    * blocklisted, so the recipient can request access again later. Best-effort and
@@ -419,21 +442,7 @@ class __secure_share extends Mfs {
       uid = member && member.id ? member.id : null;
     }
 
-    let revoked = false;
-    if (uid) {
-      try {
-        const db_name = await this.yp.await_func('get_db_name', hub_id);
-        if (db_name) {
-          // Exact inverse of the node-scoped secure-share grant
-          // (permission_grant(node_id, uid, ...) in _grantHubMembership). nid is the
-          // shared node carried by the access-list row.
-          await this.yp.await_proc(`${db_name}.permission_revoke`, nid, uid);
-          revoked = true;
-        }
-      } catch (e) {
-        this.warn('[secure_share.revoke_recipient] permission_revoke failed:', e && e.message);
-      }
-    }
+    const revoked = await this._revokeNodeGrant(hub_id, nid, uid);
 
     // Clear the recipient's access-event rows so they drop off the list.
     if (email) {
@@ -445,6 +454,76 @@ class __secure_share extends Mfs {
     }
 
     this.output.data({ status: 'OK', revoked, email, uid });
+  }
+
+  /**
+   * Cut ONE recipient off a link while the link keeps working for everyone else.
+   *
+   * The address goes on the token's deny list, which the DMZ gate refuses before
+   * it considers any allow rule — so it holds whether the link names addresses,
+   * allows a whole @domain, or accepts any email. It is deny-only: it can never
+   * admit someone, so it cannot widen access.
+   *
+   * Enforcement is exact for a SIGNED-IN recipient (their email comes from their
+   * authenticated account). For an anonymous visitor the email gate is a typed
+   * value with no ownership proof (pre-existing — see the capped-guest-principal
+   * work), so a denied person could return under another accepted address; on a
+   * public link there is no gate at all, which is why the panel offers this only
+   * where an email was actually captured.
+   */
+  async revoke_email() {
+    const token = this.input.need(Attr.token);
+    const email = (this.input.need(Attr.email) || '').toLowerCase().trim();
+    if (!email) {
+      return this.output.data({ status: 'INVALID_EMAIL', denied: 0 });
+    }
+
+    // Creator-scoped inside the SP: an empty row means the token is unknown or is
+    // not this caller's, and nothing was written.
+    const row = toArray(
+      await this.yp.await_proc('secure_share_deny_email', token, this.uid, email)
+    )[0] || {};
+    if (isEmpty(row) || !row.denied) {
+      return this.output.data({ status: 'FORBIDDEN', denied: 0 });
+    }
+
+    // Resolve the account behind the address so an already-granted recipient also
+    // loses the standing node grant the capped-principal binding gave them —
+    // otherwise the gate refuses them while their ACL quietly still holds.
+    let uid = null;
+    try {
+      let member = await this.yp.await_proc('drumate_exists', email);
+      if (Array.isArray(member)) member = member[0];
+      uid = member && member.id ? member.id : null;
+    } catch (e) {
+      this.warn('[secure_share.revoke_email] drumate lookup failed:', e && e.message);
+    }
+    const revoked = await this._revokeNodeGrant(row.hub_id, row.node_id, uid);
+
+    // Cut a session this person already has open on THIS link. Targeted at their
+    // own sockets (never the token's active socket, which may belong to someone
+    // else still legitimately using the link); the sharebox only reacts when the
+    // event's token matches the share it has open.
+    if (uid) {
+      try {
+        const targets = await this.yp.await_proc('user_sockets', uid);
+        if (!isEmpty(targets)) {
+          await RedisStore.sendData(
+            this.payload(
+              { event: 'secure_share_revoked', token, nid: row.node_id, recipient_email: email },
+              { service: 'share.track_event' }
+            ),
+            targets
+          );
+        }
+      } catch (e) {
+        this.warn('[secure_share.revoke_email] recipient broadcast failed:', e && e.message);
+      }
+    }
+
+    // The access-event history is deliberately kept: the sender's panel is built on
+    // it, and erasing a visit does not un-happen it.
+    this.output.data({ status: 'OK', denied: 1, token, email, revoked });
   }
 
   /**


### PR DESCRIPTION
Server side of the secure-share batch Lexis reported. The ui and schemas parts are already on \`preview\` (they rode along with ui/schemas \`test\` merges); this carries the three server commits that did not.

Verified on drumee.in (test) and signed off by Duy.

### 1. Chat sender rendered as a raw uid — `fix(chat)`
`channel_list_messages` resolves firstname/lastname/fullname/email for every listed row, but the posting paths attached only firstname + lastname to the broadcast and the echo. Both are NULL for an account that has an email and no name — the typical secure-share recipient — so a live message fell through the chat item's whole fallback chain and rendered the raw 16-char author id with a "?" avatar, while the same message after a reload showed the email.

New `service/lib/message-author.js` stamps the same field set the list procedure returns, from the session's own identity, at both posting sites. No new exposure: these are the fields `channel_list_messages` already returns to the same audience for the same message. `firstname`/`lastname` keep their previous values; the rest is added only when non-empty.

### 2. Per-recipient revoke — `feat(secure-share): revoke_email`
Revoking used to be all-or-nothing: the only way to stop one person was to revoke the link, cutting everyone else using it too.

`secure_share.revoke_email` puts the address on the token's deny list (schema already on preview), drops that account's node-scoped grant so the gate and the ACL agree, and pushes `secure_share_revoked` to that user's **own** sockets — never the token's `active_socket_id`, which may belong to someone else still legitimately using the link. Access-event history is deliberately kept.

The gate refuses a denied address **before** any allow rule is considered, at the single point both call sites (signed-in and anonymous) go through, so it holds however the link was configured — named addresses, a whole `@domain`, or any-email.

Deny-only by design: it can refuse an address, never admit one, so it cannot widen access. Chosen over editing `allowed_emails`, which would rewrite what the sender configured and — because the gate reads an empty allow-list as "no restriction" — would have turned a restricted link into an open one when the last recipient was removed.

Checked with a 480-case matrix driving the real gate functions: no case where a deny admits an address the allow rule refused, and behaviour byte-identical when the column is unset, empty, or malformed. Also proven end-to-end through the real HTTP gate: allowed → TICKET_OK, denied → EMAIL_MISMATCH, restored → TICKET_OK.

Public links deliberately get no per-recipient revoke — the gate is skipped entirely there, so a denied person would just sign out and read it anonymously. Enforcement is exact for signed-in recipients; for anonymous ones the typed-email gate has no ownership proof (pre-existing).

### 3. Invite list handed to recipients — `fix(secure-share)`
`dmz.login`'s success response spreads `info` straight to the viewer, so a recipient who passed the gate received `allowed_emails` — every address invited to that link. The gate responses and the unauthenticated `info()` probe already stripped it; this path did not. Pre-existing, found while adding the deny list.

Dropped after both gates have run, where nothing downstream reads it: inside `dmz.js` only `_emailMatchesAllowed` consumes it, `media.js` and the write guard never return it to a client, and no ui code outside the sender's own panel reads it.

### ⚠️ Before merging
Apply to the **PROD DB** (`yp` only — single DB, additive, no fleet loop, no factory restart):
- \`yellow_page/patches/add_denied_emails_to_secure_share_token.sql\`
- \`yellow_page/procedures/secure_share/secure_share_deny_email.sql\`
- \`yellow_page/procedures/secure_share/secure_share_info.sql\`
- \`yellow_page/procedures/secure_share/secure_share_list.sql\`

Merging before the apply is not breaking — an absent `denied_emails` reads as "no denials" and the gate behaves exactly as today — but `revoke_email` cannot work until it lands.

### Not included
The per-link popup (the per-recipient revoke UI) is pending Lexis's Figma. This PR is its backend.