### PR TITLE
fix(billing): supersede survives a cross-customer replacement

### DIFF
--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -293,6 +293,18 @@ class __private_payment extends Entity {
       // Deferred cycle switch: tell the webhook to let the replaced
       // subscription run out instead of cancelling it now.
       if (trial_end) metadata.defer = '1';
+      // Name the subscription being replaced EXPLICITLY. The webhook's stale
+      // scan lists the session's customer, but the replaced subscription can
+      // live on a DIFFERENT customer: a TEAM bootstrap subscribes on a
+      // payer-keyed customer (the org doesn't exist yet), while the org's
+      // next checkout uses the org-keyed customer — the scan never saw the
+      // old subscription and it kept charging (live case: CS Team, Team
+      // bootstrap sub still active after the Business upgrade was paid).
+      // Resolved here, before Stripe, from the mirror the caller is looking
+      // at — no webhook-ordering race can stale it.
+      if (current && current.subscription_id) {
+        metadata.supersede_target = current.subscription_id;
+      }
     }
     if (org_bootstrap) {
       metadata.org_ident = org_bootstrap.ident;

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -557,6 +557,21 @@ class __public_stripe_webhook extends Entity {
                     && /^(active|trialing|past_due)$/.test(s.status)
                     && s.metadata && s.metadata.entity_id === entity_id,
                 );
+                // The customer scan cannot see a replaced subscription living
+                // on a DIFFERENT customer — a TEAM bootstrap subscribes on a
+                // payer-keyed customer (no org yet), the org's next checkout
+                // on the org-keyed one. payment.checkout therefore names the
+                // subscription it is replacing (metadata.supersede_target,
+                // resolved from the mirror BEFORE the session was created, so
+                // no webhook ordering can stale it). Add it if the scan
+                // missed it and it is still alive.
+                if (md.supersede_target && md.supersede_target !== subscription_id
+                  && !stale.some((s) => s.id === md.supersede_target)) {
+                  try {
+                    const t = await stripe.subscriptions.retrieve(md.supersede_target);
+                    if (t && /^(active|trialing|past_due)$/.test(t.status)) stale.push(t);
+                  } catch (e9) { /* already gone — nothing to cancel */ }
+                }
                 for (const s of stale) {
                   if (md.defer) {
                     // Deferred cycle switch: the replaced subscription runs to
@@ -699,8 +714,24 @@ class __public_stripe_webhook extends Entity {
                 this.warn(`supersede check failed for ${entity_id}: ${e7.message}`);
               }
             }
+            // Second signal: the entity's mirror. The customer scan cannot see
+            // a replacement on a DIFFERENT customer (TEAM bootstrap subs live
+            // on a payer-keyed customer, the org's later checkouts on the
+            // org-keyed one) — live case: cancelling the leftover bootstrap
+            // sub cleared the Business entitlement the org had just paid for.
+            // By the time WE cancel a superseded subscription its replacement
+            // is paid and mirrored, so a mirror naming another id is a
+            // replacement; the Stripe scan still covers the same-customer
+            // race where the mirror write hasn't landed yet.
+            if (!superseded) {
+              try {
+                const held = await this.yp.await_proc('payment_get_subscription', entity_id);
+                const heldId = held && held.subscription_id;
+                if (heldId && obj.id && heldId !== obj.id) superseded = true;
+              } catch (e10) { /* keep the scan's verdict */ }
+            }
             if (superseded) {
-              this.debug(`ignoring deletion of superseded subscription ${obj.id}; customer ${obj.customer} still holds a live one`);
+              this.debug(`ignoring deletion of superseded subscription ${obj.id}; ${entity_id} holds a newer one`);
               break;
             }
             await this.yp.await_proc('subscription_remove', entity_id, obj.id || '');


### PR DESCRIPTION
TEAM bootstrap subs live on a **payer-keyed** Stripe customer; the org's later checkouts on the **org-keyed** one. Both supersede passes scanned a single customer, so a bootstrap-era subscription escaped them — live case (CS Team): the bootstrap Team sub **kept charging** after the Business upgrade was paid, and cancelling it later tripped the deletion path into wiping the Business entitlement.

- `payment.checkout` now names the replaced subscription (`metadata.supersede_target`, resolved from the mirror before the session exists — race-free); the webhook cancels it even when the customer scan can't see it.
- The deletion guard gains a second signal: mirror pointing at another sub id ⇒ replacement (Stripe scan still covers the same-customer race).

Verified on stage with the real account-2 profile (personal pro + bootstrap team + business upgrade): $99 paid, Payment Success modal, orphan cancelled, entitlement business/1TB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)