### PR TITLE
Secure share: stop a recipient's own grant from marking them a member

### DIFF
--- a/offline/test/secure-share-session.test.js
+++ b/offline/test/secure-share-session.test.js
@@ -302,6 +302,28 @@ const invariants = [
     );
   }],
 
+  ['dmz.js: is_member is derived from hasStanding, never from raw memberPriv', async () => {
+    const dmz = src('service/dmz.js');
+    // is_member drives the recipient UI's "limited access / Request access" banner.
+    // Deriving it from the raw memberPriv (the EFFECTIVE privilege) reports any
+    // recipient holding their OWN prior 'Secure share access' grant as a workspace
+    // member, which suppressed that banner permanently for them (prod 2026-07-29).
+    // The authoritative notion is hasStanding, which discounts the recipient's own
+    // grant. Assert the final assignment reads hasStanding and that it comes AFTER
+    // hasStanding has been resolved, so a reorder can't silently restore the bug.
+    assert.ok(
+      /is_member\s*=\s*hasStanding\s*\?\s*1\s*:\s*0/.test(dmz),
+      'is_member must be derived from hasStanding'
+    );
+    const standingIdx = dmz.indexOf('hasStanding = (memberPriv >');
+    const assignIdx = dmz.search(/is_member\s*=\s*hasStanding/);
+    assert.ok(standingIdx > 0, 'hasStanding resolution not found');
+    assert.ok(
+      assignIdx > standingIdx,
+      'is_member must be assigned AFTER hasStanding is resolved'
+    );
+  }],
+
   ['neutral host: page.js isolates share.<main_domain> onto a host-scoped cookie', async () => {
     const page = src('client/page.js');
     assert.ok(/isNeutralShareHost/.test(page), 'neutral-host detection missing');

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -666,6 +666,22 @@ class __dmz extends Mfs {
       if (isShareGrant(own)) ownShareGrant = rowPriv(own);
     }
 
+    // is_member must mean "a TRUE standing principal", which is exactly hasStanding —
+    // NOT the raw memberPriv > 0 it was first derived from above. memberPriv is the
+    // EFFECTIVE privilege, so for a non-member it resolves to the recipient's OWN prior
+    // secure-share grant: anyone who had ever opened any share in this workspace was
+    // reported as a member, and the recipient UI therefore suppressed the "limited
+    // access / Request access" banner for them permanently (Duy, prod 2026-07-29 —
+    // duinguyen88 had zero '*' membership rows yet three leftover 'Secure share access'
+    // grants, so user_permission returned 7 and is_member came back 1).
+    // Same defect class the hasStanding block above was introduced to fix; is_member
+    // simply never moved over to it. Real members keep is_member=1 (a '*' row makes
+    // memberPriv exceed their own grant) and so do manual collaborators (a non-share
+    // direct row); the creator is excluded separately via is_owner. is_member has a
+    // single consumer — the banner condition in the recipient UI — and can only ever
+    // become MORE restrictive here, so it cannot grant capability or affect any gate.
+    is_member = hasStanding ? 1 : 0;
+
     // Translate the capability set to the privilege bitmask the UI uses for
     // show/hide decisions (_K.privilege in lex/constants.js: read=3, download=7,
     // write=15 — CUMULATIVE masks). We OR each capability's cumulative mask onto


### PR DESCRIPTION
A recipient could never see the "limited access / Request access" banner once they had opened any share in a workspace.

## Cause

`is_member` drives that banner in the recipient UI. It was derived from the raw `memberPriv` — `mfs_access_node`, i.e. the **effective** `user_permission` — which for a non-member resolves to **that recipient's own prior `Secure share access` grant**. So anyone who had ever opened any share in the workspace was reported as a workspace member, and the banner was suppressed for them permanently. They had no way to request more access.

Verified on the prod DB: `duinguyen88` has **zero `*` membership rows** in the affected workspace (genuinely not a member) yet holds three leftover `Secure share access` grants, so `user_permission` returned 7 and `is_member` came back 1.

The authoritative notion already exists 30 lines below — `hasStanding`, which discounts the recipient's own share grant via `readDirectGrant`. `is_member` simply never moved over to it. This is the same defect class that block was introduced to fix (#133).

## Fix

One line, after the standing block:

```js
is_member = hasStanding ? 1 : 0;
```

## Why this is safe

- `is_member` has **exactly one consumer in the whole codebase** — the banner condition in the recipient UI. Zero server consumers (`grep -rn is_member service/` finds only the derivation and the response field). It cannot grant capability, gate anything, or touch a session, ceiling or grant decision.
- It can only ever become **more restrictive** here, so no one gains access.
- Real members keep `is_member=1` — a `*` row makes `memberPriv` exceed their own grant. Manual collaborators keep it too (a non-share direct row). The creator is excluded separately via `is_owner`.
- If the standing block is skipped (missing `info.nid`/`info.node_id`, or an unauthenticated viewer), `hasStanding` retains its `memberPriv > 0` initialisation, so the result is **byte-identical to the previous behaviour**.
- Line 608's earlier `if (memberPriv > 0) is_member = 1` is left untouched; nothing reads `is_member` between it and the new assignment (only the response at ~920), so it is harmlessly superseded.

## Verification

- Full regression suite **24/24** in a worktree with deps, including all 13 behavioural cap-guard tests.
- **New source-invariant canary**, negative-control verified: it asserts `is_member` is derived from `hasStanding` **and** assigned after `hasStanding` is resolved, so a later reorder cannot silently restore the bug. Reintroducing the defect drops the suite to 10/11 with that exact canary failing.
- **12-case matrix** driving the real extracted expressions plus the real banner condition, over every viewer class: 12/12 with four invariants, including "`is_member` may never go 0 → 1" (it can never elevate). Negative-controlled with the old expression → 9/12, exit 1.
- Verified on the test endpoint (drumee.in) by the reporter.

## Reviewer notes

- `check-source` fails by design here: the head is a hotfix branch, not `test`. The same change is on `test` as `d2b89f7`, patch-content identical.
- User-visible on deploy: recipients currently mislabelled as members — including the nine identified in the earlier blast-radius sweep — will start seeing the banner. That is the intended outcome.