### PR TITLE
fix(billing): mirror the real subscription status on checkout events

### DIFF
--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -501,7 +501,14 @@ class __public_stripe_webhook extends Entity {
             // handler mid-flight — before its payment receipt email — which is
             // why a Pro→Team upgrade paid fine but never emailed. A completed
             // session means the subscription is live: mirror 'active'.
-            const status = obj.cancel_at_period_end ? 'canceled'
+            // For a checkout SESSION prefer the retrieved subscription's real
+            // status over a hardcoded 'active': a deferred cycle switch
+            // creates the new subscription TRIALING (it starts billing when
+            // the old cycle lapses), and stamping 'active' here erased that —
+            // the UI could not tell "running now" from "starts later"
+            // (tester 2026-07-30: banner said "renews" for a plan that had
+            // not started). `sub_status` is resolved below alongside items.
+            let status = obj.cancel_at_period_end ? 'canceled'
               : (obj.object === 'checkout.session' ? 'active' : (obj.status || 'active'));
             const entity_type = md.entity_type || 'user';
             // Line items: the subscription object carries them; a checkout.session
@@ -513,6 +520,13 @@ class __public_stripe_webhook extends Entity {
                 const s = await stripe.subscriptions.retrieve(subscription_id);
                 items = (s.items && s.items.data) || [];
                 period_end = period_end || s.current_period_end || (items[0] && items[0].current_period_end) || 0;
+                // Real subscription status for the session event (see the
+                // status declaration above). trial_end doubles as period_end
+                // for a trialing sub: it IS the date the new cycle starts.
+                if (obj.object === 'checkout.session' && s.status && !obj.cancel_at_period_end) {
+                  status = s.status;
+                  if (s.status === 'trialing' && s.trial_end) period_end = s.trial_end;
+                }
               } catch (e3) { items = []; }
             }
             // SUPERSEDE, same entity. A subscriber who deliberately changed


### PR DESCRIPTION
Tester feedback on the deferred cycle switch: the hardcoded `active` for checkout sessions erased the TRIALING state of a deferred subscription, so the UI said *renews on* for a plan that hadn't started. The item-resolving subscription retrieve now supplies the real status; `trial_end` becomes `period_end` for trialing subs (it is the start date). Pairs with ui-team `fix/defer-cycle-ux` (banner + credited-days note).

Verified on stage: banner reads **Your Monthly billing starts on Jul 30, 2027** after a real year→month defer ($0 checkout, invoice CTYOW5PZ-0022).

🤖 Generated with [Claude Code](https://claude.com/claude-code)