### PR TITLE
feat(promo): LAUNCH30 claim service + expiry worker

### DIFF
--- a/acl/promo.json
+++ b/acl/promo.json
@@ -1,0 +1,50 @@
+{
+  "services": {
+    "get_state": {
+      "doc": "The caller's own LAUNCH30 promo state — eligible_unseen | eligible_seen | claimed_active | claimed_expired | ineligible. Read-only, recomputed every call.",
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {}
+    },
+    "dismiss": {
+      "doc": "Record that Modal A was shown/dismissed on this surface, once, forever (server flag, not localStorage).",
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {
+        "surface": {
+          "type": "string",
+          "required": true,
+          "doc": "'home' | 'billing'"
+        }
+      },
+      "errors": [
+        { "code": "SURFACE_INVALID", "description": "surface must be 'home' or 'billing'" }
+      ]
+    },
+    "claim": {
+      "doc": "Claim the 1-month free Team trial: no card, no Stripe object. Bootstraps (or reuses) the caller's organisation, then grants a Team-plan yp.quota row for 30 days.",
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "params": {
+        "source_surface": {
+          "type": "string",
+          "required": false,
+          "doc": "telemetry only: 'home' | 'billing_modal' | 'billing_pill'"
+        }
+      },
+      "errors": [
+        { "code": "NOT_ELIGIBLE", "description": "not on Free, or already inside another organisation" },
+        { "code": "PROVISION_FAILED", "description": "org bootstrap failed (see org_provision)" }
+      ]
+    }
+  },
+  "modules": {
+    "private": "service/private/promo"
+  }
+}

--- a/offline/workers/promoExpiryWorker.js
+++ b/offline/workers/promoExpiryWorker.js
@@ -1,0 +1,119 @@
+/**
+ * LAUNCH30 Promo Expiry Worker
+ *
+ * Reverts a claimed LAUNCH30 trial (yp.quota source='promo-launch30') once
+ * its 30 days pass. Mirrors the exact fall-back an org's Stripe cancellation
+ * already produces: payment_clear_entitlement DELETEs the org-keyed quota
+ * row, so every member falls to their own per-user free tier (tier-4) rather
+ * than a locked-out ('free','org') row. reward_grant_storage re-materialising
+ * inside that same proc does not fire here — the claimant has no
+ * yp.reward_claim completion — so the net effect for a LAUNCH30 org is
+ * exactly "back to Free".
+ *
+ * Model: mirrors reminderWorker.js — plain setTimeout self-rescheduler (the
+ * runtime ships Bull, not `cron`), short interval since trials expire at an
+ * arbitrary time of day, not at midnight.
+ *
+ * Env:
+ *   PROMO_EXPIRY_INTERVAL_SEC  poll cadence (default 900 = 15 min)
+ */
+
+const { Mariadb } = require('@drumee/server-essentials');
+
+const WORKER_NAME = process.env.WORKER_NAME || 'promo-expiry-worker-1';
+const INTERVAL_MS = (parseInt(process.env.PROMO_EXPIRY_INTERVAL_SEC, 10) || 900) * 1000;
+
+console.log(`[PromoExpiryWorker] Starting worker: ${WORKER_NAME}`);
+console.log(`[PromoExpiryWorker] Poll interval: ${INTERVAL_MS / 1000}s`);
+
+let yp;
+
+function asArray(x) {
+  if (Array.isArray(x)) return x;
+  return x == null ? [] : [x];
+}
+
+async function initialize() {
+  yp = new Mariadb({ name: 'yp' });
+  console.log('[PromoExpiryWorker] Database connected');
+}
+
+async function expireOne(row) {
+  const { payer_id, org_id } = row;
+  try {
+    // Same revert path an org's Stripe cancel takes — see the module doc.
+    await yp.await_proc('payment_clear_entitlement', org_id);
+    await yp.await_proc('promo_launch30_mark_expired', payer_id);
+    console.log(`[PromoExpiryWorker] expired promo for payer=${payer_id} org=${org_id}`);
+    return true;
+  } catch (error) {
+    console.error(`[PromoExpiryWorker] failed to expire payer=${payer_id} org=${org_id}:`, error.message);
+    return false;
+  }
+}
+
+async function runExpiryJob() {
+  try {
+    const due = asArray(await yp.await_proc('promo_launch30_due'));
+    if (!due.length) return;
+    console.log(`[PromoExpiryWorker] ${due.length} trial(s) due for expiry`);
+    let expired = 0;
+    for (const row of due) {
+      if (await expireOne(row)) expired++;
+    }
+    console.log(`[PromoExpiryWorker] done — ${expired}/${due.length} expired`);
+  } catch (error) {
+    console.error('[PromoExpiryWorker] Job failed:', error);
+  }
+}
+
+function scheduleNext() {
+  setTimeout(async () => {
+    try {
+      await runExpiryJob();
+    } finally {
+      scheduleNext();
+    }
+  }, INTERVAL_MS);
+}
+
+async function startWorker() {
+  await initialize();
+  await runExpiryJob(); // catch up immediately on boot, then settle into the interval
+  scheduleNext();
+  process.on('SIGUSR2', async () => {
+    console.log('[PromoExpiryWorker] SIGUSR2 — manual run');
+    await runExpiryJob();
+  });
+  console.log('[PromoExpiryWorker] Worker started. Manual run: kill -USR2', process.pid);
+}
+
+async function shutdown() {
+  console.log('[PromoExpiryWorker] Shutting down...');
+  try {
+    if (yp && yp.connection) await yp.end();
+  } catch (error) {
+    console.error('[PromoExpiryWorker] Shutdown error:', error.message);
+  }
+  process.exit(0);
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+process.on('uncaughtException', (error) => {
+  console.error('[PromoExpiryWorker] Uncaught exception:', error);
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+  console.error('[PromoExpiryWorker] Unhandled rejection:', reason);
+  process.exit(1);
+});
+
+startWorker().catch((error) => {
+  console.error('[PromoExpiryWorker] Failed to start worker:', error);
+  process.exit(1);
+});
+
+console.log('[PromoExpiryWorker] Worker process started (PID:', process.pid, ')');
+
+module.exports = { runExpiryJob };

--- a/service/private/promo.js
+++ b/service/private/promo.js
@@ -1,0 +1,165 @@
+// service/private/promo.js
+//
+// LAUNCH30 — "Start your 1-month Team Plan today". Design doc 2026-07-30:
+// claimed with NO credit card and NO Stripe object whatsoever (no customer,
+// no payment method, no subscription) — a raw yp.quota entitlement, separate
+// from the Stripe-backed subscription system in payment.js/stripe_webhook.js.
+//
+// Eligibility is re-checked here on every call — the client's job is to
+// render state and call claim, never to decide it (same rule as the promo
+// design doc's API contract).
+const { Entity } = require('@drumee/server-core');
+const { isEmpty } = require('@drumee/server-essentials');
+
+const TRIAL_DAYS = 30;
+
+function slugify(s) {
+  return String(s || '')
+    .toLowerCase()
+    .normalize('NFKD').replace(/[̀-ͯ]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+}
+
+class __private_promo extends Entity {
+  // The caller's own LAUNCH30 state. Called on app boot (home) and on
+  // Billing page mount — read-only, computes eligibility fresh every time
+  // rather than trusting a cached client flag.
+  async get_state() {
+    const row = await this._row();
+    if (row && row.status === 'claimed') {
+      const expired = ~~row.trial_ends_at > 0 && ~~row.trial_ends_at < Math.floor(Date.now() / 1000);
+      return this.output.data({
+        state: expired ? 'claimed_expired' : 'claimed_active',
+        trial_ends_at: row.trial_ends_at,
+        home_seen_at: row.home_seen_at,
+        billing_seen_at: row.billing_seen_at,
+      });
+    }
+    if (row && row.status === 'expired') {
+      return this.output.data({
+        state: 'claimed_expired',
+        trial_ends_at: row.trial_ends_at,
+        home_seen_at: row.home_seen_at,
+        billing_seen_at: row.billing_seen_at,
+      });
+    }
+
+    const eligible = await this._isEligible();
+    const seen = !!(row && (row.home_seen_at || row.billing_seen_at));
+    return this.output.data({
+      state: eligible ? (seen ? 'eligible_seen' : 'eligible_unseen') : 'ineligible',
+      home_seen_at: row && row.home_seen_at,
+      billing_seen_at: row && row.billing_seen_at,
+    });
+  }
+
+  // Records that `surface` ('home' | 'billing') has shown Modal A to this
+  // account, once, forever (server flag — see promo_launch30_mark_seen).
+  async dismiss() {
+    const surface = String(this.input.use('surface', '') || '');
+    if (surface !== 'home' && surface !== 'billing') {
+      return this.output.status('SURFACE_INVALID');
+    }
+    await this.yp.await_proc('promo_launch30_mark_seen', this.uid, surface);
+    this.output.json({ status: 'OK' });
+  }
+
+  // Claim: bootstrap (or reuse) the caller's organisation, then grant the
+  // Team entitlement for TRIAL_DAYS with no Stripe object anywhere.
+  // Idempotent — a retried call after a partial failure (org created, grant
+  // not yet written) completes rather than double-provisions or double-grants.
+  async claim() {
+    if (!(await this._isEligible())) {
+      return this.output.status('NOT_ELIGIBLE');
+    }
+    const existing = await this._row();
+    if (existing && existing.status !== 'unclaimed') {
+      // Already claimed/expired by a previous call — return that state
+      // rather than erroring; the source_surface param is telemetry only.
+      return this.output.json({ status: 'OK', already: 1, ...existing });
+    }
+
+    const org = await this._provisionOrg();
+    if (!org || org.error) {
+      return this.output.status(org && org.error ? org.error : 'PROVISION_FAILED');
+    }
+
+    const res = await this.yp.await_proc(
+      'promo_launch30_grant', this.uid, org.id, org.domain_id,
+    );
+    const row = Array.isArray(res) ? res[0] : res;
+
+    // Same event the Stripe webhook emits on a real plan change — the
+    // billing widget's existing onWsMessage('payment.plan_updated') handler
+    // already calls Visitor.respawn + re-renders, so the claimant's already-
+    // open session reflects Team live, no reload (mirrors the admin-access
+    // grant fix 2026-07-30 — every entitlement change needs this, not just
+    // the ones that happen to route through the webhook).
+    try {
+      let quota = await this.yp.await_func('get_quota', this.uid);
+      if (typeof quota === 'string') { try { quota = JSON.parse(quota); } catch (e) { quota = undefined; } }
+      await this.notify_user(this.uid, {
+        service: 'payment.plan_updated',
+        plan: 'team',
+        status: 'trialing',
+        period_end: row && row.trial_ends_at,
+        quota,
+      });
+    } catch (e) { /* best-effort */ }
+
+    this.output.json({
+      status: 'OK',
+      org_id: org.id,
+      domain_id: org.domain_id,
+      trial_ends_at: row && row.trial_ends_at,
+    });
+  }
+
+  async _row() {
+    const res = await this.yp.await_proc('promo_launch30_get_state', this.uid);
+    return Array.isArray(res) ? res[0] : res;
+  }
+
+  // plan=free (never bought/traded up before) AND not already living in
+  // someone else's org domain — same guard payment.js's org-bootstrap ident
+  // validation uses (_validateOrgIdent: "a payer already inside another
+  // domain cannot bootstrap a second organisation").
+  async _isEligible() {
+    if (~~this.user.domain_id() > 1) return false;
+    try {
+      let q = await this.yp.await_func('get_quota', this.uid);
+      if (typeof q === 'string') { try { q = JSON.parse(q); } catch (e) { q = null; } }
+      const plan = q && (q.plan || q.category);
+      return !plan || plan === 'free';
+    } catch (e) {
+      return false;
+    }
+  }
+
+  // Auto-generates an org name/ident — the whole point of LAUNCH30 is one
+  // click, no form. Retries the ident on collision (ident_exists covers
+  // entity + organisation + vhost/domain — see org_provision's own guard —
+  // a race there still surfaces as org.error and the caller can retry).
+  async _provisionOrg() {
+    const fullname = this.user.get('fullname') || '';
+    const email = this.user.get('email') || '';
+    const localPart = email.split('@')[0] || 'team';
+    const base = slugify(localPart) || 'team';
+    const name = fullname ? `${fullname}'s Team` : 'My Team';
+
+    let ident = base;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const taken = await this.yp.await_proc('ident_exists', ident);
+      const isTaken = Array.isArray(taken) ? taken.length > 0 : !isEmpty(taken);
+      if (!isTaken) break;
+      ident = `${base}-${Math.floor(1000 + Math.random() * 9000)}`;
+    }
+
+    const res = await this.yp.await_proc('org_provision', this.uid, name, ident);
+    return Array.isArray(res) ? res[0] : res;
+  }
+}
+
+module.exports = __private_promo;


### PR DESCRIPTION
server-team half of LAUNCH30 ("Start your 1-month Team Plan today") — a free 30-day Team trial with **no card and no Stripe object at all**.

- `service/private/promo.js` — `get_state` / `dismiss` / `claim`. Eligibility is re-checked server-side on every call (plan=free, not already in an org) — the client renders state and calls claim, never decides it. `claim` bootstraps (or reuses) the caller's organisation via `org_provision`, then grants via `promo_launch30_grant` (companion schemas PR) — both idempotent. Emits the same `payment.plan_updated` WS event the Stripe webhook uses, so the claimant's already-open session reflects Team live (no reload).
- `offline/workers/promoExpiryWorker.js` — polls `promo_launch30_due` every 15 min and reverts an expired trial through `payment_clear_entitlement`, the same path an org's Stripe cancel takes.

Verified end-to-end on stage with a brand-new real signup: eligibility gate, claim (org + `yp.quota` plan=team/disk=100GB/seat=10/source=promo-launch30), live WS refresh, Admin Console reflecting the new plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)