### PR TITLE
feat(payment): let a subscriber deliberately replace their plan through checkout

### DIFF
--- a/acl/payment.json
+++ b/acl/payment.json
@@ -43,6 +43,11 @@
           "type": "string",
           "required": false,
           "doc": "Organisation display name (TEAM bootstrap)"
+        },
+        "supersede": {
+          "type": "string",
+          "required": false,
+          "doc": "Set when the caller deliberately replaces the plan they already hold. Lifts the already-subscribed refusal; the webhook cancels the replaced subscription once this one is paid."
         }
       }
     },

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -159,7 +159,17 @@ class __private_payment extends Entity {
     const pending_cancel = status === 'canceled' && ~~(current && current.period_end) > now;
     const live = /^(active|trialing|past_due)$/.test(status) || pending_cancel;
     const holder = current && current.entity_type === 'org' ? 'org' : 'user';
-    if (current && current.subscription_id && live && holder === entity_type) {
+    // `supersede` is the caller saying, explicitly and after a warning, that
+    // they want to replace the plan they hold rather than be told they already
+    // have one. The refusals below exist to stop an ACCIDENTAL second
+    // subscription; they must not stand in the way of a deliberate change.
+    //
+    // This is safe only because the webhook finishes the job: on
+    // checkout.session.completed it cancels the entity's previous subscription
+    // as soon as the new one is paid, so the two never bill in parallel. Do not
+    // relax this guard without that half in place.
+    const supersede = !!this.input.use('supersede', '');
+    if (current && current.subscription_id && live && holder === entity_type && !supersede) {
       const same_plan = String(current.plan || '') === String(this.input.use('plan', 'team'));
       let refusal;
       if (pending_cancel) refusal = 'PENDING_CANCEL_RESUME_INSTEAD';
@@ -258,6 +268,10 @@ class __private_payment extends Entity {
     // through _cancelSupersededPersonalSubscription instead.
     if (entity_type === 'user' && this.input.use('supersede', '') === 'org') {
       metadata.supersede = 'org';
+    } else if (supersede) {
+      // Same-entity replacement (Team <-> Business). The webhook reads this to
+      // cancel the subscription being replaced once this one is paid.
+      metadata.supersede = '1';
     }
     if (org_bootstrap) {
       metadata.org_ident = org_bootstrap.ident;

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -460,6 +460,35 @@ class __public_stripe_webhook extends Entity {
                 period_end = period_end || s.current_period_end || (items[0] && items[0].current_period_end) || 0;
               } catch (e3) { items = []; }
             }
+            // SUPERSEDE, same entity. A subscriber who deliberately changed
+            // plan through checkout (payment.checkout with supersede=1) now has
+            // a SECOND Stripe subscription on the same customer: the mirror row
+            // is keyed UNIQUE(entity_id), so the upsert below would point at
+            // the new one while the old kept charging, unseen. Cancel it here,
+            // once the new subscription is confirmed paid.
+            //
+            // The pre-existing supersede helpers only cover a change of entity
+            // kind (personal <-> org); this covers the same entity moving
+            // between plans, which is the common case (Team <-> Business).
+            //
+            // Immediate cancel, not at period end: the user was warned they
+            // lose the current plan, and leaving it running to its date is the
+            // double charge this exists to prevent.
+            if (subscription_id && md.supersede) {
+              try {
+                const prev = await this.yp.await_proc('payment_get_subscription', entity_id);
+                const prevId = prev && prev.subscription_id;
+                if (prevId && prevId !== subscription_id) {
+                  await stripe.subscriptions.cancel(prevId);
+                  this.debug(`superseded subscription ${prevId} cancelled for ${entity_id}`);
+                }
+              } catch (e6) {
+                // Never fail the webhook over this — the new subscription is
+                // paid and entitlement must still be applied. A leftover is
+                // visible in Stripe and recoverable; a dropped event is not.
+                this.error(`superseded cancel failed for ${entity_id}: ${e6.message}`);
+              }
+            }
             const { seats, price, extra_disk, extra_seats } = await this._itemsEntitlement(items);
             // The price on the subscription outranks the metadata: see
             // _planFromItems. Without this a Billing Portal price switch kept


### PR DESCRIPTION
Changing plan now warns that the current plan is lost, and on accept goes to **checkout** rather than charging the card silently.

## Why it needed a server change too

Clicking another plan while subscribed used to open a confirm and swap the price on the live subscription — Stripe took the prorated difference off the card on file with no payment step at all.

Routing that through checkout means the old subscription **has to end**: two subscriptions on one customer is a double charge, which is exactly why `payment.checkout` refuses a live subscriber. So this is two halves, and neither is safe alone:

- **`checkout()`** lifts the already-subscribed refusal when the caller passes `supersede`. That flag means they were warned and accepted; the refusal exists to stop an *accidental* second subscription, not a deliberate replacement.
- **The webhook** cancels the replaced subscription as soon as the new one is paid. **This is new.** The existing supersede helpers only cover a change of entity kind (personal ↔ org); the common case — the *same* entity moving between Team and Business — had nothing. The mirror row is keyed `UNIQUE(entity_id)`, so the upsert would have pointed at the new subscription while the old one kept charging on the same customer, unseen.

Cancelled **immediately**, not at period end: the user was warned they lose the current plan, and leaving it running to its renewal date is the double charge this guards against. The cancel is wrapped so it can never fail the webhook — the new subscription is paid and entitlement must still be applied; a leftover subscription is visible in Stripe and recoverable, a dropped event is not.

`payment.change_plan` stays in place for the `USE_SUBSCRIPTION_UPDATE` path.

## The warning

> **Change to Business?**
> Your current Team plan ends as soon as the new one is paid — you lose the time already paid for on it.
> It is paid until Aug 27, 2026; that remaining time is not refunded or carried over.

Two fixes to it while wiring it up:

- The limits line was appended for **upgrades** too, telling someone buying Business what Business "includes" as if it were a loss. It now appears only when the move actually lowers the ceiling.
- It printed the internal sentinels — *"1000 GB of storage and up to 100000 members"* — where the card beside it reads **1 TB** and **Unlimited**.

## Verified on stage

| Check | Result |
|---|---|
| Team → Business | warning shown, with the paid-until date and no downgrade line |
| Accept | lands on the checkout tab with a payment button |
| `payment.checkout` **with** `supersede` | returns a Stripe checkout URL |
| `payment.checkout` **without** it | still refused — `USE_SUBSCRIPTION_UPDATE` |

## Not yet exercised end to end

The webhook's new cancel path fires only on a real `checkout.session.completed`, which needs a card walked through Stripe's hosted page. The refusal-lifting and the routing are verified above; **the cancel itself is verified by construction, not by a live payment** — worth a manual run on stage before this reaches production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
