### PR TITLE
Secure share: stop a second file share in a folder from rendering blank

### DIFF
--- a/offline/test/secure-share-session.test.js
+++ b/offline/test/secure-share-session.test.js
@@ -188,9 +188,10 @@ const invariants = [
   ['#4 dmz.js: FILE shares are NOT excluded from the recipient rebind', async () => {
     const dmz = src('service/dmz.js');
     // Anchor precisely to the BINDING block — the one that issues the secure-share
-    // node grant + rebinds bindUid. (An unrelated earlier block computes
-    // ownShareGrant/hasStanding and is intentionally scoped to non-file shares; we
-    // must not false-flag that one.) Walk back from the grant to its controlling
+    // node grant + rebinds bindUid. (An earlier block computes ownShareGrant/
+    // hasStanding; it covers BOTH share kinds — see the standing canary below — so
+    // walking back from the grant must not stop at it.) Walk back from the grant to
+    // its controlling
     // `if (isAuthenticated && user.id ...` and assert that condition does NOT exclude
     // file shares — re-adding `!info.file_nid` here is what re-opened chat-as-creator.
     // Anchor to the grant CALL's unique signature (not the earlier message-check
@@ -227,6 +228,54 @@ const invariants = [
     assert.ok(
       /info\.nid,\s*user\.id,\s*0,\s*\(grantTarget\s*&\s*0b0000011\),\s*'root',\s*'Secure share access'/.test(after),
       "parent-traversal grant must be READ-ONLY (grantTarget & 0b0000011) and NON-INHERITING (assign_via='root')"
+    );
+  }],
+
+  ['standing check covers FILE shares and reads the node memberPriv was measured on', async () => {
+    const dmz = src('service/dmz.js');
+    // memberPriv comes from mfs_access_node(user.id, info.nid) — the shared node for a
+    // folder share, the PARENT for a file share. The standing check must read the
+    // direct grant on THAT SAME node, because the parent-traversal grant above leaves
+    // a file-share recipient a PERSISTENT 'root' grant on the parent. Skipping file
+    // shares here (or reading info.node_id instead of info.nid) makes every LATER file
+    // share in the same folder look like a standing membership → the node grant is
+    // never issued → user_permission on the file stays 0 → mfs_show_node_by's
+    // `privilege > 0` filter drops it → BLANK share (Lexis/Tina prod, 2026-07-28).
+    const standIdx = dmz.indexOf('let hasStanding = memberPriv > 0;');
+    assert.ok(standIdx > 0, 'hasStanding computation not found');
+    const cond = dmz.slice(standIdx, dmz.indexOf('{', standIdx) + 1);
+    assert.ok(
+      !/!info\.file_nid/.test(cond),
+      'the standing check must NOT exclude file shares (re-blanks every later file share in a folder)'
+    );
+    const body = dmz.slice(standIdx, standIdx + 2200);
+    assert.ok(
+      /readDirectGrant\(info\.nid\)/.test(body),
+      'standing must be read on info.nid — the node memberPriv was measured on'
+    );
+    assert.ok(
+      /memberPriv > \(standingIsOwn \? rowPriv\(standing\) : 0\)/.test(body),
+      "standing must discount the recipient's OWN secure-share grant on that node"
+    );
+  }],
+
+  ['permission_get_direct is called (resource, entity) — swapping them makes it inert', async () => {
+    const dmz = src('service/dmz.js');
+    // SP signature is permission_get_direct(_rid /*resource_id*/, _eid /*entity_id*/).
+    // Passing (user.id, node) silently matches NO row (resource_id is never a uid), so
+    // ownShareGrant collapses to 0 and the whole grant-clobber protection turns into a
+    // no-op. Verified against the prod DB: correct order returns the grant row, the
+    // reversed order returns an empty set.
+    const callIdx = dmz.indexOf("'permission_get_direct'");
+    assert.ok(callIdx > 0, 'permission_get_direct call not found');
+    const args = dmz.slice(callIdx, callIdx + 200);
+    assert.ok(
+      /'permission_get_direct',\s*`'\$\{resource_id\}','\$\{user\.id\}'`/.test(args),
+      'permission_get_direct must receive (resource_id, user.id) in that order'
+    );
+    assert.ok(
+      !/`'\$\{user\.id\}','\$\{info\./.test(args),
+      'arguments are reversed — permission_get_direct would match nothing'
     );
   }],
 

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -621,30 +621,49 @@ class __dmz extends Mfs {
     // user_permission() returns a '*' membership BEFORE any node grant, so for a
     // non-member memberPriv EQUALS their own node-grant priv, while a real member's
     // memberPriv EXCEEDS it. Read the directly-stored grant row to compare.
-    // FOLDER shares only (here info.nid === info.node_id); a file share remaps
-    // info.nid to the parent, so this comparison would be cross-node — left to the
-    // existing file-share clamp below. Fail-safe: on any error treat as no direct
-    // grant, which collapses hasStanding to the prior memberPriv>0 behaviour.
+    // The comparison must read the grant on the SAME node memberPriv was measured
+    // on (info.nid above): the shared node itself for a folder share, its PARENT for
+    // a file share (info.nid is remapped to the parent at ~L497). Reading node_id for
+    // a file share would compare cross-node and mis-read a file-share recipient as a
+    // member, because the file-share fix below leaves them a PERSISTENT read-only
+    // 'root' grant on that parent — so every LATER file share in the same folder was
+    // treated as standing, skipped the node grant, and rendered blank (Lexis/Tina
+    // prod report 2026-07-28). Fail-safe: on any error treat as no direct grant,
+    // which collapses hasStanding to the prior memberPriv>0 behaviour.
+    // NOTE permission_get_direct's signature is (resource, entity) — passing them
+    // the other way round silently matches nothing and makes this check inert.
     let ownShareGrant = 0;
     let hasStanding = memberPriv > 0;
-    if (isAuthenticated && user.id && !info.file_nid && info.node_id) {
-      let direct = null;
-      try {
-        direct = toArray(await this.yp.await_proc(
-          'forward_proc', info.hub_id, 'permission_get_direct', `'${user.id}','${info.node_id}'`
-        ))[0] || null;
-      } catch (e) {
-        this.warn('[dmz.login] secure_share permission_get_direct failed:', e && e.message);
-      }
-      const directPriv = direct ? (parseInt(direct.permission, 10) || 0) : 0;
-      const isOwnShareGrant = !!direct &&
-        String(direct.message || '').indexOf('Secure share access') === 0;
-      ownShareGrant = isOwnShareGrant ? directPriv : 0;
+    if (isAuthenticated && user.id && info.nid && info.node_id) {
+      const readDirectGrant = async (resource_id) => {
+        try {
+          return toArray(await this.yp.await_proc(
+            'forward_proc', info.hub_id, 'permission_get_direct', `'${resource_id}','${user.id}'`
+          ))[0] || null;
+        } catch (e) {
+          this.warn('[dmz.login] secure_share permission_get_direct failed:', e && e.message);
+          return null;
+        }
+      };
+      const isShareGrant = (row) => !!row &&
+        String(row.message || '').indexOf('Secure share access') === 0;
+      const rowPriv = (row) => (row ? (parseInt(row.permission, 10) || 0) : 0);
+
       // standing = access from anything OTHER than their own secure-share grant:
       //  - memberPriv exceeds their own grant (a '*' membership wins in user_permission), OR
       //  - a non-secure-share direct row exists (a manual collaborator grant — never touch it).
-      hasStanding = (memberPriv > ownShareGrant) ||
-        (!!direct && !isOwnShareGrant && directPriv > 0);
+      const standing = await readDirectGrant(info.nid);
+      const standingIsOwn = isShareGrant(standing);
+      hasStanding = (memberPriv > (standingIsOwn ? rowPriv(standing) : 0)) ||
+        (!!standing && !standingIsOwn && rowPriv(standing) > 0);
+
+      // UPGRADE-ONLY baseline: the recipient's own prior secure-share privilege on
+      // the SHARED node (=== info.nid for a folder share; the file for a file share),
+      // so opening a lower link after a higher one never downgrades them.
+      const own = String(info.node_id) === String(info.nid)
+        ? standing
+        : await readDirectGrant(info.node_id);
+      if (isShareGrant(own)) ownShareGrant = rowPriv(own);
     }
 
     // Translate the capability set to the privilege bitmask the UI uses for


### PR DESCRIPTION
## Issue (PROD, reported urgent by Lexis 2026-07-28)

A public single-**FILE** share was blank for a **logged-in non-member**, while incognito and real workspace members could view it. Reported by Tina Lala's link in "Marketing Share"; Theo and Duy both reproduced.

Not the earlier file-share 403: the prod log shows `media.show_node_by` **GRANTED** on the file's parent, returning an **empty listing**.

## Root cause — two defects; fixing either alone leaves the bug

1. `memberPriv` is resolved with `mfs_access_node(user.id, info.nid)`. For a file share `info.nid` is remapped to the **parent** folder, while the shared node stays `info.node_id`.
2. The file-share listing fix leaves every recipient a **persistent** read-only `assign_via='root'` grant on that parent (`revoke` only deletes the `(node_id, uid)` row, so it outlives the share).
3. The check that tells a real member from a recipient holding only their **own** secure-share grant was scoped to non-file shares (`!info.file_nid`), so a file share fell back to the raw `memberPriv > 0`.

From a recipient's **second** file share in the same folder onward: `user_permission(uid, parent)` = 3 (a direct row wins) → they look like a standing member → the node grant is skipped → `user_permission(uid, sharedFile)` = 0 (because `parent_permission` maps `assign_via='root'` to 0 for children and halts recursion) → `mfs_show_node_by` drops it at `privilege > 0` → blank. Anonymous stays creator-bound; members win on their `*` row. The **first** file share in a folder always worked, which is why this went unnoticed.

4. Latent: `permission_get_direct`'s signature is `(resource, entity)` but it was called as `(user.id, node_id)` — **swapped**, so it matched no row and the whole grant-clobber protection has been **inert in production**. Verified against the prod DB: correct order returns the grant row, reversed returns an empty set.

## Fix (server only — no schema, no UI)

- Read the direct grant on `info.nid`, the node `memberPriv` was actually measured on. This **equals `node_id` for folder shares, so folder-share decisions are unchanged**, and discount it when it is the recipient's own `Secure share access` grant.
- Correct the argument order to `(resource_id, user.id)`.
- The upgrade-only baseline now reads the **shared node's** own grant, so a lower link no longer downgrades a recipient who already earned more on that node. This cannot resurrect revoked access because `revoke` deletes that grant, and the older higher link would still be openable anyway.

Both branches bind the recipient to their **own** uid (creator binding remains only if the grant fails). The email gate, deny-list check, regsid guard, write guard and the sender-only response strips are untouched. For view/download/chat links the pure-recipient path now stamps the session ceiling, i.e. strictly more restrictive than before.

## Verification

- Regression suite **23/23** in a worktree with deps, including all 13 behavioural cap-guard tests.
- **2 new source-invariant canaries**, each **negative-control verified**: reintroducing either defect drops the suite to 9/10.
- **80-case old-vs-new matrix** driving the real extracted expressions against simulated `user_permission` / `parent_permission` / `mfs_show_node_by` semantics: **0 invariant failures**, 4 cases flip blank → visible. Asserts no creator-bind, standing preserved for members/owners/collaborators, standing principals never granted or ceiling-clamped, no over-grant, no downgrade, no visibility loss, and no sibling leak.
- **Verified on the test endpoint (drumee.in)** with the real A→B repro by the reporter, then confirmed in the DB: the grant row on the second file is now created (priv 7), effective privilege went 0 → 7, the parent grant is correctly masked to read-only 3, and the recipient's privilege on every sibling stays 0.

## Reviewer notes

- `check-source` fails by design here — the head is a hotfix branch, not `test`. The same commit is already on `test` as `610d176`, byte-identical.
- Fixing the swapped arguments also switches the grant-clobber protection back **on** for folder shares, where it has effectively never run in production. The matrix confirms no case loses privilege, but it is worth attention in any pre-cutover regression pass.
- Pre-existing, not addressed here: `revoke` leaves the parent `root` grant behind (harmless once this lands, since it is now correctly read as the recipient's own share grant), and a manual collaborator grant on a shared file is overwritten by the share grant.