### PR TITLE
release: file-thread access revocation and recovery (server)

### DIFF
--- a/acl/channel.json
+++ b/acl/channel.json
@@ -960,7 +960,7 @@
       }
     },
     "file_thread_info": {
-      "doc": "Lookup the per-file chat thread for a file. Accepts file_nid or file_thread_id. Returns current file metadata plus, when a thread exists, its summary (reply_count, last_message_id, mtime). Does NOT create a thread — opening a file chat is side-effect free. File read permission is validated in service code via mfs_access_node.",
+      "doc": "Lookup a file chat through the canonical file-thread resolver. Dual selectors must agree; the backing media must be active and currently readable through mfs_access_node.",
       "scope": "hub",
       "permission": { "src": "read" },
       "params": {
@@ -969,7 +969,10 @@
       },
       "returns": { "type": "object", "doc": "File metadata and, if present, thread summary with exists_thread flag" },
       "errors": [
-        { "code": "NOT_FOUND", "message": "File not found or not accessible", "http_status": 404 }
+        { "code": "INVALID_SELECTOR", "message": "Supplied file and thread selectors conflict", "http_status": 400 },
+        { "code": "NOT_FOUND", "message": "File thread was not found", "http_status": 404 },
+        { "code": "SCOPE_GONE", "message": "Backing file is no longer live in this hub", "http_status": 410 },
+        { "code": "NO_PERMISSION", "message": "Caller lacks current read permission on the file", "http_status": 403 }
       ]
     },
     "file_thread_messages": {
@@ -983,7 +986,11 @@
         "page": { "type": "number", "required": false, "doc": "Page number for pagination (default 1)" }
       },
       "returns": { "type": "array", "doc": "Enriched file-thread child messages" },
-      "errors": []
+      "errors": [
+        { "code": "INVALID_SELECTOR", "message": "Supplied file and thread selectors conflict", "http_status": 400 },
+        { "code": "SCOPE_GONE", "message": "Backing file is no longer live in this hub", "http_status": 410 },
+        { "code": "NO_PERMISSION", "message": "Caller lacks current read permission on the file", "http_status": 403 }
+      ]
     },
     "file_thread_post": {
       "doc": "Post a message into a file chat thread. Creates the thread and the folder-visible file.thread root card atomically on the first message; later sends reuse the same thread. Validates the file exists, is not a folder/hub, is active, and the caller has chat permission. Derives the folder from the file current parent, not from the client. Supports attachments, folder_attachment promotion, mentions, and reply-to thread_id. Broadcasts the child message and, when new, the root card.",
@@ -1002,11 +1009,13 @@
       "returns": { "type": "object", "doc": "Posted child message plus file_thread summary (file_thread_id, root_message_id, is_new)" },
       "errors": [
         { "code": "INVALID_FILE", "message": "file_nid is missing, not a file, is a folder/hub, or deleted", "http_status": 400 },
+        { "code": "INVALID_REPLY_SCOPE", "message": "Reply target is not in the canonical file thread", "http_status": 400 },
+        { "code": "SCOPE_GONE", "message": "Backing file is no longer live in this hub", "http_status": 410 },
         { "code": "NO_PERMISSION", "message": "Caller lacks read/chat permission on the file or its folder", "http_status": 403 }
       ]
     },
     "file_thread_list_by_folder": {
-      "doc": "List existing file-thread chats for files that are current direct children of a folder. Follows media.parent_id, so a moved file surfaces only under its current parent. Files without a thread never appear.",
+      "doc": "List existing file-thread chats for current direct children of a folder. Each row is independently filtered by live media state and the caller current file permission.",
       "scope": "hub",
       "permission": { "src": "read" },
       "params": {
@@ -1018,7 +1027,7 @@
       "errors": []
     },
     "file_thread_acknowledge": {
-      "doc": "Mark a single file thread seen up to a message for the caller, scoped to that thread. Does not affect sibling folder/workspace read state. Broadcasts the acknowledgement to other participants.",
+      "doc": "Mark a canonical file thread seen up to a message after validating the message/thread pair and current file access. Broadcasts an acknowledgement DTO without message content.",
       "scope": "hub",
       "permission": { "src": "read" },
       "params": {
@@ -1026,8 +1035,12 @@
         "message_id": { "type": "string", "required": false, "doc": "Message ID up to which the thread is marked seen" },
         "socket_id": { "type": "string", "required": true, "doc": "Caller WebSocket socket ID, used to exclude the caller from broadcast recipients" }
       },
-      "returns": { "type": "object", "doc": "Acknowledgement result from channel_file_thread_read_messages" },
-      "errors": []
+      "returns": { "type": "object", "doc": "Acknowledgement DTO with message_id, canonical file_thread_id, reader_id, is_readed, and is_seen" },
+      "errors": [
+        { "code": "INVALID_SELECTOR", "message": "Message and thread selectors do not identify the same file thread", "http_status": 400 },
+        { "code": "SCOPE_GONE", "message": "Backing file is no longer live in this hub", "http_status": 410 },
+        { "code": "NO_PERMISSION", "message": "Caller lacks current read permission on the file", "http_status": 403 }
+      ]
     },
     "export_scope": {
       "doc": "Get the export scope for a folder subtree: message count + active file threads (with filename and containing folder) under the given folder. Defaults to the whole hub when nid is omitted.",

--- a/acl/dmz.json
+++ b/acl/dmz.json
@@ -18,7 +18,10 @@
         "status": {
           "type": "string",
           "doc": "Present only when an error condition is detected. WRONG_TICKET when the token does not exist; REQUIRED_PASSWORD when the share requires password authentication.",
-          "enum": ["WRONG_TICKET", "REQUIRED_PASSWORD"]
+          "enum": [
+            "WRONG_TICKET",
+            "REQUIRED_PASSWORD"
+          ]
         },
         "guest_id": {
           "type": "string",
@@ -68,7 +71,12 @@
         "status": {
           "type": "string",
           "doc": "Authentication status. TICKET_INVALID when the token does not exist; REQUIRED_PASSWORD when a password is needed; WRONG_PASSWORD when the submitted password is incorrect; TICKET_OK on success.",
-          "enum": ["TICKET_INVALID", "REQUIRED_PASSWORD", "WRONG_PASSWORD", "TICKET_OK"]
+          "enum": [
+            "TICKET_INVALID",
+            "REQUIRED_PASSWORD",
+            "WRONG_PASSWORD",
+            "TICKET_OK"
+          ]
         },
         "uid": {
           "type": "string",
@@ -153,14 +161,36 @@
         "fast_check": "public-api"
       },
       "params": {
-        "token":           { "type": "string", "required": true,  "doc": "Secure share token" },
-        "email":           { "type": "string", "required": true,  "doc": "Requester email address" },
-        "requested_level": { "type": "string", "required": true,  "doc": "can_download, can_chat, or can_edit" },
-        "message":         { "type": "string", "required": false, "doc": "Optional message to the share owner" }
+        "token": {
+          "type": "string",
+          "required": true,
+          "doc": "Secure share token"
+        },
+        "email": {
+          "type": "string",
+          "required": true,
+          "doc": "Requester email address"
+        },
+        "requested_level": {
+          "type": "string",
+          "required": true,
+          "doc": "can_download, can_chat, or can_edit"
+        },
+        "message": {
+          "type": "string",
+          "required": false,
+          "doc": "Optional message to the share owner"
+        }
       },
       "returns": {
-        "status":     { "type": "string", "doc": "REQUEST_SENT, INVALID_TOKEN, or INVALID_LEVEL" },
-        "request_id": { "type": "string", "doc": "ID of the created or existing pending request" }
+        "status": {
+          "type": "string",
+          "doc": "REQUEST_SENT, INVALID_TOKEN, or INVALID_LEVEL"
+        },
+        "request_id": {
+          "type": "string",
+          "doc": "ID of the created or existing pending request"
+        }
       }
     },
     "signup": {
@@ -190,7 +220,12 @@
         "status": {
           "type": "string",
           "doc": "Error status. Present only when signup cannot proceed.",
-          "enum": ["WRONG_TICKET", "REQUIRED_PASSWORD", "EMAIL_EXIST", "FACTORY_FAILED"]
+          "enum": [
+            "WRONG_TICKET",
+            "REQUIRED_PASSWORD",
+            "EMAIL_EXIST",
+            "FACTORY_FAILED"
+          ]
         }
       },
       "errors": [
@@ -200,6 +235,60 @@
           "http_status": 400
         }
       ]
+    },
+    "list_by_token": {
+      "doc": "Read-only listing of a secure share's contents, authorised by the TOKEN alone. Exists because dmz.login refuses to bind a share identity onto a main-domain session (regsid guard), so a page served from the main domain can never obtain the grant media.show_node_by needs. This never touches the caller's session: no cookie_touch, no grant, no identity change. The listing target is derived from the token, never from client input. Refuses any share that is not plainly open — revoked, expired, invalid, locked, password-gated or email-gated all return a status and no items, because this endpoint performs no gate. A file share lists its parent folder hard-filtered to that file. Privileges are the anonymous guest's, clamped to the share's capabilities; sender-only fields are never echoed.",
+      "scope": "hub",
+      "permission": {
+        "src": "anonymous",
+        "fast_check": "public-api"
+      },
+      "params": {
+        "token": {
+          "type": "string",
+          "required": true,
+          "doc": "Secure-share token; the sole authority for what may be listed"
+        },
+        "page": {
+          "type": "number",
+          "required": false,
+          "default": 1,
+          "min": 1,
+          "doc": "Page number"
+        },
+        "with_posters": {
+          "type": "boolean",
+          "required": false,
+          "default": false,
+          "doc": "Ask for inlined preview images. Off by default because a single video poster outweighs the whole rest of the reply; callers fetch the listing first, paint it, then re-ask with this set and upgrade the tiles in place."
+        }
+      },
+      "returns": {
+        "status": {
+          "type": "string",
+          "doc": "TICKET_OK, or TICKET_INVALID / TICKET_REVOKED / TICKET_EXPIRED / TICKET_LOCKED / REQUIRED_PASSWORD / REQUIRED_EMAIL when refused"
+        },
+        "title": {
+          "type": "string",
+          "doc": "Shared workspace name"
+        },
+        "nid": {
+          "type": "string",
+          "doc": "Folder that was listed"
+        },
+        "hub_id": {
+          "type": "string",
+          "doc": "Share's content hub"
+        },
+        "items": {
+          "type": "array",
+          "doc": "nid, filename, ext, ftype, filetype, mimetype, filesize, ctime, mtime, privilege, and poster when one already exists"
+        },
+        "poster": {
+          "type": "string",
+          "doc": "Per-item: the file's ALREADY-RENDERED preview inlined as a data URI (vignette, or thumb for pdf/office, or the source for a vector). Inline rather than a URL because media.<format> authorises against the caller's session, which an anonymous main-domain visitor cannot satisfy; sending the bytes through this token-gated call opens no second anonymous route. Never generated on demand, so an anonymous caller cannot spend server CPU. Capped at 192KB per file and 768KB per response; absent when the file has no rendered preview, is over budget, or the share does not grant read."
+        }
+      }
     }
   },
   "modules": {

--- a/acl/dmz.json
+++ b/acl/dmz.json
@@ -289,6 +289,42 @@
           "doc": "Per-item: the file's ALREADY-RENDERED preview inlined as a data URI (vignette, or thumb for pdf/office, or the source for a vector). Inline rather than a URL because media.<format> authorises against the caller's session, which an anonymous main-domain visitor cannot satisfy; sending the bytes through this token-gated call opens no second anonymous route. Never generated on demand, so an anonymous caller cannot spend server CPU. Capped at 192KB per file and 768KB per response; absent when the file has no rendered preview, is over budget, or the share does not grant read."
         }
       }
+    },
+    "chat_by_token": {
+      "doc": "Read-only workspace chat for a share, authorised by the TOKEN alone. Companion to list_by_token and exists for the same reason: channel.messages is scope hub / src read, so its ACL resolves an acl_check grant against the caller's session, which an anonymous main-domain visitor cannot hold. Never touches the caller's session. Messages are filtered to the SHARED node via metadata._scope_nid, because a hub's channel table holds every folder's conversation and an unfiltered read would leak the chat of folders that were never shared. Legacy rows with no _scope_nid are DROPPED here, unlike in-app where they fall back to appearing everywhere. Refuses any share that is not plainly open. Author email and the delivery/seen maps are never echoed.",
+      "scope": "hub",
+      "permission": {
+        "src": "anonymous",
+        "fast_check": "public-api"
+      },
+      "params": {
+        "token": {
+          "type": "string",
+          "required": true,
+          "doc": "Secure-share token; the sole authority for what may be read"
+        },
+        "page": {
+          "type": "number",
+          "required": false,
+          "default": 1,
+          "min": 1,
+          "doc": "Page number"
+        }
+      },
+      "returns": {
+        "status": {
+          "type": "string",
+          "doc": "TICKET_OK, or TICKET_INVALID / TICKET_REVOKED / TICKET_EXPIRED / TICKET_LOCKED / REQUIRED_PASSWORD / REQUIRED_EMAIL when refused"
+        },
+        "nid": {
+          "type": "string",
+          "doc": "Node the conversation is scoped to"
+        },
+        "messages": {
+          "type": "array",
+          "doc": "message_id, author_id, author (display name only), message, ctime, is_reply"
+        }
+      }
     }
   },
   "modules": {

--- a/acl/media.json
+++ b/acl/media.json
@@ -1533,6 +1533,26 @@
       },
       "method": "workspace_move"
     },
+    "move_cross_hub": {
+      "scope": "hub",
+      "permission": {
+        "src": "write"
+      },
+      "log": true,
+      "doc": "Server-owned single-file cross-hub move with durable lineage and retry state; client moved_in and lineage metadata are ignored.",
+      "params": {
+        "nid": "Source file id for a new move; optional when resuming by operation_id",
+        "recipient_id": "Single destination hub id",
+        "pid": "Destination folder id",
+        "operation_id": "Opaque server-issued id used only to resume or replay an existing move"
+      },
+      "returns": {
+        "operation_id": "Server-issued operation id",
+        "lineage_id": "Server-issued file-thread lineage id",
+        "state": "Durable saga state",
+        "access_revision": "Monotonic lineage access revision"
+      }
+    },
     "node_info": {
       "scope": "hub",
       "permission": {

--- a/acl/secure_share.json
+++ b/acl/secure_share.json
@@ -169,6 +169,26 @@
         }
       }
     },
+    "set_notify_on_open": {
+      "doc": "Turn the sender's open-notification preference on or off for one of their own links, after the link has been created. notify_on_open was create-time only, so the panel's toggle could not persist. Scoped server-side to the caller's own shares; answers NOT_FOUND identically for an unknown token and someone else's token.",
+      "scope": "hub",
+      "permission": {
+        "src": "write"
+      },
+      "log": true,
+      "params": {
+        "token": {
+          "type": "string",
+          "required": true,
+          "doc": "Secure share token whose notification preference to change"
+        },
+        "notify_on_open": {
+          "type": "integer",
+          "required": true,
+          "doc": "1 to notify the sender each time a recipient opens the share, 0 to stop notifying. The access list keeps recording opens either way."
+        }
+      }
+    },
     "revoke": {
       "doc": "Revoke a secure share token (soft delete — sets revoked_at timestamp). Broadcasts a secure_share_revoked event via Redis to all hub socket connections so the recipient loses access instantly.",
       "scope": "hub",

--- a/docs/superpowers/specs/2026-08-02-invite-cta-skip-guest-landing-design.md
+++ b/docs/superpowers/specs/2026-08-02-invite-cta-skip-guest-landing-design.md
@@ -1,0 +1,251 @@
+# Workspace-invite CTA: skip the guest landing page
+
+Date: 2026-08-02
+
+## Problem
+
+The workspace-invite email's CTA (`service/private/templates/butler/workspace-invite-member.html`)
+links at an anonymous guest landing page. Opening the workspace one was invited to
+therefore costs four hops:
+
+1. click the email CTA → guest landing page (`signin_guest`)
+2. click *Join Workspace* / *Sign Up Free* on that page → arms `drumee_guest_join`
+3. sign in or sign up
+4. click *Open Workspace* on a dialog the desk raises after Home settles
+
+Steps 1–2 exist only to render a preview the email already shows, and step 4 asks
+for a click the recipient has effectively already made twice.
+
+An already-signed-in recipient gets a worse deal: `welcome.loadSignin()` short-circuits
+on `Visitor.isOnline()` into `_redeemInviteThenEnter()`, which — with no `?invite=`
+token on the link — just sets `location.hash = desk`. They never see the landing page
+and land on a bare desk with nothing opened, because the welcome router stashes
+`args.hub_id` while `_guestLandingLink` emits `hub=`.
+
+## Goal
+
+Clicking the email CTA takes the recipient to the sign-in form. Once they are
+authenticated the desk offers the invited workspace — "Open Workspace" / "Cancel" —
+and confirming puts them in it. No landing page, and no click spent leaving one.
+
+## Design
+
+### 1. The CTA becomes a plain welcome link
+
+`_guestLandingLink(hubname, external, token, hub_id)` in `service/private/hub.js`
+is replaced by `_inviteCtaLink(hub_id, hubname)`, which returns:
+
+```
+https://<main_domain><endpoint_path>/#/welcome/signin?hub_id=<hub_id>&name=<workspace>
+```
+
+`view=guest`, `scope` and `token` are dropped:
+
+- `scope` only ever selected a landing-page layout.
+- `token` authorised the landing page's `dmz.list_by_token` read. Nothing on the
+  new path reads share content anonymously.
+- `hub` becomes `hub_id`, which is the name the welcome router already reads.
+- `name` stays, but for a different job: it was the landing page's header, and it is
+  now display copy for the prompt's message ("…you were invited to: Alpha"). It is
+  never an identity — `hub_id` alone selects the workspace and every service behind
+  it authorises the caller's session. Both values are percent-encoded, so a
+  workspace called `R&D = Q3` cannot forge extra query params.
+
+Two things deliberately stay in `invite()`:
+
+- `await this._ensurePublicShareToken()` is still called, now purely for its side
+  effects — it creates the external room on first use and re-applies the area-based
+  guest permission, which `copy_link` and the share panel depend on. Its return
+  value is discarded.
+- `workspace_external` still drives the email's body copy and whether the preview
+  rows are redacted. That is unchanged; only the CTA target moves.
+
+### 2. One lib owns the deep-link stash
+
+The mechanism this rides on already exists: `welcome/index.js` stashes `?hub_id=`
+into `sessionStorage.drumee_hubDeepLink`, and `desk/wm.onDomRefresh` consumes it by
+calling `loadWorkspace({hub_id})`. It is sessionStorage-only, which does not survive
+a recipient who signs up, closes the original tab, and finishes in the tab opened by
+the verification link. (The signup flow usually saves them — `check-inbox` polls
+`signup.check_verification` and redirects the *original* tab to sign-in — but only
+while that tab is still open.)
+
+A new `src/drumee/libs/hub-deep-link.js` in ui-team, alongside the existing
+`libs/campaign.js`, owns the whole thing:
+
+- `arm(hub_id, name)` writes **both** `sessionStorage.drumee_hubDeepLink` — kept a
+  BARE hub_id string, its original shape, so a desk bundle from before this module
+  still reads it — and `localStorage.drumee_hubDeepLink = {hub_id, name, ts}`. The
+  name rides only on the localStorage copy, which has no older reader.
+- `peek()` returns `{hub_id, name}` or null. Session decides *whether* an intent
+  belongs to this tab; the localStorage copy supplies the name, and stands in
+  wholesale when the session key is gone. A localStorage copy for a *different*
+  hub never lends its name.
+- `consume()` is `peek()` + `clear()`, so a consumed intent cannot prompt twice.
+- `has()` answers the same question without consuming.
+- `clear()` drops both keys.
+
+The 7-day guard mirrors `_maybeOfferInvitedWorkspace`: an intent that outlives the
+session can also outlive the recipient's interest, and the invite itself stays in
+the activity list either way.
+
+Call sites:
+
+| File | Change |
+|------|--------|
+| `modules/welcome/index.js` | `arm(args.hub_id, decoded name)` in place of the bare `setItem` |
+| `modules/desk/wm/index.js` | boot path no longer opens an armed intent — only the explicit `#/desk/wm/hub?hub_id=` hash form still opens immediately |
+| `modules/desk/index.js` | `_maybeOfferInvitedWorkspace` consumes it; `_hasDeepLink()` uses `has()`, so desk-state restore does not race the prompt |
+
+The secure-share branch in `desk/wm.onDomRefresh` clears **both** keys instead of
+one — a secure-share return must still win over a hub deep link.
+
+### 3. The prompt, and where it lives
+
+The desk asks before opening. `_maybeOfferInvitedWorkspace` already rendered exactly
+this dialog for the guest-landing flow, so it takes the new intent as a second
+source rather than growing a second modal:
+
+```
+You can now open the workspace you were invited to: Alpha
+
+        [ Open Workspace ]   [ Cancel ]
+```
+
+Consumption belongs to the desk, NOT to `desk/wm.onDomRefresh`, because the prompt
+must inherit `_afterHomeSettled` → `_waitForHomePopups()`: the reward flow and the
+LAUNCH30 popup are full-screen and self-gating, and an earlier version of this
+dialog appeared on top of them. The boot path cannot see either.
+
+**Open Workspace** sets `#/desk/wm/open/?hub_id=…&nid=0&filetype=folder&pid=0`, the
+same deep link the "<name> invited you to <workspace>" activity row uses. It launches
+a normal popup `window_folder` with the full window chrome.
+
+`Wm.loadWorkspace({hub_id})` — the headless workspace pane the sidebar opens — was
+tried here and reverted. A headless folder topbar deliberately drops the zoom and
+minimize controls (`folder/skeleton/topbar.js`: `headless ? "" : zoomMenu(ui)`,
+because a pane already fills the desk area), so the window opened from this dialog
+came up without its zoom control. Keeping the popup route also means this dialog and
+the activity row behave identically, which is the point of reusing the route rather
+than re-deriving it.
+
+`nid=0` is required, not decorative — see the note under Verification.
+
+**Cancel** is `_e.close` — the notice dismisses and the intent is already consumed,
+so it does not come back.
+
+#### The wait before it
+
+The prompt is late by design, so the desk says so. `_showInvitedWorkspaceLoader`
+raises a "Preparing your workspace…" notice (spinner + label, `mode: "hb"` so it has
+the drumee/✕ header and no footer) at the TOP of the chain, before the reward flow —
+the floor is ~2.4s (`SETTLE` 2000 + the 400ms settle) and unbounded while a
+full-screen flow is up.
+
+Raising it that early is only safe because of two things:
+
+- It hides itself whenever `_homePopupsBusy()` is true. That predicate is extracted
+  from `_waitForHomePopups`' local `busy()` so there is ONE definition, and the skin
+  hides `[data-guest-join-loading="1"][data-busy="1"]`. Hidden, not unmounted —
+  remounting on each toggle would flicker and lose its place in the windows pool.
+- `dismiss_after` is a hard backstop. Every path that ends the wait calls
+  `_hideInvitedWorkspaceLoader` (prompt raised, Wm never arrived, stale intent,
+  popups never cleared, chain failed), but a footerless loader has no button to
+  dismiss it, so it must not be able to outlive its reason to exist if a future path
+  forgets.
+
+It is a no-op unless a workspace is armed, which `_hasInvitedWorkspaceIntent` answers
+WITHOUT consuming — the prompt still needs that intent.
+
+### 4. Resulting flow
+
+```
+email CTA  →  #/welcome/signin?hub_id=42&name=Alpha
+                 |
+    +------------+-----------------+--------------------+
+    | anonymous  | no account      | already signed in  |
+    v            v                 v
+ sign-in      sign-up -> verify   welcome sees hub_id -> arm
+    |            | (create_account resolves            |
+    |            |  pending_invitation -> membership)   |
+    +------------+-----------------+--------------------+
+                                   v
+                    desk boot -> "Preparing your workspace…"
+                                 (hidden while reward / LAUNCH30 is up)
+                                   v
+                        Home settles, popups clear
+                                   v
+                  "Open Workspace / Cancel"  -> consume()
+                                   v
+              #/desk/wm/open/?hub_id=42&nid=0&filetype=folder&pid=0
+                                   v
+                     popup window_folder on the hub root
+```
+
+Membership is granted exactly as before, and nothing about it moves:
+
+- existing account → `_grantMembership` at invite time, plus the `hub.invite_received`
+  websocket push;
+- no account → `_addInviteToken` + `yp_add_pending_invitation`, resolved by
+  `signup.create_account` → `_resolve_pending_invitation`.
+
+### 5. What is deliberately left alone
+
+Every link already sitting in an inbox carries `?view=guest&scope=…&token=…&hub=…`
+and must keep working end to end, so none of this is removed:
+
+- the `signin_guest` widget, its skeletons and its sample/share/chat content;
+- the `view=guest` branch in `signin_router.onDomRefresh`;
+- `dmz.list_by_token` / `dmz.chat_by_token` (no consumer other than that widget);
+- the guest flow's `drumee_guest_join` key and `_armJoinIntent`, so an old link
+  still arms and still gets its dialog.
+
+`_maybeOfferInvitedWorkspace` and the `guest-join-open-workspace` handler are shared
+rather than left alone: they now serve both intent sources. The handler's outcome is
+unchanged — still the `#/desk/wm/open/` popup — so an old guest-landing link behaves
+exactly as it did before.
+
+Retiring the rest is a separate decision, taken once no old link can plausibly
+still be clicked.
+
+## Verification
+
+Neither repo has a test runner (`package.json` scripts are dev/deploy only), so:
+
+- a throwaway node harness asserting `_inviteCtaLink`'s output (including that a
+  workspace name containing `&` or `=` cannot forge query params) and the
+  `hub-deep-link` age-guard / precedence / name-pairing rules — all pure, no DB,
+  no DOM;
+- a harness that lifts the loader's four methods out of `desk/index.js` and runs the
+  shipped bodies against a fake desk and Wm: intent detection stays read-only, the
+  window is shaped right (`mode: "hb"`, no `actions`, `dismiss_after` set), and it
+  hides — without unmounting — for each of the busy signals;
+- the loader's two visual states rendered with a standalone `sass` compile of the
+  info skin and a headless chromium screenshot, checking both that the card looks
+  right and that `[data-busy="1"]` paints nothing at all;
+- a manual click-through on `local.drumee` for the anonymous and
+  already-signed-in cases.
+
+This box only serves `local.drumee`, so the link string and the storage logic can
+be verified here but a real inbox → production workspace open cannot.
+
+Note on `nid`: a caller that knows only a `hub_id` must reach `media.attributes` with
+`nid: 0`, the server's own hub-root value. Leaving it unset is not equivalent —
+`fetchService` builds its GET query with `encodeURI(v)` per key, so an undefined nid
+is sent as the literal string `"undefined"`, which `mfs_access_node` resolves to zero
+rows. That is what `Wm._rootNid` exists for, and why the prompt's Open deep link
+spells out `nid=0`.
+
+## Risks
+
+- **A stale localStorage intent.** Bounded by the 7-day guard and by `consume()`
+  clearing both keys on the first read.
+- **Recipients on an old link get the old four-hop flow.** Accepted: it still
+  works, and it drains as inboxes age.
+- **No preview before signing in.** The email itself carries the preview rows and
+  the recent-activity snippets, which is where a recipient actually sees them.
+- **The prompt can be missed.** It waits for Home to settle and for the reward /
+  LAUNCH30 popups to clear, and gives up if `Wm` never appears within six seconds.
+  The intent is consumed either way, so a missed prompt does not return. The invite
+  stays in the activity list and the workspace stays in the sidebar, so nothing is
+  lost — the recipient just opens it themselves.

--- a/offline/media/chat-export.js
+++ b/offline/media/chat-export.js
@@ -14,7 +14,8 @@
  *
  * Args (argv[0] JSON):
  *   { uid, hub_id, hub_name, root_nid, root_name, folder_sel, thread_sel,
- *     start_date, end_date, format:'pdf', zipid, zipname, socket_id, lang }
+ *     start_date, end_date, format:'pdf', zipid, zipname, socket_id, lang,
+ *     authorized_file_threads }
  *
  * Progress events sent via RedisStore.sendData:
  *   { phase:'prepare'|'gather'|'build'|'convert'|'exit', progress:0-100,
@@ -42,6 +43,10 @@ const { spawn } = require("child_process");
 const { DOWNLOAD_FOLDER } = Constants;
 const { tmp_dir } = sysEnv();
 const { buildOdt } = require("./chat-export-odt");
+const MFS_PERMISSION_READ =
+  (Constants.permission && Constants.permission.read) || 0b0000010;
+const FILE_THREAD_SELECTOR_RE = /^[0-9a-zA-Z_-]{1,64}$/;
+const EXPORT_ACCESS_MANIFEST = ".file-thread-access.json";
 
 // ─── Lock-file guard (mirrors to-pdf.js pattern) ─────────────────────────────
 // Only one soffice conversion at a time per process; track PID to detect stale.
@@ -153,6 +158,63 @@ function normalizeRow(row, hub_id) {
 }
 
 /**
+ * Revalidate the server-authorized candidates in the hub DB immediately before
+ * gathering. The worker never broadens scope by discovering file threads on
+ * its own, and canonical selector agreement prevents stale/id-swapped rows.
+ */
+async function revalidateAuthorizedFileThreads(db, uid, candidates) {
+  const allowed = [];
+  for (const candidate of toArray(candidates)) {
+    const file_nid = `${candidate && candidate.file_nid || ""}`;
+    const file_thread_id = `${candidate && candidate.file_thread_id || ""}`;
+    if (
+      !FILE_THREAD_SELECTOR_RE.test(file_nid)
+      || !FILE_THREAD_SELECTOR_RE.test(file_thread_id)
+    ) {
+      continue;
+    }
+
+    const resolved = toArray(
+      await db.await_proc(
+        "channel_file_thread_resolve_access",
+        uid,
+        file_nid,
+        file_thread_id,
+        "",
+      ),
+    )[0] || {};
+    if (
+      `${resolved.resolution_status || ""}` !== "OK"
+      || `${resolved.file_nid || ""}` !== file_nid
+      || `${resolved.file_thread_id || ""}` !== file_thread_id
+    ) {
+      continue;
+    }
+
+    const node = toArray(
+      await db.await_proc("mfs_access_node", uid, file_nid),
+    )[0] || {};
+    const privilege = Number(node.privilege || node.permission || 0);
+    if (
+      `${node.nid || node.id || ""}` !== file_nid
+      || `${node.status || ""}` !== "active"
+      || (privilege & MFS_PERMISSION_READ) !== MFS_PERMISSION_READ
+    ) {
+      continue;
+    }
+
+    allowed.push({
+      file_thread_id,
+      file_nid,
+      filename: candidate.filename || "",
+      folder_nid: candidate.folder_nid || null,
+      folder_name: candidate.folder_name || null,
+    });
+  }
+  return allowed;
+}
+
+/**
  * Order channel_export_folder_tree rows depth-first (parent before children,
  * siblings by name — the proc pre-sorts by depth/name) and attach a display
  * `path` string to each row.
@@ -189,7 +251,7 @@ function orderFolderTree(folders) {
  * @param {string|string[]} thread_sel  'all' | [file_thread_ids] | 'none'
  * @param {number|null} date_start
  * @param {number|null} date_end
- * @param {Array}   file_threads  from channel_export_file_thread_list
+ * @param {Array}   file_threads  server-authorized and worker-revalidated rows
  * @param {Array}   folder_tree   from channel_export_folder_tree
  * @returns {Promise<Array>}
  */
@@ -232,16 +294,20 @@ async function gatherSections(db, uid, hub_id, root_nid, folder_sel, thread_sel,
       );
       if (!rows.length) break;
       for (const row of rows) {
-        const msg = normalizeRow(row, hub_id);
+        let rootThread = null;
         if (row.message_type === "file.thread") {
           let meta = {};
           try {
             meta = typeof row.metadata === "string"
               ? jsonParse(row.metadata) : row.metadata || {};
           } catch (_) {}
-          const ft = ftByFileNid.get(`${meta._file_nid}`);
+          rootThread = ftByFileNid.get(`${meta._file_nid}`);
+          if (!rootThread) continue;
+        }
+        const msg = normalizeRow(row, hub_id);
+        if (rootThread) {
           msg.type = "event";
-          msg.text = `Chat thread started for "${(ft && ft.filename) || meta._file_nid || "a file"}"`;
+          msg.text = `Chat thread started for "${rootThread.filename || "a file"}"`;
         }
         const key = row.scope_nid || (rootFolder ? `${rootFolder.id}` : "");
         if (!byFolder.has(key)) byFolder.set(key, []);
@@ -337,10 +403,11 @@ class __chat_export_job extends Offline {
     this.hub_name   = data.hub_name || data.hub_id;
     this.root_nid   = data.root_nid || null;
     this.root_name  = data.root_name || this.hub_name;
-    // Scope axes come pre-resolved from channel.export() as 'all' | array |
-    // 'none' (see _resolveScope). Default to 'all' for safety.
+    // channel.export() resolves "all" to an explicit authorized id list before
+    // spawning. Fail closed rather than letting a malformed job broaden scope.
     this.folder_sel = data.folder_sel === undefined ? "all" : data.folder_sel;
-    this.thread_sel = data.thread_sel === undefined ? "all" : data.thread_sel;
+    this.thread_sel = data.thread_sel === "none" ? [] : data.thread_sel;
+    this.authorized_file_threads = data.authorized_file_threads;
     this.date_start = data.start_date || null;
     this.date_end   = data.end_date   || null;
     this.zipid      = data.zipid;
@@ -353,6 +420,13 @@ class __chat_export_job extends Offline {
         console.error(`chat-export: required arg '${name}' is missing`);
         exit(1);
       }
+    }
+    if (
+      !Array.isArray(this.thread_sel)
+      || !Array.isArray(this.authorized_file_threads)
+    ) {
+      console.error("chat-export: explicit authorized thread scope is required");
+      exit(1);
     }
 
     global.verbosity = 2;
@@ -427,8 +501,22 @@ class __chat_export_job extends Offline {
       zipid: this.zipid, message: "GATHERING_MESSAGES",
     });
 
-    const file_threads = toArray(
-      await db.await_proc("channel_export_file_thread_list", this.uid, this.root_nid),
+    const file_threads = await revalidateAuthorizedFileThreads(
+      db,
+      this.uid,
+      this.authorized_file_threads,
+    );
+    writeFileSync(
+      pathJoin(stageDir, EXPORT_ACCESS_MANIFEST),
+      stringify({
+        schema_version: 1,
+        hub_id: `${this.hub_id}`,
+        file_threads: file_threads.map((ft) => ({
+          file_thread_id: ft.file_thread_id,
+          file_nid: ft.file_nid,
+        })),
+      }),
+      "utf8",
     );
     const folder_tree = toArray(
       await db.await_proc("channel_export_folder_tree", this.hub_id, this.root_nid),

--- a/offline/test/secure-share-session.test.js
+++ b/offline/test/secure-share-session.test.js
@@ -332,6 +332,58 @@ const invariants = [
     // than the apex) — the property that makes it un-usable as the apex auth session.
     assert.ok(/host\s*=\s*this\.input\.host\(\)/.test(page), 'host-scoping of the isolated cookie missing');
   }],
+
+  ['set_notify_on_open is creator-scoped and never takes an owner id from the client', async () => {
+    const ss = src('service/private/secure_share.js');
+    const idx = ss.indexOf('async set_notify_on_open()');
+    assert.ok(idx > 0, 'set_notify_on_open method not found');
+    const body = ss.slice(idx, idx + 1200);
+    // The ONLY thing standing between this setter and "edit anyone's link" is that
+    // the creator scope comes from the session (this.uid), never from the request.
+    assert.ok(
+      /await_proc\(\s*'secure_share_set_notify_on_open'\s*,\s*token\s*,\s*this\.uid\s*,/.test(body),
+      'creator scope must be this.uid, passed as the 2nd arg of the SP'
+    );
+    assert.ok(
+      !/creator_id/.test(body),
+      'must never read a creator/owner id from the request'
+    );
+    // An unknown token and someone else's token must be indistinguishable, else the
+    // endpoint becomes a probe for other people's tokens.
+    assert.ok(
+      /isEmpty\(row\)\)\s*\{?\s*\n?\s*return this\.output\.data\(\{\s*status:\s*'NOT_FOUND'/.test(body),
+      'empty SP result must answer NOT_FOUND'
+    );
+    // Explicit setter: only a recognised truthy form may turn notifications ON.
+    assert.ok(
+      /raw === 1 \|\| raw === '1' \|\| raw === true\) \? 1 : 0/.test(body),
+      'notify_on_open must be coerced strictly from an explicit value'
+    );
+    // Echo the STORED value so the panel can revert a toggle that did not persist.
+    assert.ok(
+      /notify_on_open:\s*Number\(row\.notify_on_open\)/.test(body),
+      'response must echo the stored value, not the requested one'
+    );
+  }],
+
+  ['the two open-notification paths still honour notify_on_open', async () => {
+    // The whole point of the setter is that these gates exist. If either one is
+    // removed, turning the toggle off goes silently back to notifying the sender.
+    const dmz = src('service/dmz.js');
+    assert.ok(
+      /info\.notify_on_open\s*!=\s*0/.test(dmz),
+      'dmz.js must still gate the real-time secure_share_opened push on notify_on_open'
+    );
+    const gateIdx = dmz.search(/info\.notify_on_open\s*!=\s*0/);
+    const pushIdx = dmz.indexOf("event           : 'secure_share_opened'");
+    assert.ok(pushIdx > 0, 'secure_share_opened push not found');
+    assert.ok(gateIdx > 0 && gateIdx < pushIdx, 'the gate must precede the push');
+    // The access log / access-event write must NOT be inside that gate: turning
+    // notifications off still records the open in the access list.
+    const logIdx = dmz.indexOf("'secure_share_log_access_event'");
+    assert.ok(logIdx > 0, 'access-event log not found');
+    assert.ok(logIdx < gateIdx, 'the access list must be recorded BEFORE/outside the notify gate');
+  }],
 ];
 
 // Behavioural tests only when their (private) dep loaded; canaries always.

--- a/plans/reports/research-260717-1016-chat-export-section-grouping-bug-report.md
+++ b/plans/reports/research-260717-1016-chat-export-section-grouping-bug-report.md
@@ -1,0 +1,92 @@
+# Research Report: Chat export sai section — "This Folder Chat" gộp mọi folder, root card rỗng, tên = id
+
+Date: 2026-07-17 | Branch: `test` | Hub kiểm chứng: `ca2375f3ca2375f8` (DB `d_ca2376d5ca2376d6`, stage)
+
+## Executive Summary
+
+Export chat hiện **hub-scoped** trong khi UI chat hiển thị **folder-scoped** (lọc `metadata._scope_nid` ở JS). Proc `channel_export_messages` chỉ lọc `file_thread_id IS NULL`, KHÔNG lọc/nhóm theo `_scope_nid` → mọi general chat của A, B, C, D đổ chung vào 1 section "This Folder Chat". Root card `file.thread` (message rỗng, `message_type='file.thread'`) cũng bị xuất ra thành message trống. `meta.hub_name` + tên file export dùng hub id thay vì tên workspace vì cột `hubname` trong `yp.hub` của hub này chứa chính id.
+
+Xác minh bằng data thật trên stage (bảng dưới) — export JSON của user khớp 100% với dự đoán từ code.
+
+## Data thật trên stage (đối chiếu)
+
+Cấu trúc thư mục (`media`): root `cab853b7cab853bc` (=A, hub root, mimetype `special`) → `sub1`=`c924896fc9248973` (=C), `sub2`=`cc6f6d91cc6f6d95` (=B); `sub3`=`d11499c5d11499c8` (=D, con của sub1); 2 file trong D: `e7afc3c1e7afc3c5`, `e9566e24e9566e29` (2 file_thread active).
+
+Bảng `channel` (12 rows):
+
+| sys_id | message | file_thread_id | `_scope_nid` | Thuộc chat |
+|---|---|---|---|---|
+| 4,5,6 | hello / hi / mention | NULL | `cab853b7…` | **A** (root) |
+| 7 | (rỗng — root card) | NULL | `d11499c5…` | card thread file 1 |
+| 8,10 | hi / why so slow | `02ed640e…` | `d11499c5…` | thread file 1 |
+| 11 | (rỗng — root card) | NULL | `d11499c5…` | card thread file 2 |
+| 12,14 | hello sub 3 file 2 / oh hello… | `c8e302c8…` | `d11499c5…` | thread file 2 |
+| 15 | sumoner thread | NULL | `d11499c5…` | **D** general |
+| 16 | hello | NULL | `cc6f6d91…` | **B** general |
+| 17 | from sub 1 general | NULL | `c924896f…` | **C** general |
+
+Export JSON của user: section "This Folder Chat" chứa sys 4,5,6,**7**,**11**,15,16,17 — đúng như phân tích: trộn A+B+C+D + 2 root card rỗng (sys 7, 11 xuất hiện với `"text": ""`).
+
+`yp.hub` row: `hubname='ca2375f3ca2375f8'` (= id!), `name='aaron-ws'` → `meta.hub_name` và filename `Drumee_Chat_ca2375f3ca2375f8_…` lấy nhầm id.
+
+Lưu ý: 2 section file-thread có `name` = `Drumee_Chat_8e34ce93…` — đây LÀ `user_filename` thật của file (file test là file JSON export cũ nên tên trông như id). Logic resolve filename của thread đúng; vấn đề tên-id nằm ở hub_name.
+
+## Root Causes
+
+### RC1 — Export không nhóm theo folder (`_scope_nid`)
+- `schemas/hub/procedures/channel/channel_export_messages.sql`: WHERE chỉ có `file_thread_id IS NULL` + delete_channel + date range. Không đọc `metadata._scope_nid`.
+- Đối chiếu runtime: `service/private/channel.js` `messages()` (L107–122) lọc `meta._scope_nid === nid` per-folder ở JS. Export bỏ qua hoàn toàn chiều này.
+- `channel_export_count` cùng lỗi → count trong modal (folder card "N messages") là count TOÀN HUB, không phải folder đang mở → đây chính là case "user mới chat/mới tải file thì info show không đúng": folder mới tinh vẫn hiện count/mtime của hub.
+
+### RC2 — Root card `file.thread` bị xuất như message thường
+- Row sys 7/11: `message=NULL`, `metadata.message_type='file.thread'`, `_file_thread_root=1`. `_gatherSections`/`_normalizeMessage` (channel.js L2801–2935) và worker `chat-export.js` không lọc `message_type` → JSON/PDF có message rỗng vô nghĩa.
+
+### RC3 — hub_name = id
+- `export()`/`export_scope()` dùng `this.hub.get(Attr.name) || this.hub.get("hubname") || id`; hub model phía server đang trả về giá trị = id (yp.hub.hubname=id do flow tạo workspace chỉ set `name`). UI đã workaround (`ui.mget(_a.name)` — comment "backend hub.name may resolve to the hub_id hash until export_scope is fixed" trong skeleton) nhưng backend meta + `_exportBasename` vẫn dính.
+
+### RC4 — Nội dung message thô, khó đọc trong PDF
+- Mention giữ nguyên markup `[@label](mention:hub:nid)` (sys 6).
+- `reply_to` in ra message_id thô (`Reply to: f8388648…`) trong PDF thay vì author + trích đoạn.
+- Fullname có trailing space (`"Huynh "`) do `CONCAT(firstname,' ',lastname)` khi lastname rỗng.
+
+### RC5 — Scope UI hub-wide
+- `channel_export_file_thread_list` liệt kê thread TOÀN hub (không lọc theo folder đang mở, media.parent_id) → mở export ở folder B vẫn thấy thread của D. Cùng gốc RC1: export chưa có khái niệm folder.
+
+## Đề xuất cải thiện (thứ tự triển khai)
+
+### P1 — Nhóm section theo folder (fix chính)
+1. Proc mới hoặc sửa `channel_export_messages`: SELECT thêm `read_json_object(c.metadata,'_scope_nid') AS scope_nid`; vẫn trả phẳng, **JS nhóm** (giữ proc đơn giản, tránh GROUP BY JSON).
+2. `_gatherSections` (+ bản clone trong `chat-export.js`): nhóm messages theo `scope_nid`; join tên folder qua proc nhẹ (`mfs_node_attr`/query media theo list nid — cần proc read-only `channel_export_folder_names(nids JSON)` trả `id,user_filename`).
+3. Section đầu ra: `{type:'folder_chat', name:<folder path hoặc user_filename>, nid, messages}`; hub root đặt tên = workspace name + "(root)"; legacy message không có `_scope_nid` → section "General".
+4. Sắp xếp section theo cây (A trước, rồi B, C, C/D) — dùng parent_id chain từ proc names ở bước 2.
+5. File-thread section: gắn thêm `folder_nid`/`folder_name` (media.parent_id của file) để PDF in "D / file.pdf".
+
+### P2 — Lọc/format root card
+- Trong `_normalizeMessage`+`normalizeRow`: nếu `message_type==='file.thread'` (hoặc `metadata._file_thread_root`) → bỏ qua, HOẶC render thành event line "— started chat thread for <filename> —". Bỏ qua là đơn giản nhất (thread đã có section riêng).
+
+### P3 — hub_name đúng
+- `export_scope`/`export`: fallback chain đọc `yp.hub.name` khi giá trị hiện tại == hub_id (regex `^[0-9a-f]{16}$` và == id) — hoặc nhận `name` từ client như UI đang có. Sửa luôn `_exportBasename`.
+
+### P4 — Count folder-scoped trong modal
+- `channel_export_count` thêm param `_scope_nid` (NULL = toàn hub) để folder card hiện đúng số message của folder đang mở; UI truyền `nid` folder.
+
+### P5 — Trau chuốt nội dung
+- Render mention markup → `@label`; strip trailing space fullname (`TRIM(CONCAT_WS(' ',firstname,lastname))` trong proc); PDF `Reply to:` → resolve author + 40 ký tự đầu (lookup trong section đã gather, zero DB call).
+
+## Files phải sửa
+
+| Repo | File | Việc |
+|---|---|---|
+| schemas | `hub/procedures/channel/channel_export_messages.sql` | +`scope_nid` column, TRIM fullname |
+| schemas | `hub/procedures/channel/channel_export_count.sql` | +param `_scope_nid` |
+| schemas | mới `hub/procedures/channel/channel_export_folder_names.sql` | resolve nid→user_filename+parent_id |
+| server-team | `service/private/channel.js` (`_gatherSections`, `_normalizeMessage`, `export_scope`, `export`) | nhóm folder, lọc root card, hub_name |
+| server-team | `offline/media/chat-export.js` (clone gather) | đồng bộ y hệt (comment DRY INTENT L76–79) |
+| server-team | `offline/media/chat-export-html.js` | render folder sections, reply_to resolve, mention |
+| ui-team | `widget/chat-export/index.js` + `skeleton/index.js` | truyền `nid` folder cho export_scope/export; label section |
+
+## Unresolved Questions
+1. **Section per folder trong JSON**: đổi `type:'hub_chat'` → nhiều `folder_chat` là breaking change cho consumer JSON (nếu có tool ngoài đọc format cũ). Giữ thêm field `schema_version: 2`?
+2. **Export tại folder con**: user mở export ở D thì xuất toàn hub (hiện tại) hay chỉ subtree D? Đề xuất: giữ toàn hub nhưng nhóm section; thêm option "This folder subtree only" sau.
+3. Root card: bỏ hẳn hay render event line? (P2 đề xuất bỏ.)
+4. `channel_export_file_thread_list` không lọc `m.status='active'` — file đã trash còn hiện trong scope list? Cần xác nhận hành vi mong muốn.

--- a/plans/reports/research-260717-1938-chat-export-pdf-column-align-page-break-fix.md
+++ b/plans/reports/research-260717-1938-chat-export-pdf-column-align-page-break-fix.md
@@ -1,0 +1,69 @@
+# Research: Fix cột chat-export PDF lệch ở trang 2+ (LibreOffice)
+
+Date: 2026-07-17 | Scope: `offline/media/chat-export-html.js` + `chat-export.js` | Verified trên stage (soffice 25.2.3)
+
+## TL;DR — CÓ cách sửa, đã kiểm chứng pixel
+
+**Root cause thật:** không phải soffice yếu — mà là **HTML import dùng "Writer/Web" filter**, filter này KHÔNG có khái niệm "page" nên không giữ được table column-width qua page-break. Chuyển sang cho soffice một **Flat ODT (.fodt)** thay vì HTML → dùng "Writer" filter thật → column-width khóa tuyệt đối qua MỌI trang + header row tự lặp đầu trang.
+
+**Bằng chứng (đo pixel, 60 rows / 3 trang trên stage):** cột Message bắt đầu ở x=320-321px trên cả 3 trang (**spread = 1px** = khớp hoàn hảo). So với HTML hiện tại: page 2 lệch ~25px.
+
+## Các hướng đã cân nhắc
+
+| Hướng | Kết quả | Ghi chú |
+|---|---|---|
+| **A. Sinh Flat ODT (.fodt) thay HTML** | ✅ **KHUYẾN NGHỊ** | soffice giữ `style:column-width` (cm) tuyệt đối qua page-break; `<table:table-header-rows>` lặp header. Verified spread=1px. Không cần cài gì thêm. |
+| B. Đổi engine: wkhtmltopdf / weasyprint / chromium | ❌ loại | Stage KHÔNG có (chỉ soffice). Cài thêm = thay đổi hạ tầng, cần ops. weasyprint/wkhtml render CSS chuẩn nhưng out-of-scope. |
+| C. Node PDF lib (pdfkit/puppeteer) | ❌ loại | node_modules không có; puppeteer cần chromium. |
+| D. HTML `<thead>` lặp + table-layout:fixed | ⚠️ đã thử, KHÔNG đủ | Đã ship rồi vẫn lệch trang 2 — vì Web filter bỏ qua. |
+| E. Chấp nhận / block-layout | ⚠️ fallback | block-layout hết lệch nhưng user chê xấu, đã revert. |
+
+## Giải pháp A — chi tiết kỹ thuật
+
+### Tại sao hoạt động
+- HTML → soffice: filter `HTML (StarWriter)` = **Writer/Web** (web layout, no pages) → table columns co giãn theo nội dung mỗi page fragment.
+- FODT → soffice: filter `OpenDocument Text` = **Writer** (page layout thật) → `<style:table-column-properties style:column-width="3cm">` là ràng buộc CỨNG, giữ nguyên mọi trang.
+- Bonus: `<table:table-header-rows>` → header "Time/Author/Message" tự lặp đầu mỗi trang (HTML `<thead>` không làm được qua Web filter).
+
+### FODT skeleton (đã test chạy)
+```xml
+<office:document office:mimetype="application/vnd.oasis.opendocument.text" ...>
+ <office:automatic-styles>
+  <style:style style:name="C1" style:family="table-column">
+    <style:table-column-properties style:column-width="3cm"/></style:style>
+  <!-- C2=3cm, C3=10cm → tỉ lệ ~1:1:3 -->
+  <style:style style:name="Cell" style:family="table-cell">
+    <style:table-cell-properties fo:padding="0.1cm" fo:border-bottom="0.02cm solid #e8e8e8"/></style:style>
+ </office:automatic-styles>
+ <office:body><office:text>
+  <table:table table:name="Chat">
+   <table:table-column table:style-name="C1"/> <!-- x3 -->
+   <table:table-header-rows> <table:table-row>...Time/Author/Message...</table:table-row> </table:table-header-rows>
+   <table:table-row><table:table-cell><text:p>...</text:p></table:table-cell>...</table:table-row>
+  </table:table>
+ </office:text></office:body>
+</office:document>
+```
+Convert y hệt hiện tại: `soffice --headless --convert-to pdf file.fodt`.
+
+### Việc phải làm để chuyển
+1. **Viết lại `chat-export-html.js` → `chat-export-odt.js`** (hoặc giữ tên, đổi nội dung): sinh FODT XML thay HTML. Map lại:
+   - Section title (colspan) → `table:number-columns-spanned="3"` cell, hoặc 1 paragraph heading giữa các bảng.
+   - Rich text (bold author, màu, italic event) → `<text:span>` + `text:style-name` (định nghĩa trong automatic-styles). KHÁC HTML inline style — cần khai báo style trước.
+   - Reply quote / attachment → paragraph con trong cell message với style riêng.
+   - Mention flatten, esc XML (`&<>"`) giữ nguyên logic.
+2. **`chat-export.js`**: đổi ext output `export.html` → `export.fodt`; soffice output vẫn ra `export.pdf`. Không đổi gì khác.
+3. **Rich text formatting trong ODT phức tạp hơn HTML** — mọi màu/đậm/nghiêng phải là named style khai báo trước, không inline được như CSS. Đây là chi phí chính của việc chuyển.
+
+## Ước lượng công sức
+- Rewrite builder HTML→FODT: **trung bình** (2-3h). Logic gather/section/reply KHÔNG đổi, chỉ đổi lớp render markup.
+- Rủi ro: ODT rich-text verbose; cần map cẩn thận bold/color/italic sang named styles. Table borders/padding cm thay vì px.
+- Zero hạ tầng mới — cùng soffice, cùng flow spawn.
+
+## Khuyến nghị
+Nếu user cần cột thẳng tuyệt đối qua nhiều trang **và** giữ dạng bảng đẹp → **làm hướng A (FODT)**. Đây là cách đúng đắn duy nhất với hạ tầng hiện tại (chỉ soffice). Nếu chấp nhận lệch nhẹ trang 2 với chat dài → giữ HTML table hiện tại (đã revert về).
+
+## Unresolved
+1. User có muốn bỏ công rewrite sang FODT không, hay chấp nhận HTML table hiện tại (chat ngắn 1 trang là hoàn hảo)?
+2. Nếu làm FODT: giữ per-section table riêng (mỗi section 1 `<table:table>` — header lặp per-section) hay 1 bảng chung? Với FODT nên mỗi section 1 bảng (header repeat đẹp hơn, không cần colspan title-row hack).
+3. Có cần cài weasyprint/chromium lên stage để mở đường CSS-chuẩn về sau không (quyết định ops)?

--- a/service/butler.js
+++ b/service/butler.js
@@ -21,6 +21,7 @@ const {
 const { platform } = require('./lib/env');
 const { resolve } = require('path');
 const { isEmpty, isString } = require("lodash");
+const { notifyMemberJoined } = require("./lib/notify-member-joined");
 const {
   PASS_CHECKER,
   ID_NOBODY,
@@ -764,6 +765,11 @@ class __butler extends Mfs {
         } catch (err) {
           this.warn(`[_resolve_pending_invitation] WS notify failed for hub ${hub_id}:`, err && err.message);
         }
+
+        // Tell online members a member joined so an open permission matrix
+        // refreshes. (butler.js has no direct service boundary with hub.js, so
+        // the shared helper is used instead of an inherited method.)
+        await notifyMemberJoined(this, hub_id, newUser.id);
 
         this.debug(`[_resolve_pending_invitation] Added user ${newUser.id} to hub ${hub_id}`);
       } catch (err) {

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -1330,14 +1330,23 @@ class __dmz extends Mfs {
    * Input:  token {String} required, page {Number} optional
    * Output: { status, title, nid, hub_id, items[] }
    */
-  async list_by_token() {
-    const token = this.input.need(Attr.token);
-    const page = parseInt(this.input.use(Attr.page, 1), 10) || 1;
-    const deny = (status) => this.output.data({ status, items: [] });
-
-    // Two kinds of share token exist and the caller cannot be expected to know
-    // which it holds, so resolve exactly as dmz.login does: secure share first,
-    // legacy dmz token second. Both are normalised to one shape.
+  /**
+   * Resolve a share from its token alone, refusing anything not plainly open.
+   *
+   * Shared by every *_by_token endpoint so they can never drift apart on what
+   * counts as an acceptable share — a gate relaxed in one place but not the
+   * other is exactly the bug this prevents.
+   *
+   * Two kinds of token exist and the caller cannot be expected to know which it
+   * holds, so it resolves as dmz.login does: secure share first, legacy dmz
+   * token second, both normalised to one shape.
+   *
+   * @param {string} token
+   * @param {string} tag caller name, for log lines
+   * @returns {Promise<{info: object, viewerUid: ?string, legacyPrivilege: ?number}
+   *                  |{status: string}>} `status` set means REFUSED, no data.
+   */
+  async _shareByToken(token, tag) {
     let info = null;
     let viewerUid = null;
     let legacyPrivilege = null;
@@ -1345,7 +1354,7 @@ class __dmz extends Mfs {
       const secure = toArray(await this.yp.await_proc('secure_share_info', token))[0];
       if (secure && !secure.failed && secure.creator_id) info = secure;
     } catch (e) {
-      this.warn('[dmz.list_by_token] secure_share_info failed:', e && e.message);
+      this.warn(`[${tag}] secure_share_info failed:`, e && e.message);
     }
     if (!info) {
       try {
@@ -1358,19 +1367,30 @@ class __dmz extends Mfs {
           legacyPrivilege = legacy.privilege == null ? null : Number(legacy.privilege);
         }
       } catch (e) {
-        this.warn('[dmz.list_by_token] dmz_info_next failed:', e && e.message);
+        this.warn(`[${tag}] dmz_info_next failed:`, e && e.message);
       }
     }
     if (!info || !info.hub_id || !(info.node_id || info.nid)) {
-      return deny('TICKET_INVALID');
+      return { status: 'TICKET_INVALID' };
     }
     if (info.validity && info.validity !== 'TICKET_OK') {
-      return deny(info.validity);
+      return { status: info.validity };
     }
-    // Gated shares are the gate's business, not this endpoint's.
-    if (info.is_locked) return deny('TICKET_LOCKED');
-    if (info.require_password) return deny('REQUIRED_PASSWORD');
-    if (info.require_email) return deny('REQUIRED_EMAIL');
+    // Gated shares are the gate's business, not these endpoints'.
+    if (info.is_locked) return { status: 'TICKET_LOCKED' };
+    if (info.require_password) return { status: 'REQUIRED_PASSWORD' };
+    if (info.require_email) return { status: 'REQUIRED_EMAIL' };
+    return { info, viewerUid, legacyPrivilege };
+  }
+
+  async list_by_token() {
+    const token = this.input.need(Attr.token);
+    const page = parseInt(this.input.use(Attr.page, 1), 10) || 1;
+    const deny = (status) => this.output.data({ status, items: [] });
+
+    const share = await this._shareByToken(token, 'dmz.list_by_token');
+    if (share.status) return deny(share.status);
+    const { info, viewerUid, legacyPrivilege } = share;
 
     // Listing target from the token. A real file → list its parent, filtered to
     // the file itself; a folder / hub / root → list it directly.
@@ -1457,6 +1477,121 @@ class __dmz extends Mfs {
       hub_id: info.hub_id,
       items,
     });
+  }
+
+  /**
+   * Read-only workspace chat for a share, authorised BY THE TOKEN ALONE.
+   *
+   * The companion to list_by_token, and it exists for the same reason:
+   * channel.messages is scope hub / src read, so its ACL resolves an acl_check
+   * grant against the caller's session, which a main-domain anonymous visitor
+   * cannot hold. This answers from the token and never touches the session.
+   *
+   * Scoped the same way the folder window scopes its team chat: messages carry
+   * a metadata._scope_nid, and only those matching the SHARED node are
+   * returned. That matters — a hub's channel table holds every folder's
+   * conversation, so without the filter a share of one folder would leak the
+   * chat of all the others.
+   *
+   * Legacy rows (written before _scope_nid existed) appear in every folder
+   * context in the app. Here they are DROPPED instead: in-app that fallback
+   * shows an old message to someone who already has hub access, whereas here it
+   * would hand an unscoped message to an anonymous visitor.
+   *
+   * The reply carries what it takes to render a bubble — author display name,
+   * text, time — and deliberately not the author's email or the delivery and
+   * seen maps in metadata.
+   *
+   * Input:  token {String} required, page {Number} optional
+   * Output: { status, nid, messages[] }
+   */
+  async chat_by_token() {
+    const token = this.input.need(Attr.token);
+    const page = parseInt(this.input.use(Attr.page, 1), 10) || 1;
+    const deny = (status) => this.output.data({ status, messages: [] });
+
+    const share = await this._shareByToken(token, 'dmz.chat_by_token');
+    if (share.status) return deny(share.status);
+    const { info, viewerUid } = share;
+
+    // Chat belongs to the shared container. A file share shows the chat of the
+    // folder it sits in, which is the same conversation the app shows there.
+    let nid = info.node_id || info.nid;
+    try {
+      const attr = toArray(
+        await this.yp.await_proc('forward_proc', info.hub_id, 'mfs_node_attr', `'${nid}'`)
+      )[0] || {};
+      if (attr.filetype && !['folder', 'hub', 'root'].includes(attr.filetype) && attr.pid) {
+        nid = attr.pid;
+      }
+    } catch (e) {
+      // Probe failed → treat the shared node as the container.
+    }
+
+    const guest_id = viewerUid || Cache.getSysConf('guest_id');
+    let rows;
+    try {
+      rows = toArray(await this.yp.await_proc(
+        'forward_proc', info.hub_id, 'channel_list_messages',
+        `'${guest_id}', 'date', 'asc', ${page}`
+      ));
+    } catch (e) {
+      this.warn('[dmz.chat_by_token] channel_list_messages failed:', e && e.message);
+      return deny('TICKET_INVALID');
+    }
+
+    // Scope filter — see above on why an absent _scope_nid is dropped here.
+    rows = rows.filter((r) => {
+      if (!r || r.status !== 'active') return false;
+      let meta = r.metadata;
+      try {
+        if (typeof meta === 'string') meta = JSON.parse(meta);
+      } catch (e) {
+        return false;
+      }
+      return meta && `${meta._scope_nid}` === `${nid}`;
+    });
+
+    // One contact lookup per distinct author, not per message.
+    //
+    // channel.messages forwards this proc to the VIEWER's own db, resolving the
+    // author out of the viewer's contacts. A guest has no db, so it runs in the
+    // AUTHOR's db instead — every drumate has the proc, and asked about itself
+    // it returns that person's own profile.
+    const authors = {};
+    for (const r of rows) {
+      const id = r.author_id;
+      if (!id || authors[id] !== undefined) continue;
+      authors[id] = '';
+      try {
+        const row = toArray(await this.yp.await_proc(
+          'forward_proc', id, 'shareroom_contact_get', `'${id}'`
+        ))[0] || {};
+        // A real name when the account has one. Otherwise the LOCAL PART of
+        // the address the proc returns in `surname` — enough to tell two
+        // participants apart, which a conversation needs, without handing an
+        // anonymous visitor a working address. The domain is never sent.
+        const name = [row.firstname, row.lastname].filter(Boolean).join(' ').trim();
+        authors[id] = name || String(row.surname || '').split('@')[0].trim();
+      } catch (e) {
+        this.debug('[dmz.chat_by_token] contact lookup failed for', id, e && e.message);
+      }
+    }
+
+    // channel_list_messages answers newest-first whatever order is asked for,
+    // and a conversation reads oldest-first.
+    rows.sort((a, b) => Number(a.ctime || 0) - Number(b.ctime || 0));
+
+    const messages = rows.map((r) => ({
+      message_id: r.message_id,
+      author_id: r.author_id,
+      author: authors[r.author_id] || '',
+      message: r.message,
+      ctime: r.ctime,
+      is_reply: r.thread_id ? 1 : 0,
+    }));
+
+    this.output.data({ status: 'TICKET_OK', nid, messages });
   }
 
 }

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -21,8 +21,12 @@ const {
   ID_NOBODY
 } = Constants;
 const { verifyPassword: verifySecureSharePassword } = require('./lib/secure-share-password');
+const { secureShareCapPrivilege } = require('./lib/secure-share-write-guard');
 const Jwt = require('jsonwebtoken');
 const { resolve: _resolvePath } = require('path');
+const { existsSync, readFileSync, statSync } = require('fs');
+const { get_node_content } = require('@drumee/server-core/lib/utils/mfs');
+const { PERM_READ } = Constants;
 // Shared `drumee` secret, loaded ONCE at module load, used to sign a short-lived
 // owner-edit assertion (see _loginSecureShare). The euroffice editor verifies it with
 // the same secret. Best-effort: if the secret file is unavailable the feature is simply
@@ -89,6 +93,54 @@ function _emailMatchesAllowed(email, info) {
     return (email.split('@')[1] || '') === info.domain_restriction.toLowerCase().trim();
   }
   return false;
+}
+
+
+// Office extensions whose first page the server rasterizes into thumb.png.
+// Mirrors the client's builtins/player/document/editable.js — keep in step.
+const DOC_EDITABLE = new Set([
+  'doc', 'docx', 'docm', 'dotx', 'dotm', 'odt', 'ott',
+  'xlsx', 'xls', 'xlsm', 'xltx', 'xltm', 'xlsb', 'ods', 'ots',
+  'pptx', 'ppt', 'pptm', 'potx', 'potm', 'ppsx', 'ppsm', 'odp', 'otp',
+  'rtf',
+]);
+
+// A poster is never worth more than this many bytes on the wire. Sized so that
+// video vignettes clear it — a 720p poster frame runs to ~120KB and is the most
+// useful preview of the lot — while a pathologically large rendering does not.
+const POSTER_MAX_BYTES = 192 * 1024;
+// Nor is a whole listing's worth of them. A folder of videos spends this on the
+// first few tiles; the rest fall back to icons rather than inflating the reply.
+const POSTER_BUDGET_BYTES = 768 * 1024;
+
+/**
+ * Which already-rendered preview a row could show, in the order the desk grid
+ * would prefer them. Mirrors media/core.js initURL(): a vector shows its own
+ * source, a PDF or office document shows the rasterized first page (thumb),
+ * everything else shows the vignette.
+ *
+ * The client picks exactly one format; this returns a short preference list
+ * instead, because here the file must actually exist on disk and falling back
+ * to the other rendering beats showing no poster at all.
+ *
+ * @returns {Array<[string, string, string]>} [format, extension, mime]
+ */
+function _posterCandidates(row) {
+  const ext = String(row.ext || '').toLowerCase();
+  const ftype = String(row.filetype || row.ftype || '').toLowerCase();
+
+  // Containers have no content of their own; text-ish files are the two
+  // negative gates in the client's imgCapable() and would only ever produce a
+  // thumbnail of a wall of text.
+  if (['folder', 'hub', 'root'].includes(ftype)) return [];
+  if (/shell|script|text/.test(ftype)) return [];
+  if (/^text/.test(String(row.mimetype || ''))) return [];
+
+  if (ftype === 'vector' || ext === 'svg') return [['orig', 'svg', 'image/svg+xml']];
+  if (ext === 'pdf' || DOC_EDITABLE.has(ext)) {
+    return [['thumb', 'png', 'image/png'], ['vignette', 'png', 'image/png']];
+  }
+  return [['vignette', 'png', 'image/png'], ['thumb', 'png', 'image/png']];
 }
 
 
@@ -1187,6 +1239,224 @@ class __dmz extends Mfs {
    */
   notification_list() {
     this.output.data([]);
+  }
+
+  /**
+   * The row's already-rendered preview, as a data URI, or null.
+   *
+   * Why inline rather than a URL: the desk grid points `background-image` at
+   * file/<format>/<nid>/<hub_id>, which is media.<format>, whose ACL resolves
+   * an acl_check grant against the CALLER'S session — the very grant a
+   * main-domain anonymous visitor cannot hold (see list_by_token's preamble).
+   * Handing out a URL would therefore mean opening a second anonymous route
+   * with its own authorisation story. Returning the bytes through the call
+   * that is already token-gated adds no new surface at all: there is nothing
+   * to guess, nothing to share on, and nothing reachable without the token.
+   *
+   * Deliberately serves ONLY what is already on disk and NEVER generates.
+   * media._send_thumb() rasterizes on demand, which is fine behind a login but
+   * would let an anonymous caller spend server CPU by the folder-full. A file
+   * nobody has viewed yet simply shows its filetype icon.
+   *
+   * @param {object} row     listing row (nid, ext, filetype, mimetype, privilege)
+   * @param {string} mfsRoot storage root of the share's hub
+   * @param {{left: number}} budget mutable byte budget for the whole response
+   * @returns {string|null} "data:image/png;base64,…"
+   */
+  _posterFor(row, mfsRoot, budget) {
+    // nid indexes a directory name; it comes from the DB, but validate anyway
+    // so a malformed row can never escape the storage root.
+    const nid = String(row.nid || '');
+    if (!mfsRoot || !/^[0-9a-f]{16}$/.test(nid)) return null;
+    // A share that does not grant read does not get to show content either.
+    if (!((row.privilege || 0) & PERM_READ)) return null;
+    if (budget.left <= 0) return null;
+
+    for (const [format, ext, mime] of _posterCandidates(row)) {
+      let path;
+      try {
+        path = get_node_content({ ...row, id: nid, mfs_root: mfsRoot }, format, ext);
+      } catch (e) {
+        continue;
+      }
+      if (!path || !existsSync(path)) continue;
+      let size;
+      try {
+        size = statSync(path).size;
+      } catch (e) {
+        continue;
+      }
+      // Video vignettes in particular can run to six figures. Over the cap the
+      // icon is the better answer — do not spend the whole budget on one tile.
+      if (!size || size > POSTER_MAX_BYTES || size > budget.left) return null;
+      try {
+        const b64 = readFileSync(path).toString('base64');
+        budget.left -= size;
+        return `data:${mime};base64,${b64}`;
+      } catch (e) {
+        this.debug(`[dmz.list_by_token] poster unreadable nid=${nid}:`, e.message);
+        return null;
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Read-only listing of a share's contents, authorised BY THE TOKEN ALONE.
+   *
+   * Why this exists: dmz.login refuses to bind a share identity onto a
+   * main-domain session (see the regsid guard in login/_loginSecureShare — it
+   * would hijack or clamp the caller's auth session). So a page served from the
+   * main domain, such as the signin plugin's guest landing page, can never
+   * obtain the grant that media.show_node_by requires, and every listing there
+   * comes back 403. This answers from the token instead and NEVER touches the
+   * caller's session: no cookie_touch, no grant, no identity change.
+   *
+   * It is deliberately narrow — it lists, and nothing else:
+   *
+   *   - the target is derived from the token, never from client input. A client
+   *     cannot name a nid, so it cannot walk out of the share.
+   *   - a share that is not plainly open is refused: revoked, expired, invalid,
+   *     locked, password-gated or email-gated all return a status and NO items.
+   *     This endpoint performs no gate, so it must not serve gated content.
+   *   - a FILE share lists the parent folder hard-filtered to that one file, so
+   *     siblings are never exposed (same remap as _loginSecureShare).
+   *   - displayed privilege is the anonymous guest's, then clamped again by the
+   *     share's own capability set.
+   *   - the reply carries only what a viewer needs. secure_share_info also
+   *     returns sender-only data (password_hash, allowed_emails, denied_emails,
+   *     recipient_email, creator ids); none of it is echoed.
+   *
+   * Input:  token {String} required, page {Number} optional
+   * Output: { status, title, nid, hub_id, items[] }
+   */
+  async list_by_token() {
+    const token = this.input.need(Attr.token);
+    const page = parseInt(this.input.use(Attr.page, 1), 10) || 1;
+    const deny = (status) => this.output.data({ status, items: [] });
+
+    // Two kinds of share token exist and the caller cannot be expected to know
+    // which it holds, so resolve exactly as dmz.login does: secure share first,
+    // legacy dmz token second. Both are normalised to one shape.
+    let info = null;
+    let viewerUid = null;
+    let legacyPrivilege = null;
+    try {
+      const secure = toArray(await this.yp.await_proc('secure_share_info', token))[0];
+      if (secure && !secure.failed && secure.creator_id) info = secure;
+    } catch (e) {
+      this.warn('[dmz.list_by_token] secure_share_info failed:', e && e.message);
+    }
+    if (!info) {
+      try {
+        const legacy = await this.yp.await_proc('dmz_info_next', token);
+        if (legacy && !legacy.failed && legacy.hub_id) {
+          info = legacy;
+          // A legacy share owns a guest user; view as that identity and cap by
+          // the privilege the share itself grants.
+          viewerUid = legacy.uid || legacy.guest_id || null;
+          legacyPrivilege = legacy.privilege == null ? null : Number(legacy.privilege);
+        }
+      } catch (e) {
+        this.warn('[dmz.list_by_token] dmz_info_next failed:', e && e.message);
+      }
+    }
+    if (!info || !info.hub_id || !(info.node_id || info.nid)) {
+      return deny('TICKET_INVALID');
+    }
+    if (info.validity && info.validity !== 'TICKET_OK') {
+      return deny(info.validity);
+    }
+    // Gated shares are the gate's business, not this endpoint's.
+    if (info.is_locked) return deny('TICKET_LOCKED');
+    if (info.require_password) return deny('REQUIRED_PASSWORD');
+    if (info.require_email) return deny('REQUIRED_EMAIL');
+
+    // Listing target from the token. A real file → list its parent, filtered to
+    // the file itself; a folder / hub / root → list it directly.
+    let nid = info.node_id || info.nid;
+    let file_nid = null;
+    // Doubles as the storage-root lookup: every node physically in this hub
+    // lives under the same mfs_root, so one probe covers the whole listing.
+    // A row that is actually a cross-hub mount resolves to a path that does not
+    // exist, which costs it its poster and nothing else.
+    let mfs_root = null;
+    try {
+      const attr = toArray(
+        await this.yp.await_proc('forward_proc', info.hub_id, 'mfs_node_attr', `'${nid}'`)
+      )[0] || {};
+      mfs_root = attr.mfs_root || null;
+      if (attr.filetype && !['folder', 'hub', 'root'].includes(attr.filetype) && attr.pid) {
+        file_nid = nid;
+        nid = attr.pid;
+      }
+    } catch (e) {
+      // Probe failed → treat the shared node as a container, and show no posters.
+    }
+
+    // The anonymous guest is the viewing identity: mfs_show_node_by uses the uid
+    // for the per-row privilege/ownership columns, so this keeps the reply from
+    // ever describing the creator's own access.
+    const guest_id = viewerUid || Cache.getSysConf('guest_id');
+    const params = JSON.stringify({ sort_by: 'rank', order: 'asc', page, type: 'all' });
+    let rows;
+    try {
+      rows = toArray(await this.yp.await_proc(
+        'forward_proc', info.hub_id, 'mfs_show_node_by',
+        `'${nid}', '${guest_id}', '${params}'`
+      ));
+    } catch (e) {
+      this.warn('[dmz.list_by_token] listing failed:', e && e.message);
+      return deny('TICKET_INVALID');
+    }
+
+    if (file_nid) rows = rows.filter((r) => r && r.nid === file_nid);
+
+    // Clamp each row's displayed privilege to the share's caps, as
+    // media.show_node_by does. Anonymous caller → no recipient email.
+    let capPriv = legacyPrivilege;
+    if (capPriv == null) {
+      try {
+        capPriv = await secureShareCapPrivilege(this.yp, token, '');
+      } catch (e) {
+        capPriv = 0; // unknown caps → advertise none rather than the node's own
+      }
+    }
+
+    // Whitelist the columns that leave the server. Everything the viewer does
+    // not need — owner ids, db names, vhosts, metadata — stays here.
+    // Posters are opt-in and cost far more than the rest of the reply put
+    // together (a single video frame outweighs a whole folder of metadata), so
+    // the default answer stays small and the caller asks for them on a second
+    // pass once it has something on screen. Same endpoint, same token gate.
+    const wantPosters = /^(1|true|yes)$/i.test(String(this.input.use('with_posters', '')));
+    const budget = { left: wantPosters ? POSTER_BUDGET_BYTES : 0 };
+    const items = rows.map((r) => {
+      const privilege = capPriv == null ? r.privilege : (r.privilege || 0) & capPriv;
+      const item = {
+        nid: r.nid,
+        filename: r.filename,
+        ext: r.ext,
+        ftype: r.ftype || r.filetype,
+        filetype: r.filetype || r.ftype,
+        mimetype: r.mimetype,
+        filesize: r.filesize,
+        ctime: r.ctime,
+        mtime: r.mtime,
+        privilege,
+      };
+      const poster = this._posterFor({ ...r, privilege }, mfs_root, budget);
+      if (poster) item.poster = poster;
+      return item;
+    });
+
+    this.output.data({
+      status: 'TICKET_OK',
+      title: info.title || '',
+      nid,
+      hub_id: info.hub_id,
+      items,
+    });
   }
 
 }

--- a/service/lib/notify-member-joined.js
+++ b/service/lib/notify-member-joined.js
@@ -1,0 +1,56 @@
+/**
+ * @license
+ * Copyright 2026 Thidima SA. All Rights Reserved.
+ * Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE, Version 3.
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+const { RedisStore, utils } = require("@drumee/server-essentials");
+const { isEmpty } = require("lodash");
+
+// toArray comes from server-essentials' utils, NOT lodash — lodash's toArray
+// turns an object into its values array, which would silently mangle the
+// entity_sockets row set. Mirrors hub.js:52 `const { toArray } = utils`.
+const { toArray } = utils;
+
+/**
+ * Tell every online member of a hub that someone just joined, so any open
+ * permission matrices (Folder settings) refetch instead of showing a member
+ * list that is missing the person who was just invited/added.
+ *
+ * Callable from any service context — including anonymous-scope ones like
+ * hub.accept_invite that have no this.hub / this.db — because hub_id is passed
+ * in rather than read off the service.
+ *
+ * The joiner's own sockets are NOT excluded here: entity_sockets' `exclude`
+ * arg splices JSON array items straight into `s.id NOT IN (...)`, and
+ * user_sockets returns rows ({cookie,uid,socket_id}) rather than bare ids, so
+ * passing them through would emit broken SQL. The receiving window drops its
+ * own echo instead (folder/index.js _onMemberJoined guards data.uid === Visitor.id).
+ *
+ * Never throws: a failed notification must not fail the join itself — every
+ * call site is reached only after add_member/permission_grant have committed.
+ *
+ * @param {object} svc      service instance (needs .yp, .payload, .warn)
+ * @param {string} hub_id   hub the member joined
+ * @param {string} uid      the joiner's drumate id (may be null/undefined for
+ *                          admin-driven multi-adds where there is no single
+ *                          joiner to echo)
+ */
+async function notifyMemberJoined(svc, hub_id, uid) {
+  if (!svc || !hub_id) return;
+  try {
+    const dest = toArray(await svc.yp.await_proc("entity_sockets", hub_id));
+    if (isEmpty(dest)) return;
+    await RedisStore.sendData(
+      svc.payload({ hub_id, uid }, { service: "hub.member_joined" }),
+      dest
+    );
+  } catch (e) {
+    if (svc.warn) {
+      svc.warn("[notifyMemberJoined] failed for hub", hub_id, e && e.message);
+    }
+  }
+}
+
+module.exports = { notifyMemberJoined };

--- a/service/otp.js
+++ b/service/otp.js
@@ -114,18 +114,25 @@ class Otp extends Entity {
     // matching the other butler emails. Falls back to default sender if unset.
     const sender = butlerSender();
     const from = sender ? `"Drumee" <${sender}>` : undefined;
-    let sent = 0;
-    try {
-      const result = await msg.send(from ? { html, from } : { html });
-      if (result && result.error) {
-        this.warn(`OTP email delivery failed: ${result.error}`);
-      } else {
-        sent = 1;
-      }
-    } catch (e) {
-      this.warn(e);
-    }
-    this.output.data({ status: 'ok', sent, ...user, secret, email });
+    const payload = from ? { html, from } : { html };
+
+    // Answer with the secret the moment it's minted — the SMTP round-trip is the
+    // slow part (seconds) and the client only needs the secret to open the
+    // code-entry modal. Blocking the response on delivery made the "Delete my
+    // account" button look frozen, so users clicked again and minted extra codes.
+    // `sent` is optimistic: the email is dispatched below without awaiting, and a
+    // genuine delivery failure is recovered via the modal's Resend action.
+    this.output.data({ status: 'ok', sent: 1, ...user, secret, email });
+
+    // Fire-and-forget: the request is already answered, so a delivery error is
+    // only logged here, never surfaced to the (already-served) caller.
+    Promise.resolve(msg.send(payload))
+      .then((result) => {
+        if (result && result.error) {
+          this.warn(`OTP email delivery failed: ${result.error}`);
+        }
+      })
+      .catch((e) => this.warn(e));
   }
 
   /**

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -27,7 +27,7 @@ const { isEmpty } = require("lodash");
 const Crypto = require("crypto");
 const { resolve: pathResolve, join: pathJoin } = require("path");
 const {
-  mkdirSync, writeFileSync, existsSync, symlinkSync, rmSync
+  mkdirSync, writeFileSync, readFileSync, existsSync, symlinkSync, rmSync
 } = require("fs");
 const Spawn = require("child_process").spawn;
 
@@ -38,6 +38,10 @@ const SPAWN_OPT = { detached: true, stdio: ["ignore", "ignore", "ignore"] };
 const OFFLINE_DIR = pathResolve(__dirname, "..", "..", "offline", "media");
 const EXPORT_CAP = 10000;
 const EXPORT_MIME = { json: "application/json", pdf: "application/pdf" };
+const MFS_PERMISSION_READ =
+  (Constants.permission && Constants.permission.read) || 0b0000010;
+const FILE_THREAD_SELECTOR_RE = /^[0-9a-zA-Z_-]{1,64}$/;
+const EXPORT_ACCESS_MANIFEST = ".file-thread-access.json";
 
 // Meeting system messages are stored as a body sentinel `[[MEETING:start|end:
 // {json}]]` (no message_type) — the live chat renders them as "X started/ended
@@ -144,6 +148,19 @@ class __private_channel extends Entity {
     let cache = {};
     let hub_id = this.hub.get(Attr.id);
     for (let message of data) {
+      if (`${message.message_type || ""}` === "file.thread") {
+        const access = await this._resolveFileThreadAccess(
+          { message_id: message.message_id },
+          { require_thread: true },
+        );
+        // Keep the card, flagged unavailable, rather than dropping it: the
+        // thread marker belongs to the folder's history and vanishing on
+        // reload looked like the conversation had been deleted. The flag makes
+        // the client render it inert, so the thread itself stays unreachable.
+        if (!access.ok) {
+          await this._markRootCardUnavailable(message, access, hub_id);
+        }
+      }
       // Own-authored rows keep the viewer as the entity id, but also carry the
       // SP-resolved display fields (incl. email) so a viewer who renders this
       // author as NOT "me" on their side — e.g. a creator-bound secure-share
@@ -194,10 +211,48 @@ class __private_channel extends Entity {
     dest = toArray(dest).filter((e) => {
       return e.uid != this.uid;
     });
-    await RedisStore.sendData(
-      this.payload(messages, { service: "channel.acknowledge" }),
-      dest,
-    );
+    for (const recipient of dest) {
+      const visible = [];
+      for (const message of messages) {
+        if (`${message.message_type || ""}` !== "file.thread") {
+          visible.push(message);
+          continue;
+        }
+        if (isEmpty(recipient.uid)) continue;
+        try {
+          const access = await this._resolveFileThreadAccess(
+            { message_id: message.message_id },
+            { hub_id, uid: recipient.uid, require_thread: true },
+          );
+          if (access.ok) {
+            visible.push(message);
+          } else {
+            // Same rule as the list above: keep the marker, flagged for THIS
+            // recipient. Clone first — `messages` is the caller's own output
+            // and is shared across every iteration of this loop, so marking in
+            // place would leak one recipient's verdict into another's payload
+            // and into the caller's response.
+            visible.push(
+              await this._markRootCardUnavailable(
+                { ...message },
+                access,
+                hub_id,
+              ),
+            );
+          }
+        } catch (e) {
+          this.warn(
+            "channel.messages: recipient root-card access check failed",
+            recipient.uid,
+            e && e.message,
+          );
+        }
+      }
+      await RedisStore.sendData(
+        this.payload(visible, { service: "channel.acknowledge" }),
+        recipient,
+      );
+    }
 
     // Why do we need to inform the reader ?
     // dest = await this.yp.await_proc('user_sockets', this.uid);
@@ -510,6 +565,286 @@ class __private_channel extends Entity {
   }
 
   /**
+   * Run a stored procedure in the current hub or another hub selected by id.
+   * Remote calls use forward_proc, whose argument list is SQL text, so only
+   * already-validated scalar ids may pass through this helper.
+   */
+  async _fileThreadHubProc(hub_id, proc, args) {
+    const current_hub_id = `${this.hub.get(Attr.id)}`;
+    if (`${hub_id}` === current_hub_id) {
+      return this.db.await_proc(proc, ...args);
+    }
+    const sql_args = args
+      .map((value) => `'${`${value == null ? "" : value}`.replace(/'/g, "''")}'`)
+      .join(",");
+    return this.yp.await_proc("forward_proc", `${hub_id}`, proc, sql_args);
+  }
+
+  /**
+   * Canonical file-thread authorization boundary. The resolver proves that all
+   * supplied selectors agree and that the backing media row is live; this
+   * helper then requires the caller's current mfs_access_node read privilege.
+   */
+  async _resolveFileThreadAccess(selectors = {}, options = {}) {
+    const hub_id = `${options.hub_id || this.hub.get(Attr.id)}`;
+    const uid = `${options.uid || this.uid}`;
+    const file_nid = selectors.file_nid ? `${selectors.file_nid}` : "";
+    const file_thread_id = selectors.file_thread_id
+      ? `${selectors.file_thread_id}`
+      : "";
+    const message_id = selectors.message_id ? `${selectors.message_id}` : "";
+    const supplied = [file_nid, file_thread_id, message_id].filter(Boolean);
+
+    if (
+      !FILE_THREAD_SELECTOR_RE.test(hub_id)
+      || !FILE_THREAD_SELECTOR_RE.test(uid)
+      || supplied.some((value) => !FILE_THREAD_SELECTOR_RE.test(value))
+    ) {
+      return { ok: false, status: "INVALID_SELECTOR", is_file_thread: 1 };
+    }
+
+    const rows = await this._fileThreadHubProc(
+      hub_id,
+      "channel_file_thread_resolve_access",
+      [uid, file_nid, file_thread_id, message_id],
+    );
+    const resolved = toArray(rows)[0] || {};
+    const is_file_thread = Number(resolved.is_file_thread) === 1;
+    const resolution_status = `${resolved.resolution_status || "NOT_FOUND"}`;
+
+    if (resolution_status === "GENERAL") {
+      if (options.allow_general) {
+        return { ok: true, status: "OK", is_file_thread: false, hub_id };
+      }
+      return { ...resolved, ok: false, status: "INVALID_REPLY_SCOPE", hub_id };
+    }
+    if (resolution_status !== "OK") {
+      return {
+        ...resolved,
+        ok: false,
+        status: resolution_status === "SELECTOR_CONFLICT"
+          ? "INVALID_SELECTOR"
+          : resolution_status,
+        is_file_thread,
+        hub_id,
+      };
+    }
+    if (options.require_thread && isEmpty(resolved.file_thread_id)) {
+      return { ...resolved, ok: false, status: "NOT_FOUND", hub_id };
+    }
+
+    const node_rows = await this._fileThreadHubProc(
+      hub_id,
+      "mfs_access_node",
+      [uid, `${resolved.file_nid}`],
+    );
+    const node = toArray(node_rows)[0] || {};
+    const privilege = Number(node.privilege || node.permission || 0);
+    if (
+      isEmpty(node)
+      || `${node.nid || node.id || ""}` !== `${resolved.file_nid}`
+      || `${node.status || ""}` !== "active"
+    ) {
+      return { ...resolved, ok: false, status: "SCOPE_GONE", hub_id };
+    }
+    if ((privilege & MFS_PERMISSION_READ) !== MFS_PERMISSION_READ) {
+      return { ...resolved, ok: false, status: "NO_PERMISSION", hub_id };
+    }
+
+    return {
+      ...resolved,
+      ok: true,
+      status: "OK",
+      is_file_thread,
+      hub_id,
+      node,
+    };
+  }
+
+  _fileThreadFailure(access, extra = {}) {
+    return {
+      status: access.status || "NO_PERMISSION",
+      file_thread_id: access.file_thread_id || undefined,
+      file_nid: access.file_nid || undefined,
+      ...extra,
+    };
+  }
+
+  /**
+   * Mark a General-chat "file.thread" root card as unavailable instead of
+   * dropping it from the conversation. The card is part of the folder's
+   * history — silently removing it on reload made an entire thread vanish for
+   * everyone once its file was trashed, which reads as data loss.
+   *
+   * The card is rendered inert client-side (data-ft_available="0"), so the
+   * thread behind it stays unreachable; this only preserves the marker.
+   *
+   * No content is added that the viewer could not already see: the filename is
+   * read from `trash_media`, which only holds files that were trashed out of a
+   * folder this viewer was reading. A NO_PERMISSION card (file still live,
+   * viewer never had read access) has no trash row, so it carries no name and
+   * the client falls back to a generic label.
+   */
+  async _markRootCardUnavailable(message, access, hub_id) {
+    let meta = {};
+    try {
+      meta =
+        typeof message.metadata === "string"
+          ? jsonParse(message.metadata)
+          : message.metadata || {};
+    } catch (e) {
+      meta = {};
+    }
+    const file_nid = `${access.file_nid || meta._file_nid || ""}`;
+    meta._file_thread_unavailable = 1;
+    meta._file_thread_unavailable_reason = access.status || "SCOPE_GONE";
+    const filename = await this._trashedFilename(file_nid, hub_id);
+    if (filename) meta._file_thread_last_filename = filename;
+    message.metadata = meta;
+    return message;
+  }
+
+  /**
+   * Last known filename of a file that is no longer live, read from the hub's
+   * trash. Returns "" when the node was purged, moved to another hub, or never
+   * trashed (a still-live file the caller simply cannot read).
+   */
+  async _trashedFilename(file_nid, hub_id) {
+    if (isEmpty(file_nid)) return "";
+    try {
+      const rows = await this._fileThreadHubProc(
+        `${hub_id || this.hub.get(Attr.id)}`,
+        "channel_file_thread_trashed_filename",
+        [`${file_nid}`],
+      );
+      const row = toArray(rows)[0] || {};
+      return `${row.user_filename || ""}`;
+    } catch (e) {
+      // Best effort: a missing name only costs the card its label.
+      return "";
+    }
+  }
+
+  async _filterAccessibleFileThreads(rows, hub_id = this.hub.get(Attr.id)) {
+    const allowed = [];
+    const denied = [];
+    for (const row of toArray(rows)) {
+      const access = await this._resolveFileThreadAccess(
+        {
+          file_nid: row.file_nid,
+          file_thread_id: row.file_thread_id,
+        },
+        { hub_id, require_thread: true },
+      );
+      if (access.ok) {
+        allowed.push({
+          ...row,
+          file_nid: access.file_nid,
+          file_thread_id: access.file_thread_id,
+        });
+      } else {
+        denied.push({ row, access });
+      }
+    }
+    return { allowed, denied };
+  }
+
+  /**
+   * Restrict live recipients to users who can still read the backing file.
+   * A socket without a resolvable uid is excluded because its authorization
+   * cannot be proven at send time.
+   */
+  async _filterFileThreadRecipients(
+    recipients,
+    file_nid,
+    hub_id = this.hub.get(Attr.id),
+  ) {
+    const allowed = [];
+    for (const recipient of toArray(recipients)) {
+      if (!recipient || isEmpty(recipient.uid)) continue;
+      try {
+        const access = await this._resolveFileThreadAccess(
+          { file_nid },
+          { hub_id, uid: recipient.uid },
+        );
+        if (access.ok) allowed.push(recipient);
+      } catch (e) {
+        this.warn(
+          "channel._filterFileThreadRecipients: access check failed",
+          recipient.uid,
+          e && e.message,
+        );
+      }
+    }
+    return allowed;
+  }
+
+  async _acknowledgeResolvedFileThread(access, message_id, exclude) {
+    let row;
+    if (`${message_id}` === `${access.file_thread_id}`) {
+      await this.db.await_proc("channel_read_messages", message_id, this.uid);
+      row = { message_id, is_readed: 1, is_seen: 0 };
+    } else {
+      const res = await this.db.await_proc(
+        "channel_file_thread_read_messages",
+        `${message_id}`,
+        this.uid,
+        `${access.file_thread_id}`,
+      );
+      row = toArray(res)[0];
+    }
+    if (!row || `${row.message_id}` !== `${message_id}`) {
+      return {
+        ok: false,
+        failure: {
+          status: "INVALID_SELECTOR",
+          message_id,
+          file_thread_id: access.file_thread_id,
+        },
+      };
+    }
+
+    const hub_id = this.hub.get(Attr.id);
+    const acknowledgement = {
+      message_id: `${message_id}`,
+      file_thread_id: `${access.file_thread_id}`,
+      reader_id: this.uid,
+      is_readed: Number(row.is_readed) || 0,
+      is_seen: Number(row.is_seen) || 0,
+      key_id: hub_id,
+    };
+    let recipients = await this.yp.await_proc("entity_sockets", {
+      hub_id,
+      exclude,
+    });
+    recipients = await this._filterFileThreadRecipients(
+      recipients,
+      access.file_nid,
+      hub_id,
+    );
+    await RedisStore.sendData(
+      this.payload(acknowledgement, {
+        service: "channel.file_thread_acknowledge",
+      }),
+      recipients,
+    );
+    return { ok: true, result: acknowledgement };
+  }
+
+  async _validateGeneralReplyTarget(thread_id, hub_id) {
+    if (isEmpty(thread_id)) return { ok: true };
+    const access = await this._resolveFileThreadAccess(
+      { message_id: thread_id },
+      { hub_id, allow_general: true },
+    );
+    if (!access.ok) return access;
+    if (access.is_file_thread) {
+      return { ...access, ok: false, status: "INVALID_REPLY_SCOPE" };
+    }
+    return access;
+  }
+
+  /**
    * Folder windows live-append nodes from "media.new" payloads
    * (window/utils handleWsEvent) — the chat broadcast alone never reaches
    * the Files tab. Mirrors media.sendNodeAttributes.
@@ -552,8 +887,26 @@ class __private_channel extends Entity {
    * @param {*} uid
    * @returns
    */
-  async threadInfo(thread_id, uid) {
+  async threadInfo(thread_id, uid, expected_file_thread_id = null) {
     let thread = {};
+    const access = await this._resolveFileThreadAccess(
+      {
+        message_id: thread_id,
+        file_thread_id: expected_file_thread_id,
+      },
+      {
+        hub_id: uid,
+        allow_general: isEmpty(expected_file_thread_id),
+        require_thread: !isEmpty(expected_file_thread_id),
+      },
+    );
+    if (!access.ok) {
+      return {
+        message: "DELETED",
+        message_id: thread_id,
+        status: access.status,
+      };
+    }
     let data = await this.yp.await_proc(
       "forward_proc",
       uid,
@@ -1086,6 +1439,14 @@ class __private_channel extends Entity {
       return this.output.data({ status: "SCOPE_GONE", nid });
     }
 
+    const reply_access = await this._validateGeneralReplyTarget(
+      thread_id,
+      this.hub.get(Attr.id),
+    );
+    if (!reply_access.ok) {
+      return this.output.data(this._fileThreadFailure(reply_access));
+    }
+
     let message_id = await this.db.await_proc("message_id");
     let sbox;
     message_id = message_id.id;
@@ -1269,26 +1630,29 @@ class __private_channel extends Entity {
     if (isEmpty(file_nid) && isEmpty(file_thread_id)) {
       return this.output.data({ status: "INVALID_FILE" });
     }
+    const access = await this._resolveFileThreadAccess({
+      file_nid,
+      file_thread_id,
+    });
+    if (!access.ok) {
+      return this.output.data({
+        exists_thread: 0,
+        ...this._fileThreadFailure(access),
+      });
+    }
     let info = toArray(
       await this.db.await_proc(
         "channel_file_thread_info",
         this.uid,
-        `${file_nid || ""}`,
-        `${file_thread_id || ""}`,
+        `${access.file_nid}`,
+        "",
       ),
     )[0];
     if (isEmpty(info) || isEmpty(info.file_nid)) {
       return this.output.data({ exists_thread: 0, status: "NOT_FOUND" });
     }
-    // Validate the caller can read the file itself (hydrates rename/delete state).
-    const node = await this.db.await_proc(
-      "mfs_access_node",
-      this.uid,
-      `${info.file_nid}`,
-    );
-    if (isEmpty(node)) {
-      return this.output.data({ exists_thread: 0, status: "NO_PERMISSION" });
-    }
+    info.file_nid = access.file_nid;
+    if (access.file_thread_id) info.file_thread_id = access.file_thread_id;
     this.output.data(info);
   }
 
@@ -1303,42 +1667,21 @@ class __private_channel extends Entity {
     const file_nid = this.input.use("file_nid");
     const hub_id = this.hub.get(Attr.id);
 
-    if (isEmpty(file_thread_id)) {
-      if (isEmpty(file_nid)) return this.output.list([]);
-      const byFile = toArray(
-        await this.db.await_proc(
-          "channel_file_thread_info",
-          this.uid,
-          `${file_nid}`,
-          "",
-        ),
-      )[0];
-      if (isEmpty(byFile) || !Number(byFile.exists_thread)) {
-        return this.output.list([]);
-      }
-      file_thread_id = byFile.file_thread_id;
-    }
-
-    // Access check via the thread's file.
-    const info = toArray(
-      await this.db.await_proc(
-        "channel_file_thread_info",
-        this.uid,
-        "",
-        `${file_thread_id}`,
-      ),
-    )[0];
-    // Fail closed: if the thread's file cannot be resolved or the caller
-    // cannot read it, return no messages rather than leaking thread content.
-    if (isEmpty(info) || isEmpty(info.file_nid)) {
+    if (isEmpty(file_thread_id) && isEmpty(file_nid)) {
       return this.output.list([]);
     }
-    const node = await this.db.await_proc(
-      "mfs_access_node",
-      this.uid,
-      `${info.file_nid}`,
+
+    const access = await this._resolveFileThreadAccess(
+      { file_nid, file_thread_id },
+      { require_thread: true },
     );
-    if (isEmpty(node)) return this.output.list([]);
+    if (!access.ok) {
+      if (access.status === "NOT_FOUND" && isEmpty(file_thread_id)) {
+        return this.output.list([]);
+      }
+      return this.output.data(this._fileThreadFailure(access));
+    }
+    file_thread_id = access.file_thread_id;
 
     let data = toArray(
       await this.db.await_proc(
@@ -1367,7 +1710,11 @@ class __private_channel extends Entity {
         }
       }
       if (!isEmpty(message.thread_id)) {
-        message.thread = await this.threadInfo(message.thread_id, hub_id);
+        message.thread = await this.threadInfo(
+          message.thread_id,
+          hub_id,
+          file_thread_id,
+        );
       }
     }
     this.output.list(data);
@@ -1385,7 +1732,14 @@ class __private_channel extends Entity {
       this.uid,
       `${folder_nid}`,
     );
-    if (isEmpty(folder)) return this.output.list([]);
+    const folder_privilege = Number(
+      folder && (folder.privilege || folder.permission) || 0,
+    );
+    if (
+      isEmpty(folder)
+      || `${folder.status || ""}` !== "active"
+      || (folder_privilege & MFS_PERMISSION_READ) !== MFS_PERMISSION_READ
+    ) return this.output.list([]);
     const order = this.input.use(Attr.order, "desc");
     const page = this.input.use(Attr.page) || 1;
     let data = await this.db.await_proc(
@@ -1395,7 +1749,8 @@ class __private_channel extends Entity {
       order,
       page,
     );
-    this.output.list(toArray(data));
+    const { allowed } = await this._filterAccessibleFileThreads(data);
+    this.output.list(allowed);
   }
 
   /**
@@ -1407,31 +1762,23 @@ class __private_channel extends Entity {
     const message_id = this.input.use(Attr.message_id);
     let exclude = this.input.need(Attr.socket_id);
     if (exclude) exclude = [exclude];
-    let res = {};
-    // Nothing to acknowledge without a message_id; skip the channel_get('')
-    // lookup and the broadcast entirely.
-    if (message_id) {
-      res = await this.db.await_proc(
-        "channel_file_thread_read_messages",
-        `${message_id}`,
-        this.uid,
-        `${file_thread_id}`,
-      );
-      const message = await this.db.await_proc("channel_get", `${message_id}`);
-      if (!isEmpty(message)) {
-        message.key_id = this.hub.get(Attr.id);
-        message.file_thread_id = file_thread_id;
-        const recipients = await this.yp.await_proc("entity_sockets", {
-          hub_id: message.key_id,
-          exclude,
-        });
-        await RedisStore.sendData(
-          this.payload(message, { service: "channel.file_thread_acknowledge" }),
-          recipients,
-        );
-      }
+    const access = await this._resolveFileThreadAccess(
+      { file_thread_id, message_id },
+      { require_thread: true },
+    );
+    if (!access.ok) {
+      return this.output.data(this._fileThreadFailure(access, { message_id }));
     }
-    this.output.data(res);
+    if (!message_id) return this.output.data({});
+    const acknowledgement = await this._acknowledgeResolvedFileThread(
+      access,
+      message_id,
+      exclude,
+    );
+    if (!acknowledgement.ok) {
+      return this.output.data(acknowledgement.failure);
+    }
+    this.output.data(acknowledgement.result);
   }
 
   /**
@@ -1443,7 +1790,7 @@ class __private_channel extends Entity {
    * trusted from the client) and the original file is never auto-attached.
    */
   async file_thread_post() {
-    const file_nid = this.input.use("file_nid");
+    let file_nid = this.input.use("file_nid");
     if (isEmpty(file_nid)) {
       return this.output.data({ status: "INVALID_FILE" });
     }
@@ -1455,23 +1802,12 @@ class __private_channel extends Entity {
     let exclude = this.input.need(Attr.socket_id);
     if (exclude) exclude = [exclude];
 
-    // Validate the target file: exists, is a file (not folder/hub), readable.
-    const file_node = await this.db.await_proc(
-      "mfs_access_node",
-      this.uid,
-      `${file_nid}`,
-    );
-    if (isEmpty(file_node)) {
-      // mfs_access_node swallows SQLEXCEPTION and returns nothing for BOTH
-      // "no such node" and "caller denied" (F7/F4) — an empty result alone
-      // cannot tell gone from denied. Disambiguate with the dedicated
-      // existence check so a moved/purged file reports SCOPE_GONE instead
-      // of the misleading NO_PERMISSION.
-      if (!(await this._scopeExists(file_nid))) {
-        return this.output.data({ status: "SCOPE_GONE", nid: file_nid });
-      }
-      return this.output.data({ status: "NO_PERMISSION" });
+    const target_access = await this._resolveFileThreadAccess({ file_nid });
+    if (!target_access.ok) {
+      return this.output.data(this._fileThreadFailure(target_access, { nid: file_nid }));
     }
+    file_nid = `${target_access.file_nid}`;
+    const file_node = target_access.node;
     // mfs_access_node returns the node's media category as `filetype` and
     // UNIONs trash_media. Reject containers (folder/hub/root) — a file chat
     // only attaches to a real file; active files carry specific categories
@@ -1479,12 +1815,6 @@ class __private_channel extends Entity {
     const cat = `${file_node.filetype || ""}`;
     if (["folder", "hub", "root"].includes(cat)) {
       return this.output.data({ status: "INVALID_FILE" });
-    }
-    // Trashed/deleted nodes (trash_media rows surface as status 'deleted';
-    // 'orphaned' is a transient pre-purge state) are a gone-scope, not a
-    // malformed request — the file existed, it just moved into trash.
-    if (["deleted", "orphaned"].includes(`${file_node.status || ""}`)) {
-      return this.output.data({ status: "SCOPE_GONE", nid: file_nid });
     }
     const folder_nid = `${file_node.parent_id}`;
     if (isEmpty(folder_nid)) {
@@ -1496,6 +1826,32 @@ class __private_channel extends Entity {
     // client, per the same invariant as channel.post's folder-scope guard.
     if (!(await this._scopeExists(folder_nid))) {
       return this.output.data({ status: "SCOPE_GONE", nid: folder_nid });
+    }
+
+    if (!isEmpty(thread_id)) {
+      if (isEmpty(target_access.file_thread_id)) {
+        return this.output.data({
+          status: "INVALID_REPLY_SCOPE",
+          file_nid,
+        });
+      }
+      const reply_access = await this._resolveFileThreadAccess(
+        {
+          message_id: thread_id,
+          file_thread_id: target_access.file_thread_id,
+          file_nid,
+        },
+        { require_thread: true },
+      );
+      if (!reply_access.ok) {
+        const status = reply_access.status === "INVALID_SELECTOR"
+          ? "INVALID_REPLY_SCOPE"
+          : reply_access.status;
+        return this.output.data(this._fileThreadFailure(
+          { ...reply_access, status },
+          { file_nid },
+        ));
+      }
     }
 
     attachment = toArray(attachment).map(String);
@@ -1674,7 +2030,7 @@ class __private_channel extends Entity {
     );
 
     if (!isEmpty(thread_id)) {
-      data.thread = await this.threadInfo(thread_id, hub_id);
+      data.thread = await this.threadInfo(thread_id, hub_id, file_thread_id);
     }
     stampAuthorIdentity(this.user, data);
     data.hub_id = hub_id;
@@ -1688,10 +2044,15 @@ class __private_channel extends Entity {
       is_new,
     };
 
-    const recipients = await this.yp.await_proc("entity_sockets", {
+    let recipients = await this.yp.await_proc("entity_sockets", {
       exclude,
       hub_id,
     });
+    recipients = await this._filterFileThreadRecipients(
+      recipients,
+      file_nid,
+      hub_id,
+    );
 
     // On new thread, broadcast the folder-visible root card as a normal
     // channel.post so folder chat renders the "file thread started" card.
@@ -1736,9 +2097,14 @@ class __private_channel extends Entity {
           (id) => id !== this.uid && !hubRecipientUids.includes(id),
         );
         if (extraMentionIds.length) {
-          const mentionRecipients = await this.yp.await_proc(
+          let mentionRecipients = await this.yp.await_proc(
             "user_sockets",
             extraMentionIds,
+          );
+          mentionRecipients = await this._filterFileThreadRecipients(
+            mentionRecipients,
+            file_nid,
+            hub_id,
           );
           if (!isEmpty(mentionRecipients)) {
             await RedisStore.sendData(
@@ -1799,6 +2165,14 @@ class __private_channel extends Entity {
     const mention_ids = this.input.use("mention_ids", null);
     let exclude = this.input.need(Attr.socket_id);
     if (exclude) exclude = [exclude];
+
+    const reply_access = await this._validateGeneralReplyTarget(
+      thread_id,
+      this.hub.get(Attr.id),
+    );
+    if (!reply_access.ok) {
+      return this.output.data(this._fileThreadFailure(reply_access));
+    }
 
     let message_id = await this.db.await_proc("message_id");
     message_id = message_id.id;
@@ -2096,6 +2470,28 @@ class __private_channel extends Entity {
     let exclude = this.input.need(Attr.socket_id);
     if (exclude) exclude = [exclude];
 
+    if (message_id) {
+      const access = await this._resolveFileThreadAccess(
+        { message_id },
+        { allow_general: true },
+      );
+      if (!access.ok) {
+        return this.output.data(this._fileThreadFailure(access, { message_id }));
+      }
+      if (access.is_file_thread) {
+        const acknowledgement = await this._acknowledgeResolvedFileThread(
+          access,
+          message_id,
+          exclude,
+        );
+        return this.output.data(
+          acknowledgement.ok
+            ? acknowledgement.result
+            : acknowledgement.failure,
+        );
+      }
+    }
+
     let res = {};
     res = await this.db.await_proc("acknowledge_message", message_id, this.uid);
     // Persist the reader into metadata._seen_ for every message up to message_id
@@ -2130,6 +2526,13 @@ class __private_channel extends Entity {
     if (!glyphs.length || glyphs.length > 8 || /['"\\\s]/.test(emoji)) {
       return this.output.data({ status: "INVALID_EMOJI" });
     }
+    const access = await this._resolveFileThreadAccess(
+      { message_id },
+      { allow_general: true },
+    );
+    if (!access.ok) {
+      return this.output.data(this._fileThreadFailure(access, { message_id }));
+    }
     const res = await this.db.await_proc(
       "message_reaction_toggle",
       message_id,
@@ -2140,7 +2543,14 @@ class __private_channel extends Entity {
     const reactions = row && row.reactions ? this.parseJSON(row.reactions) : {};
     const hub_id = this.hub.get(Attr.id);
     const data = { message_id, reactions, key_id: hub_id };
-    const recipients = await this.yp.await_proc("entity_sockets", { hub_id, exclude });
+    let recipients = await this.yp.await_proc("entity_sockets", { hub_id, exclude });
+    if (access.is_file_thread) {
+      recipients = await this._filterFileThreadRecipients(
+        recipients,
+        access.file_nid,
+        hub_id,
+      );
+    }
     await RedisStore.sendData(
       this.payload(data, { service: "channel.react" }),
       recipients
@@ -2159,6 +2569,13 @@ class __private_channel extends Entity {
   async meeting_end() {
     const message_id = this.input.need(Attr.message_id);
     if (!message_id) return this.output.data({ found: 0 });
+    const access = await this._resolveFileThreadAccess(
+      { message_id },
+      { allow_general: true },
+    );
+    if (!access.ok) {
+      return this.output.data(this._fileThreadFailure(access, { message_id }));
+    }
     const res = await this.db.await_proc("channel_meeting_end", message_id);
     const row = Array.isArray(res) ? res[0] : res;
     if (!row || !row.found) return this.output.data({ found: 0 });
@@ -2167,6 +2584,13 @@ class __private_channel extends Entity {
     let recipients = await this.yp.await_proc("entity_sockets", {
       hub_id: message.key_id,
     });
+    if (access.is_file_thread) {
+      recipients = await this._filterFileThreadRecipients(
+        recipients,
+        access.file_nid,
+        message.key_id,
+      );
+    }
     await RedisStore.sendData(this.payload(message), recipients);
     this.output.data(message);
   }
@@ -2270,14 +2694,24 @@ class __private_channel extends Entity {
     let res = {};
     let data = {};
     let temp_result = [];
+    const accessByMessage = new Map();
 
     if (option != "me" && option != "all") {
       res.status = "INVALID_OPTION";
       return this.output.data(res);
     }
+    messages = toArray(messages).map(String);
     let invalid_messageid = 0;
     let invalid_option = 0;
     for (let message_id of messages) {
+      const access = await this._resolveFileThreadAccess(
+        { message_id },
+        { allow_general: true },
+      );
+      if (!access.ok) {
+        return this.output.data(this._fileThreadFailure(access, { message_id }));
+      }
+      accessByMessage.set(`${message_id}`, access);
       data = await this.db.await_proc("channel_get", message_id);
       if (isEmpty(data)) {
         invalid_messageid = invalid_messageid + 1;
@@ -2340,6 +2774,14 @@ class __private_channel extends Entity {
           "entity_sockets",
           this.hub.get(Attr.id),
         );
+        const access = accessByMessage.get(`${message.message_id}`);
+        if (access && access.is_file_thread) {
+          recipients = await this._filterFileThreadRecipients(
+            recipients,
+            access.file_nid,
+            this.hub.get(Attr.id),
+          );
+        }
         await RedisStore.sendData(this.payload(message), recipients);
       }
     }
@@ -2360,6 +2802,14 @@ class __private_channel extends Entity {
   async bookmark_add() {
     const message_id = this.input.need("message_id");
     const hub_id = this.input.need("hub_id");
+
+    const access = await this._resolveFileThreadAccess(
+      { message_id },
+      { hub_id, allow_general: true },
+    );
+    if (!access.ok) {
+      return this.output.data(this._fileThreadFailure(access, { message_id }));
+    }
 
     const user_db = await this.yp.await_func("get_db_name", this.uid);
     if (!user_db) return this.exception.server("USER_DB_NOT_FOUND");
@@ -2397,11 +2847,19 @@ class __private_channel extends Entity {
     const user_db = await this.yp.await_func("get_db_name", this.uid);
     if (!user_db) return this.exception.server("USER_DB_NOT_FOUND");
 
-    const data = await this.yp.await_proc(
+    const data = toArray(await this.yp.await_proc(
       `${user_db}.notification_bookmark_list`,
       page,
-    );
-    this.output.list(data);
+    ));
+    const allowed = [];
+    for (const bookmark of data) {
+      const access = await this._resolveFileThreadAccess(
+        { message_id: bookmark.message_id },
+        { hub_id: bookmark.hub_id, allow_general: true },
+      );
+      if (access.ok) allowed.push(bookmark);
+    }
+    this.output.list(allowed);
   }
 
   /**
@@ -2651,7 +3109,14 @@ class __private_channel extends Entity {
    */
   async list_by_file() {
     const file_nid = this.input.need("file_nid");
-    const data = await this.db.await_proc("channel_list_by_file", file_nid);
+    const access = await this._resolveFileThreadAccess({ file_nid });
+    if (!access.ok) {
+      return this.output.data(this._fileThreadFailure(access));
+    }
+    const data = await this.db.await_proc(
+      "channel_list_by_file",
+      access.file_nid,
+    );
     this.output.list(data);
   }
 
@@ -2663,12 +3128,16 @@ class __private_channel extends Entity {
    */
   async list_thread_by_file() {
     const file_nid = this.input.need("file_nid");
+    const access = await this._resolveFileThreadAccess({ file_nid });
+    if (!access.ok) {
+      return this.output.data(this._fileThreadFailure(access));
+    }
     const hub_id = this.hub.get(Attr.id);
-    const pattern = `mention:${hub_id}:${file_nid}`;
+    const pattern = `mention:${hub_id}:${access.file_nid}`;
 
     const attachHits = await this.db.await_proc(
       "channel_list_by_file",
-      file_nid,
+      access.file_nid,
     );
     let mentionHits = [];
     try {
@@ -2840,23 +3309,18 @@ class __private_channel extends Entity {
       return this.output.list([]);
     }
 
-    // Resolve the file thread from file_nid when the client knows only the file
-    // (in-place file-thread scope before its thread id resolved client-side). A
-    // file with no thread yet has no messages, so return [] rather than falling
-    // back to the team chat (which would show the wrong conversation).
-    if (isEmpty(file_thread_id) && !isEmpty(file_nid)) {
-      const byFile = toArray(
-        await this.db.await_proc(
-          "channel_file_thread_info",
-          this.uid,
-          `${file_nid}`,
-          "",
-        ),
-      )[0];
-      if (isEmpty(byFile) || !Number(byFile.exists_thread)) {
-        return this.output.list([]);
+    if (!isEmpty(file_thread_id) || !isEmpty(file_nid)) {
+      const access = await this._resolveFileThreadAccess(
+        { file_thread_id, file_nid },
+        { require_thread: true },
+      );
+      if (!access.ok) {
+        if (access.status === "NOT_FOUND" && isEmpty(file_thread_id)) {
+          return this.output.list([]);
+        }
+        return this.output.data(this._fileThreadFailure(access));
       }
-      file_thread_id = byFile.file_thread_id;
+      file_thread_id = access.file_thread_id;
     }
 
     const hub_id = this.hub.get(Attr.id);
@@ -3001,7 +3465,7 @@ class __private_channel extends Entity {
         );
         if (!rows.length) break;
         for (const row of rows) {
-          const msg = this._normalizeMessage(row);
+          let rootThread = null;
           // Root cards are folder-visible "thread started" markers, not chat.
           if (row.message_type === "file.thread") {
             let meta = {};
@@ -3009,9 +3473,15 @@ class __private_channel extends Entity {
               meta = typeof row.metadata === "string"
                 ? jsonParse(row.metadata) : row.metadata || {};
             } catch (_) {}
-            const ft = ftByFileNid.get(`${meta._file_nid}`);
+            rootThread = ftByFileNid.get(`${meta._file_nid}`);
+            // A root card is file-thread-derived. If its canonical file was
+            // filtered by current access or is no longer live, omit the card.
+            if (!rootThread) continue;
+          }
+          const msg = this._normalizeMessage(row);
+          if (rootThread) {
             msg.type = "event";
-            msg.text = `Chat thread started for "${(ft && ft.filename) || meta._file_nid || "a file"}"`;
+            msg.text = `Chat thread started for "${rootThread.filename || "a file"}"`;
           }
           // Legacy rows (no _scope_nid) surface in every folder in the live
           // UI — group them into the export root section.
@@ -3195,8 +3665,12 @@ class __private_channel extends Entity {
     const message_count = countRow ? Number(countRow.message_count) : 0;
 
     // List active file threads inside the subtree
-    const file_threads = toArray(
+    const raw_file_threads = toArray(
       await this.db.await_proc("channel_export_file_thread_list", this.uid, root_nid),
+    );
+    const { allowed: file_threads } = await this._filterAccessibleFileThreads(
+      raw_file_threads,
+      hub_id,
     );
 
     const folder_tree = toArray(
@@ -3297,7 +3771,7 @@ class __private_channel extends Entity {
     // to include, thread_sel picks which file threads. Each is 'all' | array |
     // 'none'. When absent, fall back from the legacy scope_sel/include_folders
     // contract so older clients keep working (see _legacyScope).
-    const { folder_sel, thread_sel } = this._resolveScope();
+    let { folder_sel, thread_sel } = this._resolveScope();
 
     const date_start = this.input.use("start_date") || null;
     const date_end = this.input.use("end_date") || null;
@@ -3311,9 +3785,34 @@ class __private_channel extends Entity {
     }
 
     // Resolve the subtree's active file threads once (needed for scope + count)
-    const file_threads = toArray(
+    const raw_file_threads = toArray(
       await this.db.await_proc("channel_export_file_thread_list", this.uid, root_nid),
     );
+    const { allowed: file_threads } = await this._filterAccessibleFileThreads(
+      raw_file_threads,
+    );
+
+    if (Array.isArray(thread_sel)) {
+      for (const requested_thread_id of thread_sel) {
+        const access = await this._resolveFileThreadAccess(
+          { file_thread_id: requested_thread_id },
+          { require_thread: true },
+        );
+        if (!access.ok) {
+          return this.output.data(this._fileThreadFailure(access));
+        }
+      }
+    }
+    if (thread_sel === "all") {
+      thread_sel = file_threads.map((ft) => `${ft.file_thread_id}`);
+    } else if (Array.isArray(thread_sel)) {
+      const allowed_ids = new Set(
+        file_threads.map((ft) => `${ft.file_thread_id}`),
+      );
+      thread_sel = thread_sel
+        .map(String)
+        .filter((id) => allowed_ids.has(id));
+    }
 
     // ── 10k guard ────────────────────────────────────────────────────────────
     // Folder chat: counted via channel_export_count (date-aware, whole subtree).
@@ -3392,6 +3891,40 @@ class __private_channel extends Entity {
     const stageDir = pathResolve(tmp_dir, DOWNLOAD_FOLDER, this.uid, zipid);
     mkdirSync(stageDir, { recursive: true });
 
+    // Bind the staged artifact to every file thread whose content or root-card
+    // metadata may appear in it. export_fetch revalidates this manifest so a
+    // later ACL revocation also invalidates an already-generated download.
+    const artifactThreads = new Map();
+    for (const ft of selectedFts) {
+      artifactThreads.set(`${ft.file_thread_id}`, ft);
+    }
+    if (includeHub) {
+      for (const ft of file_threads) {
+        artifactThreads.set(`${ft.file_thread_id}`, ft);
+      }
+    }
+    const authorized_file_threads = Array.from(artifactThreads.values()).map(
+      (ft) => ({
+        file_thread_id: `${ft.file_thread_id}`,
+        file_nid: `${ft.file_nid}`,
+        filename: ft.filename || "",
+        folder_nid: ft.folder_nid || null,
+        folder_name: ft.folder_name || null,
+      }),
+    );
+    writeFileSync(
+      pathJoin(stageDir, EXPORT_ACCESS_MANIFEST),
+      stringify({
+        schema_version: 1,
+        hub_id: `${this.hub.get(Attr.id)}`,
+        file_threads: authorized_file_threads.map((ft) => ({
+          file_thread_id: ft.file_thread_id,
+          file_nid: ft.file_nid,
+        })),
+      }),
+      "utf8",
+    );
+
     // ── JSON (synchronous) ────────────────────────────────────────────────────
     if (format === "json") {
       const sections = await this._gatherSections({
@@ -3445,6 +3978,7 @@ class __private_channel extends Entity {
       zipname,
       socket_id,
       lang,
+      authorized_file_threads,
     };
 
     const cmd = pathResolve(OFFLINE_DIR, "chat-export.js");
@@ -3466,24 +4000,71 @@ class __private_channel extends Entity {
    * Creates a symlink under mfs_dir so nginx can serve the file.
    */
   async export_fetch() {
-    const zipid = this.input.need("zipid");
-    const zipname = this.input.need("zipname") || "export";
+    const zipid = `${this.input.need("zipid") || ""}`;
+    const zipname = `${this.input.need("zipname") || "export"}`;
 
-    const src = pathJoin(tmp_dir, DOWNLOAD_FOLDER, this.uid, zipid, zipname);
+    if (
+      !FILE_THREAD_SELECTOR_RE.test(zipid)
+      || !/^[0-9a-zA-Z_.-]{1,255}\.(json|pdf)$/.test(zipname)
+    ) {
+      return this.output.data({ status: "INVALID_SELECTOR" });
+    }
+
+    const stageDir = pathJoin(tmp_dir, DOWNLOAD_FOLDER, this.uid, zipid);
+    const src = pathJoin(stageDir, zipname);
+    const ext = zipname.split(".").pop().toLowerCase();
+    const target = pathJoin(mfs_dir, DOWNLOAD_FOLDER, this.uid, zipid);
+    const file = pathJoin(target, `${zipid}.${ext}`);
+    // Remove any link issued by an earlier fetch before current ACL checks.
+    // A denied retry therefore cannot keep using the prior service path.
+    if (existsSync(file)) rmSync(file);
     const fileio = new FileIo(this);
     if (!existsSync(src)) {
       return fileio.not_found();
     }
 
+    let manifest;
+    try {
+      manifest = jsonParse(
+        readFileSync(pathJoin(stageDir, EXPORT_ACCESS_MANIFEST), "utf8"),
+      );
+    } catch (_) {
+      return fileio.not_found();
+    }
+    const hub_id = `${manifest && manifest.hub_id || ""}`;
+    const manifestThreads = manifest && manifest.file_threads;
+    if (
+      Number(manifest && manifest.schema_version) !== 1
+      || hub_id !== `${this.hub.get(Attr.id)}`
+      || !Array.isArray(manifestThreads)
+    ) {
+      return fileio.not_found();
+    }
+    for (const ft of manifestThreads) {
+      if (
+        !ft
+        || !FILE_THREAD_SELECTOR_RE.test(`${ft.file_thread_id || ""}`)
+        || !FILE_THREAD_SELECTOR_RE.test(`${ft.file_nid || ""}`)
+      ) {
+        return fileio.not_found();
+      }
+      const access = await this._resolveFileThreadAccess(
+        {
+          file_thread_id: `${ft.file_thread_id}`,
+          file_nid: `${ft.file_nid}`,
+        },
+        { hub_id, require_thread: true },
+      );
+      if (!access.ok) {
+        return this.output.data(this._fileThreadFailure(access));
+      }
+    }
+
     // Stable, space-free symlink under mfs_dir; FileIo.static() builds the
     // correct X-Accel-Redirect path (mirrors media.zip() — manual header
     // stripping produced an nginx path that 404'd: "File wasn't available").
-    const ext = zipname.split(".").pop().toLowerCase();
     const mimetype = EXPORT_MIME[ext] || "application/octet-stream";
-    const target = pathJoin(mfs_dir, DOWNLOAD_FOLDER, this.uid, zipid);
     mkdirSync(target, { recursive: true });
-    const file = pathJoin(target, `${zipid}.${ext}`);
-    if (existsSync(file)) rmSync(file);
     symlinkSync(src, file);
 
     fileio.static({ path: file, name: zipname, mimetype, code: 200 });

--- a/service/private/hub.js
+++ b/service/private/hub.js
@@ -28,6 +28,7 @@ const {
   ID_NOT_FOUND,
 } = Constants;
 const { resolve } = require("path");
+const { notifyMemberJoined } = require("../lib/notify-member-joined");
 
 /**
  * Configured envelope sender (email.json -> auth.user), resolved once. Used to
@@ -907,6 +908,11 @@ class __private_hub extends Hub {
         err && err.message
       );
     }
+    // Notify online members (admins with the Folder settings permission matrix
+    // open) so the new member appears immediately without a manual reload.
+    // Covers both callers of _grantMembership: invite() branch B (drumate
+    // already exists) and add_contributors().
+    await notifyMemberJoined(this, this.hub.get(Attr.id), uid);
     return r;
   }
 
@@ -1275,6 +1281,10 @@ class __private_hub extends Hub {
       entity_id: hub_id,
       log: `Invite accepted — ${this.user.get(Attr.email) || this.uid} joined the workspace`,
     });
+    // Notify the workspace's online members that a member just joined via
+    // token redemption — accept_invite pushed nothing before, so admins with
+    // the Folder settings matrix open were stuck with a stale member list.
+    await notifyMemberJoined(this, hub_id, this.uid);
     this.output.data({ hub_id });
   }
 
@@ -1606,6 +1616,11 @@ class __private_hub extends Hub {
         const sockets = await this.yp.await_proc('user_sockets', recipient.id);
         await RedisStore.sendData(this.payload(hub), sockets);
       }
+
+      // One broadcast per hub is enough — the matrix refetches the whole
+      // member list. uid is left null: this is an admin-driven multi-add, so
+      // every online member (including the acting admin) should refresh.
+      await notifyMemberJoined(this, hub_id, null);
 
       results.push({ hub_id, added: members.length });
     }

--- a/service/private/hub.js
+++ b/service/private/hub.js
@@ -353,13 +353,23 @@ class __private_hub extends Hub {
    * @param {string} [token] anonymous share token, external only
    * @returns {string} absolute URL
    */
-  _guestLandingLink(hubname, external, token) {
+  _guestLandingLink(hubname, external, token, hub_id) {
     const q = [
       "view=guest",
       `scope=${external ? "external" : "internal"}`,
       `name=${encodeURIComponent(hubname || "")}`,
     ];
     if (external && token) q.push(`token=${encodeURIComponent(token)}`);
+    // Which workspace this invite is for. Carried on BOTH scopes so the landing
+    // page can remember it across sign-in and offer to open it afterwards.
+    //
+    // External could infer it from the token (dmz.list_by_token returns hub_id),
+    // internal has no token and could not — so the id travels on the link and
+    // both scopes work the same way.
+    //
+    // It grants nothing on its own: every service behind it still authorises the
+    // caller's session, and the recipient is being invited to this workspace.
+    if (hub_id) q.push(`hub=${encodeURIComponent(hub_id)}`);
     return `${this._endpointBase()}/#/welcome/signin?${q.join("&")}`;
   }
 
@@ -1120,9 +1130,6 @@ class __private_hub extends Hub {
     // The ONE axis the email body varies on: internal (private) vs external
     // (shared) workspace. Also decides whether the workspace preview is redacted.
     const workspace_external = isExternalArea(area);
-    // Narrower than workspace_external (excludes `dmz`) and used ONLY to gate the
-    // pending_invitation fallback below, preserving the pre-existing behaviour.
-    const isShareLink = (area === "share");
     const EXPIRY_DAYS = 7;
     const expiryTs = Math.floor(Date.now() / 1000) + EXPIRY_DAYS * 86400;
     const message = this.input.use(Attr.message)
@@ -1144,7 +1151,9 @@ class __private_hub extends Hub {
     // external => Figma 1602:77081 (shared contents), internal => 1602:76946
     // (redacted behind the Content Restricted gate). The token travels only on the
     // external link, which is the one whose page reads real content.
-    const ctaLink = this._guestLandingLink(hubname, workspace_external, shareToken);
+    const ctaLink = this._guestLandingLink(
+      hubname, workspace_external, shareToken, this.hub.get(Attr.id)
+    );
     // Address-book context resolved once for the whole call (see
     // _rememberInvitee). Null when the inviter has no drumate DB — the invite
     // still goes through, it just isn't remembered.
@@ -1186,15 +1195,29 @@ class __private_hub extends Hub {
           }
         } else {
           // No account yet: mint an invite token so the address can be redeemed
-          // after sign-up. `isShareLink` (area === "share" exactly) still gates the
-          // pending_invitation fallback — unchanged on purpose, since which rows a
-          // newcomer's invite writes is functional behaviour, not email copy.
+          // after sign-up, AND record a pending invitation so the membership is
+          // actually granted when the account appears.
+          //
+          // The pending row is what does the granting: signup's create_account
+          // calls _resolve_pending_invitation(email), which reads
+          // pending_invitation_get_by_email and adds the new user to each hub.
+          // Nothing anywhere redeems the invite TOKEN during sign-up — it is for
+          // the link flow — so an invite that writes only a token leaves the
+          // person with no membership at all.
+          //
+          // This used to be gated on `!isShareLink`, which excluded exactly the
+          // external (area === "share") workspaces: an invitee with no account
+          // signed up, was never added, and landed on a desk showing only the
+          // three default workspaces. Opening the workspace they were invited to
+          // then failed with "the file you requested does not exist", which is
+          // what a hub with no grant looks like from the client.
+          //
+          // Internal is unaffected: it already took the branch that writes this
+          // row, and it still writes exactly the same row.
           await this._addInviteToken(email, hubId, privilege, expiryTs);
-          if (!isShareLink) {
-            await this.yp.await_proc(
-              "yp_add_pending_invitation", hubId, 0, privilege, email
-            );
-          }
+          await this.yp.await_proc(
+            "yp_add_pending_invitation", hubId, 0, privilege, email
+          );
           await writeAudit(this, {
             db: this.hub.get(Attr.db_name),
             uid: this.uid,

--- a/service/private/hub.js
+++ b/service/private/hub.js
@@ -324,26 +324,62 @@ class __private_hub extends Hub {
   }
 
   /**
-   * Anonymous guest landing page for an INTERNAL workspace — the signin plugin's
-   * signin_guest widget (Figma 1602:76946 "Guest Landing Page (Viral) Restricted"):
-   * the workspace shown as redacted placeholders behind a "Content Restricted"
-   * card, with Login / Join Workspace CTAs.
+   * Anonymous guest landing page — the signin plugin's signin_guest widget. BOTH
+   * halves of the invite CTA land here; `scope` picks which layout it renders:
    *
-   * Used instead of the #/dmz/share/<token> view because an internal workspace has
-   * nothing a guest may browse — the share view would render an empty or view-only
-   * folder. An EXTERNAL workspace keeps the share link, which is the page in Figma
-   * 1602:77081 ("Link shared") and is already implemented by ui-team's dmz_sharebox.
+   *   internal  Figma 1602:76946 "Guest Landing Page (Viral) Restricted" —
+   *             redacted placeholders behind a "Content Restricted" card
+   *   external  Figma 1602:77081 "Guest Landing Page (Viral) Link shared" —
+   *             the shared folder's contents, no gate
    *
-   * `name` rides along so the landing page's header shows the real workspace name
-   * instead of its generic localized fallback; the page itself stays API-free.
+   * Preferred over linking straight at #/dmz/share/<token>: the landing page is the
+   * page these two designs specify, it works for recipients with and without an
+   * account, and it carries the Login / Join Workspace conversion CTAs.
+   *
+   * `name` rides along so the header shows the real workspace name instead of its
+   * generic localized fallback.
+   *
+   * `token` is the hub's anonymous share token, and it is sent ONLY for an external
+   * workspace — the external layout browses the real shared folder (show_node_by)
+   * and reads the conversation, and the token is what authorises that for a visitor
+   * with no session (dmz.login consumes it; the granted privilege stays server-side
+   * in _publicSharePermission — VIEW for internal, DOWNLOAD for external).
+   *
+   * An internal workspace gets NO token: its layout is the redacted gate, so there
+   * is nothing for a guest to fetch and no reason to hand out access.
    *
    * @param {string} hubname workspace display name
+   * @param {boolean} [external] true for a shared workspace, false/omitted for internal
+   * @param {string} [token] anonymous share token, external only
    * @returns {string} absolute URL
    */
-  _guestLandingLink(hubname) {
-    const base = this.input.homepath(this.hub.get(Attr.hostname));
-    const q = `view=guest&name=${encodeURIComponent(hubname || "")}`;
-    return `${base}#/welcome/signin?${q}`;
+  _guestLandingLink(hubname, external, token) {
+    const q = [
+      "view=guest",
+      `scope=${external ? "external" : "internal"}`,
+      `name=${encodeURIComponent(hubname || "")}`,
+    ];
+    if (external && token) q.push(`token=${encodeURIComponent(token)}`);
+    return `${this._endpointBase()}/#/welcome/signin?${q.join("&")}`;
+  }
+
+  /**
+   * Canonical app base for links mailed to people who are NOT yet in a workspace:
+   * `https://<main_domain><endpoint_path>`, the same shape analytics-server's
+   * _endpointBase() uses for the reward campaign's desk link.
+   *
+   * Deliberately NOT input.homepath(hub.hostname), which the share links use. That
+   * builds a per-hub host from the request's own path, which is right for opening a
+   * specific workspace but wrong for a generic app route: the guest landing page is
+   * served by the app at its endpoint, not per workspace. `endpoint_path` already
+   * carries the endpoint name on a non-main install (sysEnv joins it onto
+   * app_routing_mark), so this stays correct on multi-endpoint deployments.
+   *
+   * @returns {string} e.g. "https://drumee.com/-"
+   */
+  _endpointBase() {
+    const { main_domain, endpoint_path } = sysEnv();
+    return `https://${main_domain}${endpoint_path || "/-"}`;
   }
 
   /**
@@ -369,8 +405,15 @@ class __private_hub extends Hub {
    * On an existing room the area-based permission is re-applied via
    * dmz_update_permission_next so the share token is preserved (not regenerated)
    * for previously-sent links.
+   *
+   * Returns the raw TOKEN, not a URL: the invite email's CTA is the guest landing
+   * page (_guestLandingLink), which needs the token as a query param rather than a
+   * #/dmz/share/<token> path. Called on every invite for its side effects too — it
+   * creates the external room on first use and re-applies the guest permission.
+   *
+   * @returns {string} the share token, or "" when the room has none
    */
-  async _ensurePublicShareLink() {
+  async _ensurePublicShareToken() {
     const nid = this.home_id;
     const hub_id = this.hub.get(Attr.id);
     let rows = await this.db.await_proc("dmz_settings") || [];
@@ -382,7 +425,7 @@ class __private_hub extends Hub {
     } else {
       await this.yp.await_proc("dmz_update_permission_next", hub_id, nid, this._publicSharePermission());
     }
-    return this._getShareLink(res && res.link);
+    return (res && res.link) || "";
   }
 
   /**
@@ -1092,18 +1135,16 @@ class __private_hub extends Hub {
     // Latest 2 non-meeting messages for the "Recent Activity" preview; shown
     // (clear) for external workspaces, kept redacted for internal ones.
     const recent_messages = await this._recentMessages();
-    // Anonymous public share link for the hub. Still resolved unconditionally —
-    // it creates the external room on first use and re-applies the area-based guest
-    // permission, both of which must happen whatever the email links to. Computed
-    // once (one shared token per hub).
-    const publicLink = await this._ensurePublicShareLink();
-    // Where the email's CTA goes, per workspace scope:
-    //   external -> the share view itself (Figma 1602:77081, ui-team dmz_sharebox)
-    //   internal -> the guest landing gate (Figma 1602:76946, signin_guest)
-    // Both open with no login; neither exposes content the scope doesn't allow.
-    const ctaLink = workspace_external
-      ? publicLink
-      : this._guestLandingLink(hubname);
+    // Anonymous share token for the hub. Resolved unconditionally — it creates the
+    // external room on first use and re-applies the area-based guest permission,
+    // both of which must happen whatever the email links to. Computed once (one
+    // shared token per hub).
+    const shareToken = await this._ensurePublicShareToken();
+    // Both CTA halves open the guest landing page; `scope` selects its layout —
+    // external => Figma 1602:77081 (shared contents), internal => 1602:76946
+    // (redacted behind the Content Restricted gate). The token travels only on the
+    // external link, which is the one whose page reads real content.
+    const ctaLink = this._guestLandingLink(hubname, workspace_external, shareToken);
     // Address-book context resolved once for the whole call (see
     // _rememberInvitee). Null when the inviter has no drumate DB — the invite
     // still goes through, it just isn't remembered.

--- a/service/private/hub.js
+++ b/service/private/hub.js
@@ -324,53 +324,41 @@ class __private_hub extends Hub {
   }
 
   /**
-   * Anonymous guest landing page — the signin plugin's signin_guest widget. BOTH
-   * halves of the invite CTA land here; `scope` picks which layout it renders:
+   * The invite CTA: the sign-in form, with the invited workspace named on the URL.
    *
-   *   internal  Figma 1602:76946 "Guest Landing Page (Viral) Restricted" —
-   *             redacted placeholders behind a "Content Restricted" card
-   *   external  Figma 1602:77081 "Guest Landing Page (Viral) Link shared" —
-   *             the shared folder's contents, no gate
+   *   <endpoint>/#/welcome/signin?hub_id=<hub_id>&name=<workspace>
    *
-   * Preferred over linking straight at #/dmz/share/<token>: the landing page is the
-   * page these two designs specify, it works for recipients with and without an
-   * account, and it carries the Login / Join Workspace conversion CTAs.
+   * The frontend does the rest. welcome/index.js reads both params and arms them
+   * (libs/hub-deep-link); once the recipient is authenticated — however they got
+   * there, by sign-in, sign-up, or an already-live session — the desk offers to
+   * open the workspace ("Open Workspace" / "Cancel"), and confirming opens it
+   * through the app's own #/desk/wm/open/ deep link.
    *
-   * `name` rides along so the header shows the real workspace name instead of its
-   * generic localized fallback.
+   * `name` is display copy for that prompt, nothing more: it names the workspace in
+   * the message instead of the generic fallback. It is never trusted as an
+   * identity — `hub_id` alone selects the workspace, and the services behind it
+   * authorise the caller's own session.
    *
-   * `token` is the hub's anonymous share token, and it is sent ONLY for an external
-   * workspace — the external layout browses the real shared folder (show_node_by)
-   * and reads the conversation, and the token is what authorises that for a visitor
-   * with no session (dmz.login consumes it; the granted privilege stays server-side
-   * in _publicSharePermission — VIEW for internal, DOWNLOAD for external).
+   * Replaces the former guest landing page (?view=guest&scope=…&token=…&hub=…),
+   * which cost two extra clicks — one to leave the landing page, one on the desk's
+   * "Open Workspace" prompt — to show a preview this email already contains. See
+   * docs/superpowers/specs/2026-08-02-invite-cta-skip-guest-landing-design.md.
+   * Links already sitting in inboxes still carry the old query and still work:
+   * nothing on the guest path has been removed.
    *
-   * An internal workspace gets NO token: its layout is the redacted gate, so there
-   * is nothing for a guest to fetch and no reason to hand out access.
+   * `hub_id` grants nothing on its own — every service behind it still authorises
+   * the caller's session, and the recipient is being invited to this workspace.
    *
-   * @param {string} hubname workspace display name
-   * @param {boolean} [external] true for a shared workspace, false/omitted for internal
-   * @param {string} [token] anonymous share token, external only
+   * @param {string|number} hub_id the workspace being invited to
+   * @param {string} [hubname] workspace display name, for the prompt's copy
    * @returns {string} absolute URL
    */
-  _guestLandingLink(hubname, external, token, hub_id) {
-    const q = [
-      "view=guest",
-      `scope=${external ? "external" : "internal"}`,
-      `name=${encodeURIComponent(hubname || "")}`,
-    ];
-    if (external && token) q.push(`token=${encodeURIComponent(token)}`);
-    // Which workspace this invite is for. Carried on BOTH scopes so the landing
-    // page can remember it across sign-in and offer to open it afterwards.
-    //
-    // External could infer it from the token (dmz.list_by_token returns hub_id),
-    // internal has no token and could not — so the id travels on the link and
-    // both scopes work the same way.
-    //
-    // It grants nothing on its own: every service behind it still authorises the
-    // caller's session, and the recipient is being invited to this workspace.
-    if (hub_id) q.push(`hub=${encodeURIComponent(hub_id)}`);
-    return `${this._endpointBase()}/#/welcome/signin?${q.join("&")}`;
+  _inviteCtaLink(hub_id, hubname) {
+    const base = `${this._endpointBase()}/#/welcome/signin`;
+    if (!hub_id) return base;
+    const q = [`hub_id=${encodeURIComponent(hub_id)}`];
+    if (hubname) q.push(`name=${encodeURIComponent(hubname)}`);
+    return `${base}?${q.join("&")}`;
   }
 
   /**
@@ -407,19 +395,16 @@ class __private_hub extends Hub {
   }
 
   /**
-   * Return the hub's anonymous public share link (#/dmz/share/<token>), creating
-   * the external room on first use. Invite emails point here so recipients can
-   * open the workspace with no login (the dmz module + dmz.login + show_node_by
-   * are all anonymous-scoped), instead of the private #/desk/wm/hub/ route.
+   * Ensure the hub HAS an anonymous public share room, and return its token.
    *
    * On an existing room the area-based permission is re-applied via
    * dmz_update_permission_next so the share token is preserved (not regenerated)
    * for previously-sent links.
    *
-   * Returns the raw TOKEN, not a URL: the invite email's CTA is the guest landing
-   * page (_guestLandingLink), which needs the token as a query param rather than a
-   * #/dmz/share/<token> path. Called on every invite for its side effects too — it
-   * creates the external room on first use and re-applies the guest permission.
+   * invite() calls this for the SIDE EFFECTS alone and drops the token: the CTA is
+   * now the sign-in form (_inviteCtaLink), not a share link. The room still has to
+   * exist and still has to carry the right guest permission, because copy_link and
+   * the share panel both hand that same room out.
    *
    * @returns {string} the share token, or "" when the room has none
    */
@@ -1142,18 +1127,15 @@ class __private_hub extends Hub {
     // Latest 2 non-meeting messages for the "Recent Activity" preview; shown
     // (clear) for external workspaces, kept redacted for internal ones.
     const recent_messages = await this._recentMessages();
-    // Anonymous share token for the hub. Resolved unconditionally — it creates the
-    // external room on first use and re-applies the area-based guest permission,
-    // both of which must happen whatever the email links to. Computed once (one
-    // shared token per hub).
-    const shareToken = await this._ensurePublicShareToken();
-    // Both CTA halves open the guest landing page; `scope` selects its layout —
-    // external => Figma 1602:77081 (shared contents), internal => 1602:76946
-    // (redacted behind the Content Restricted gate). The token travels only on the
-    // external link, which is the one whose page reads real content.
-    const ctaLink = this._guestLandingLink(
-      hubname, workspace_external, shareToken, this.hub.get(Attr.id)
-    );
+    // Called for its SIDE EFFECTS only, which is why the token it returns is
+    // discarded: it creates the external room on first use and re-applies the
+    // area-based guest permission, and copy_link plus the share panel both depend
+    // on that room existing. The CTA itself no longer carries a share token —
+    // see _inviteCtaLink.
+    await this._ensurePublicShareToken();
+    // One CTA for everyone: the sign-in form, carrying the workspace so the desk
+    // can offer to open it once the recipient is authenticated.
+    const ctaLink = this._inviteCtaLink(hubId, hubname);
     // Address-book context resolved once for the whole call (see
     // _rememberInvitee). Null when the inviter has no drumate DB — the invite
     // still goes through, it just isn't remembered.

--- a/service/private/media.js
+++ b/service/private/media.js
@@ -59,6 +59,27 @@ const JSON_OPT = { spaces: 2, EOL: "\r\n" };
 const { emptyTrash } = require('../../offline/queues/trashQueue');
 const indexQueue = require('../../offline/queues/indexQueue');
 
+const FILE_MOVE_TTL_SECONDS = 15 * 60;
+
+function firstRow(data) {
+  return toArray(data)[0] || null;
+}
+
+function samePhysicalNode(source, destination) {
+  if (!source || !destination || !existsSync(source) || !existsSync(destination)) return false;
+  const sourceStat = statSync(source);
+  const destinationStat = statSync(destination);
+  if (sourceStat.isDirectory() !== destinationStat.isDirectory()) return false;
+  if (!sourceStat.isDirectory()) return sourceStat.size === destinationStat.size;
+  const sourceEntries = readdirSync(source).sort();
+  const destinationEntries = readdirSync(destination).sort();
+  if (sourceEntries.length !== destinationEntries.length) return false;
+  return sourceEntries.every((entry, index) =>
+    entry === destinationEntries[index]
+      && samePhysicalNode(join(source, entry), join(destination, entry))
+  );
+}
+
 //########################################
 class __private_media extends Media {
   constructor(...args) {
@@ -67,6 +88,7 @@ class __private_media extends Media {
     this.chk_pre_transact = this.chk_pre_transact.bind(this);
     this.pre_transact = this.pre_transact.bind(this);
     this.copy_all = this.copy_all.bind(this);
+    this.move_cross_hub = this.move_cross_hub.bind(this);
     this.move_all = this.move_all.bind(this);
     this.workspace_move = this.workspace_move.bind(this);
     this.pre_restore_into = this.pre_restore_into.bind(this);
@@ -613,6 +635,562 @@ class __private_media extends Media {
   }
 
   /**
+   * Server-owned, single-file cross-hub move. Ordinary media.copy remains
+   * copy-only; this coordinator never consumes client moved_in/lineage data.
+   */
+  async move_cross_hub() {
+    const requestedOperationId = this.input.get("operation_id");
+    let saga;
+
+    if (requestedOperationId) {
+      saga = firstRow(await this.yp.await_proc("file_move_saga_get", requestedOperationId));
+      if (!saga || saga.actor_id !== this.uid) {
+        return this.exception.user("FILE_MOVE_OPERATION_NOT_FOUND");
+      }
+      if (["committed", "compensated", "failed", "expired", "compensation_failed"].includes(saga.state)) {
+        return this.output.data(this._fileMoveResult(saga));
+      }
+    } else {
+      saga = await this._beginCrossHubMove();
+      if (!saga) return;
+    }
+
+    const result = await this._runCrossHubMove(saga);
+    this.output.data(result);
+  }
+
+  async _beginCrossHubMove() {
+    const sourceHubId = this.input.get(Attr.hub_id) || this.hub.get(Attr.id);
+    const sourceFileNid = this.input.need(Attr.nid);
+    const destinationHubId = this.input.need(RECIPIENT_ID);
+    const destinationParentNid = this.input.need(PID);
+
+    if (!isString(sourceFileNid) || sourceHubId === destinationHubId) {
+      this.exception.user("CROSS_HUB_SINGLE_FILE_REQUIRED");
+      return null;
+    }
+
+    const sourceStorage = firstRow(await this.yp.await_proc("file_move_entity_storage", sourceHubId));
+    const destinationStorage = firstRow(await this.yp.await_proc("file_move_entity_storage", destinationHubId));
+    if (!sourceStorage || !destinationStorage) {
+      this.exception.user("FILE_MOVE_HUB_NOT_FOUND");
+      return null;
+    }
+
+    const source = firstRow(await this.yp.await_proc(
+      `${sourceStorage.db_name}.file_move_source_snapshot`, this.uid, sourceFileNid
+    ));
+    const destination = firstRow(await this.yp.await_proc(
+      `${destinationStorage.db_name}.file_move_destination_snapshot`, this.uid, destinationParentNid
+    ));
+    if (!source || source.category === FOLDER || source.category === HUB || !source.file_thread_id) {
+      this.exception.user("FILE_THREAD_MOVE_REQUIRED");
+      return null;
+    }
+    if (!(source.permission & Permission.DELETE) || !destination
+      || !(destination.permission & Permission.WRITE)) {
+      this.exception.forbiden("FILE_MOVE_PERMISSION_DENIED");
+      return null;
+    }
+
+    const lineage = firstRow(await this.yp.await_proc(
+      "file_thread_lineage_resolve", sourceHubId, sourceFileNid
+    ));
+    if (lineage && (lineage.state !== "active" || lineage.current_thread_id !== source.file_thread_id)) {
+      this.exception.user("FILE_MOVE_LINEAGE_CONFLICT");
+      return null;
+    }
+
+    if (lineage && lineage.original_hub_id === destinationHubId) {
+      const precheck = firstRow(await this.yp.await_proc(
+        `${destinationStorage.db_name}.file_move_return_precheck`, lineage.original_file_nid
+      ));
+      if (!precheck || precheck.old_node_available) {
+        this.exception.user("FILE_MOVE_OLD_NODE_AVAILABLE");
+        return null;
+      }
+    }
+
+    const operationId = this.randomString().slice(0, 16);
+    const lineageId = (lineage && lineage.lineage_id) || this.randomString().slice(0, 16);
+    const begun = firstRow(await this.yp.await_proc(
+      "file_move_saga_begin",
+      operationId,
+      lineageId,
+      this.uid,
+      sourceHubId,
+      sourceFileNid,
+      source.parent_nid,
+      source.file_thread_id,
+      destinationHubId,
+      destinationParentNid,
+      Math.floor(Date.now() / 1000) + FILE_MOVE_TTL_SECONDS
+    ));
+    if (!begun || begun.failed) {
+      this.exception.user((begun && begun.status) || "FILE_MOVE_SAGA_FAILED");
+      return null;
+    }
+    if (begun.actor_id !== this.uid) {
+      this.exception.user("FILE_MOVE_OPERATION_IN_PROGRESS");
+      return null;
+    }
+    return begun;
+  }
+
+  async _runCrossHubMove(saga) {
+    const sourceStorage = firstRow(await this.yp.await_proc(
+      "file_move_entity_storage", saga.source_hub_id
+    ));
+    const destinationStorage = firstRow(await this.yp.await_proc(
+      "file_move_entity_storage", saga.destination_hub_id
+    ));
+    if (!sourceStorage || !destinationStorage) {
+      return this._failCrossHubMove(saga, "FILE_MOVE_STORAGE_NOT_FOUND", true);
+    }
+
+    const sourceNode = { nid: saga.source_file_nid, mfs_root: sourceStorage.mfs_root };
+    const stagingNode = {
+      nid: saga.operation_id,
+      mfs_root: join(destinationStorage.home_dir, "__storage__", ".file-move-staging"),
+    };
+
+    if (["copy_pending", "copy_verified"].includes(saga.state)) {
+      const source = firstRow(await this.yp.await_proc(
+        `${sourceStorage.db_name}.file_move_source_snapshot`, this.uid, saga.source_file_nid
+      ));
+      const destination = firstRow(await this.yp.await_proc(
+        `${destinationStorage.db_name}.file_move_destination_snapshot`,
+        this.uid,
+        saga.destination_parent_nid
+      ));
+      if (!source || source.file_thread_id !== saga.source_thread_id
+        || !(source.permission & Permission.DELETE) || !destination
+        || !(destination.permission & Permission.WRITE)) {
+        return this._failCrossHubMove(saga, "FILE_MOVE_PERMISSION_OR_POSITION_CHANGED");
+      }
+
+      if (Math.floor(Date.now() / 1000) >= saga.expires_at) {
+        this._removePhysicalNode(stagingNode);
+        return this._transitionCrossHubMove(saga, saga.state, "expired", {
+          failure_code: "FILE_MOVE_EXPIRED",
+        });
+      }
+
+      if (saga.state === "copy_pending" || !check_base(stagingNode)) {
+        this._removePhysicalNode(stagingNode);
+        copy_node(sourceNode, stagingNode, 0);
+        const sourcePath = check_base(sourceNode);
+        const stagingPath = check_base(stagingNode);
+        if (!samePhysicalNode(sourcePath, stagingPath)) {
+          this._removePhysicalNode(stagingNode);
+          return this._failCrossHubMove(saga, "FILE_MOVE_COPY_VERIFY_FAILED");
+        }
+        if (saga.state === "copy_pending") {
+          saga = await this._transitionCrossHubMove(saga, "copy_pending", "copy_verified");
+          if (saga.failed) return this._fileMoveResult(saga);
+        }
+      }
+
+      let movePlan;
+      try {
+        movePlan = toArray(await this.yp.await_proc(
+          `${sourceStorage.db_name}.mfs_move_all`,
+          [{ nid: saga.source_file_nid, hub_id: saga.source_hub_id }],
+          this.uid,
+          saga.destination_parent_nid,
+          saga.destination_hub_id
+        ));
+      } catch (error) {
+        return this._failCrossHubMove(saga, "FILE_MOVE_DATABASE_STEP_FAILED", true);
+      }
+
+      const physicalMove = movePlan.find((row) => row.action === "move" && row.nid === saga.source_file_nid);
+      const destinationFileNid = physicalMove && physicalMove.des_id;
+      const sourcePosition = firstRow(await this.yp.await_proc(
+        `${sourceStorage.db_name}.file_move_thread_position`, null, saga.source_thread_id
+      ));
+      const destinationPosition = destinationFileNid && firstRow(await this.yp.await_proc(
+        `${destinationStorage.db_name}.file_move_thread_position`, destinationFileNid, null
+      ));
+
+      if (!destinationFileNid || sourcePosition || !destinationPosition
+        || Number(destinationPosition.root_identity_count) !== 1
+        || Number(destinationPosition.stale_child_identity_count) !== 0) {
+        saga.destination_file_nid = destinationFileNid;
+        saga.destination_thread_id = destinationPosition && destinationPosition.file_thread_id;
+        return this._compensateCrossHubMove(saga, sourceStorage, destinationStorage, stagingNode);
+      }
+
+      saga = await this._transitionCrossHubMove(saga, "copy_verified", "source_removed", {
+        destination_file_nid: destinationFileNid,
+        destination_thread_id: destinationPosition.file_thread_id,
+      });
+      if (saga.failed) return this._fileMoveResult(saga);
+      saga._movePlan = movePlan;
+    }
+
+    if (saga.state === "source_removed") {
+      const destinationNode = {
+        nid: saga.destination_file_nid,
+        mfs_root: destinationStorage.mfs_root,
+      };
+      const sourcePath = check_base(sourceNode);
+      let stagingPath = check_base(stagingNode);
+      let destinationPath = check_base(destinationNode);
+
+      if (!destinationPath && stagingPath) {
+        move_node(stagingNode, destinationNode, 0);
+        stagingPath = check_base(stagingNode);
+        destinationPath = check_base(destinationNode);
+      }
+      if (!sourcePath || !destinationPath || !samePhysicalNode(sourcePath, destinationPath)) {
+        return this._compensateCrossHubMove(saga, sourceStorage, destinationStorage, stagingNode);
+      }
+      this._removePhysicalNode(sourceNode);
+      if (stagingPath) this._removePhysicalNode(stagingNode);
+
+      const lineage = firstRow(await this.yp.await_proc(
+        "file_thread_lineage_resolve", saga.source_hub_id, saga.source_file_nid
+      ));
+      if (lineage && lineage.original_hub_id === saga.destination_hub_id) {
+        const rebound = firstRow(await this.yp.await_proc(
+          `${destinationStorage.db_name}.channel_file_thread_rebind_returned_file`,
+          lineage.original_file_nid,
+          saga.destination_file_nid,
+          saga.source_thread_id
+        ));
+        if (!rebound || rebound.failed) {
+          return this._compensateCrossHubMove(saga, sourceStorage, destinationStorage, stagingNode);
+        }
+        saga.destination_thread_id = rebound.file_thread_id;
+      }
+
+      saga = await this._transitionCrossHubMove(saga, "source_removed", "committed", {
+        destination_file_nid: saga.destination_file_nid,
+        destination_thread_id: saga.destination_thread_id,
+      });
+      if (!saga.failed) {
+        await this._emitCrossHubMoveEvents(saga, sourceStorage, destinationStorage);
+      }
+    }
+
+    return this._fileMoveResult(saga);
+  }
+
+  async _compensateCrossHubMove(saga, sourceStorage, destinationStorage, stagingNode) {
+    const expected = saga.state;
+    if (!saga.destination_file_nid) {
+      saga = await this._transitionCrossHubMove(saga, expected, "compensation_failed", {
+        failure_code: "COMPENSATION_CANONICAL_TARGET_MISSING",
+      });
+      return this._fileMoveResult(saga);
+    }
+    saga = await this._transitionCrossHubMove(saga, expected, "compensating", {
+      destination_file_nid: saga.destination_file_nid,
+      destination_thread_id: saga.destination_thread_id,
+      failure_code: "FILE_MOVE_DESTINATION_THREAD_OR_COPY_CONFLICT",
+    });
+    if (saga.failed) {
+      return this._fileMoveResult(saga);
+    }
+
+    try {
+      const compensationPlan = toArray(await this.yp.await_proc(
+        `${destinationStorage.db_name}.mfs_move_all`,
+        [{ nid: saga.destination_file_nid, hub_id: saga.destination_hub_id }],
+        this.uid,
+        saga.source_parent_nid,
+        saga.source_hub_id
+      ));
+      const physicalMove = compensationPlan.find((row) =>
+        row.action === "move" && row.nid === saga.destination_file_nid
+      );
+      const compensationFileNid = physicalMove && physicalMove.des_id;
+      if (!compensationFileNid) throw new Error("COMPENSATION_DESTINATION_MISSING");
+
+      const originalNode = { nid: saga.source_file_nid, mfs_root: sourceStorage.mfs_root };
+      const destinationNode = { nid: saga.destination_file_nid, mfs_root: destinationStorage.mfs_root };
+      const compensatedNode = { nid: compensationFileNid, mfs_root: sourceStorage.mfs_root };
+      const physicalSource = check_base(originalNode) ? originalNode
+        : (check_base(destinationNode) ? destinationNode : stagingNode);
+      copy_node(physicalSource, compensatedNode, 0);
+      if (!samePhysicalNode(check_base(physicalSource), check_base(compensatedNode))) {
+        throw new Error("COMPENSATION_COPY_VERIFY_FAILED");
+      }
+
+      const rebound = firstRow(await this.yp.await_proc(
+        `${sourceStorage.db_name}.channel_file_thread_rebind_returned_file`,
+        saga.source_file_nid,
+        compensationFileNid,
+        saga.source_thread_id
+      ));
+      if (!rebound || rebound.failed) throw new Error("COMPENSATION_THREAD_REBIND_FAILED");
+
+      if (physicalSource !== originalNode) this._removePhysicalNode(physicalSource);
+      if (saga.source_file_nid !== compensationFileNid) this._removePhysicalNode(originalNode);
+      this._removePhysicalNode(destinationNode);
+      this._removePhysicalNode(stagingNode);
+
+      saga = await this._transitionCrossHubMove(saga, "compensating", "compensated", {
+        compensation_file_nid: compensationFileNid,
+        compensation_thread_id: rebound.file_thread_id,
+      });
+    } catch (error) {
+      saga = await this._transitionCrossHubMove(saga, "compensating", "compensation_failed", {
+        failure_code: (error && error.message) || "FILE_MOVE_COMPENSATION_FAILED",
+      });
+    }
+    if (!saga.failed && saga.state === "compensated") {
+      try {
+        await this._emitCrossHubCompensationEvents(saga, sourceStorage);
+      } catch (error) {
+        this.warn("Cross-hub compensation event delivery failed", error);
+      }
+    }
+    return this._fileMoveResult(saga);
+  }
+
+  async _failCrossHubMove(saga, failureCode, uncertain = false) {
+    const nextState = uncertain ? "compensation_failed" : "failed";
+    const failedSaga = await this._transitionCrossHubMove(
+      saga, saga.state, nextState, { failure_code: failureCode }
+    );
+    return this._fileMoveResult(failedSaga);
+  }
+
+  async _transitionCrossHubMove(saga, expectedState, nextState, extra = {}) {
+    const transitioned = firstRow(await this.yp.await_proc("file_move_saga_transition", {
+      operation_id: saga.operation_id,
+      actor_id: this.uid,
+      expected_state: expectedState,
+      next_state: nextState,
+      ...extra,
+    }));
+    return transitioned || { ...saga, failed: 1, status: "SAGA_TRANSITION_EMPTY" };
+  }
+
+  _removePhysicalNode(node) {
+    if (!node || !check_base(node)) return;
+    remove_node(node, 0);
+  }
+
+  _fileMoveActor() {
+    const firstname = this.user.get(Attr.firstname) || "";
+    const lastname = this.user.get(Attr.lastname) || "";
+    return {
+      id: this.uid,
+      firstname,
+      lastname,
+      fullname: `${firstname} ${lastname}`.trim() || this.uid,
+    };
+  }
+
+  async _directFileThreadSnapshot(hubId, fileNid, dbName) {
+    try {
+      if (!dbName) {
+        const storage = firstRow(await this.yp.await_proc("file_move_entity_storage", hubId));
+        dbName = storage && storage.db_name;
+      }
+      if (!dbName) return null;
+      const snapshot = firstRow(await this.yp.await_proc(
+        `${dbName}.file_move_source_snapshot`, this.uid, fileNid
+      ));
+      if (!snapshot || !snapshot.file_thread_id
+        || snapshot.category === FOLDER || snapshot.category === HUB) return null;
+      return {
+        hub_id: hubId,
+        file_nid: fileNid,
+        file_thread_id: snapshot.file_thread_id,
+        filename: snapshot.user_filename || fileNid,
+      };
+    } catch (error) {
+      this.warn("Direct file-thread snapshot failed", error);
+      return null;
+    }
+  }
+
+  async _reserveDirectFileThreadTrash(target) {
+    if (!target) return { failed: 1, reserved: 0, status: "DIRECT_TARGET_REQUIRED" };
+    target.transition_id = target.transition_id || this.randomString().slice(0, 16);
+    target.lineage_id = target.lineage_id || this.randomString().slice(0, 16);
+    try {
+      const reservation = firstRow(await this.yp.await_proc(
+        "file_thread_access_reserve_direct",
+        target.transition_id,
+        target.lineage_id,
+        this.uid,
+        target.hub_id,
+        target.file_nid,
+        target.file_thread_id
+      ));
+      if (reservation && reservation.lineage_id) {
+        target.lineage_id = reservation.lineage_id;
+      }
+      return reservation || { failed: 1, reserved: 0, status: "DIRECT_RESERVATION_EMPTY" };
+    } catch (error) {
+      this.warn("Direct file-thread trash reservation failed", error);
+      return { failed: 1, reserved: 0, status: "DIRECT_RESERVATION_FAILED" };
+    }
+  }
+
+  async _releaseDirectFileThreadTrash(target) {
+    if (!target || !target.transition_id) return null;
+    try {
+      return firstRow(await this.yp.await_proc(
+        "file_thread_access_release_direct",
+        target.transition_id,
+        target.hub_id,
+        target.file_nid,
+        target.file_thread_id
+      ));
+    } catch (error) {
+      this.warn("Direct file-thread trash reservation release failed", error);
+      return null;
+    }
+  }
+
+  async _releaseDirectFileThreadTrashBatch(targets) {
+    for (const target of targets) {
+      await this._releaseDirectFileThreadTrash(target);
+    }
+  }
+
+  async _transitionDirectFileThreadAccess(target, targetState, reason) {
+    if (!target) return null;
+    try {
+      const transition = firstRow(await this.yp.await_proc(
+        "file_thread_access_transition_direct",
+        target.transition_id || this.randomString().slice(0, 16),
+        target.lineage_id || this.randomString().slice(0, 16),
+        this.uid,
+        target.hub_id,
+        target.file_nid,
+        target.file_thread_id,
+        targetState,
+        reason
+      ));
+      if (!transition || transition.failed || Number(transition.transitioned) !== 1) {
+        return transition;
+      }
+      const recipients = await this.yp.await_proc("entity_sockets", target.hub_id);
+      await RedisStore.sendData(this.payload({
+        operation_id: transition.transition_id,
+        lineage_id: transition.lineage_id,
+        access_revision: transition.access_revision,
+        actor: this._fileMoveActor(),
+        reason,
+        state: targetState === "active" ? "restored" : "revoked",
+        hub_id: target.hub_id,
+        file_nid: target.file_nid,
+        file_thread_id: target.file_thread_id,
+        filename: target.filename,
+      }, { service: "channel.file_thread_access_changed" }), recipients);
+      return transition;
+    } catch (error) {
+      this.warn("Direct file-thread access transition failed", error);
+      return null;
+    }
+  }
+
+  async _emitCrossHubMoveEvents(saga, sourceStorage, destinationStorage) {
+    const actor = this._fileMoveActor();
+    const common = {
+      operation_id: saga.operation_id,
+      lineage_id: saga.lineage_id,
+      access_revision: saga.access_revision,
+      actor,
+      reason: "cross_hub_move",
+    };
+    const sourceSockets = await this.yp.await_proc("entity_sockets", saga.source_hub_id);
+    const destinationSockets = await this.yp.await_proc("entity_sockets", saga.destination_hub_id);
+    await RedisStore.sendData(this.payload({
+      ...common,
+      state: "revoked",
+      hub_id: saga.source_hub_id,
+      file_nid: saga.source_file_nid,
+      file_thread_id: saga.source_thread_id,
+    }, { service: "channel.file_thread_access_changed" }), sourceSockets);
+    await RedisStore.sendData(this.payload({
+      ...common,
+      state: "restored",
+      hub_id: saga.destination_hub_id,
+      file_nid: saga.destination_file_nid,
+      file_thread_id: saga.destination_thread_id,
+    }, { service: "channel.file_thread_access_changed" }), destinationSockets);
+
+    const destinationNode = firstRow(await this.yp.await_proc(
+      `${destinationStorage.db_name}.mfs_access_node`, this.uid, saga.destination_file_nid
+    ));
+    if (destinationNode) {
+      destinationNode.args = {
+        src: { nid: saga.source_file_nid, hub_id: saga.source_hub_id },
+        dest: { ...destinationNode },
+        operation_id: saga.operation_id,
+      };
+      await RedisStore.sendData(
+        this.payload(destinationNode, { service: "media.move" }),
+        destinationSockets
+      );
+    }
+  }
+
+  async _emitCrossHubCompensationEvents(saga, sourceStorage) {
+    const actor = this._fileMoveActor();
+    const recipients = await this.yp.await_proc("entity_sockets", saga.source_hub_id);
+    const compensatedNode = firstRow(await this.yp.await_proc(
+      `${sourceStorage.db_name}.mfs_access_node`, this.uid, saga.compensation_file_nid
+    ));
+    const common = {
+      operation_id: saga.operation_id,
+      lineage_id: saga.lineage_id,
+      access_revision: saga.access_revision,
+      actor,
+      reason: "cross_hub_move_compensated",
+      hub_id: saga.source_hub_id,
+      filename: compensatedNode && (compensatedNode.filename || compensatedNode.user_filename),
+    };
+    await RedisStore.sendData(this.payload({
+      ...common,
+      state: "restored",
+      file_nid: saga.compensation_file_nid,
+      file_thread_id: saga.compensation_thread_id,
+      previous_file_nid: saga.source_file_nid,
+      previous_file_thread_id: saga.source_thread_id,
+    }, { service: "channel.file_thread_access_changed" }), recipients);
+
+    if (compensatedNode) {
+      compensatedNode.args = {
+        src: { nid: saga.source_file_nid, hub_id: saga.source_hub_id },
+        dest: { ...compensatedNode },
+        operation_id: saga.operation_id,
+      };
+      await RedisStore.sendData(
+        this.payload(compensatedNode, { service: "media.move" }),
+        recipients
+      );
+    }
+  }
+
+  _fileMoveResult(saga) {
+    return {
+      operation_id: saga.operation_id,
+      lineage_id: saga.lineage_id,
+      state: saga.state,
+      source_hub_id: saga.source_hub_id,
+      source_file_nid: saga.source_file_nid,
+      source_thread_id: saga.source_thread_id,
+      destination_hub_id: saga.destination_hub_id,
+      destination_file_nid: saga.destination_file_nid,
+      destination_thread_id: saga.destination_thread_id,
+      compensation_file_nid: saga.compensation_file_nid,
+      compensation_thread_id: saga.compensation_thread_id,
+      access_revision: saga.access_revision,
+      failure_code: saga.failure_code,
+      expires_at: saga.expires_at,
+    };
+  }
+
+  /**
    * 
    */
   async move_all() {
@@ -1011,6 +1589,9 @@ class __private_media extends Media {
       return this.output.data(data);
     }
 
+    const restoredThread = await this._directFileThreadSnapshot(restored.hub_id, nid);
+    await this._transitionDirectFileThreadAccess(restoredThread, "active", "direct_restore");
+
     let changelog = await this.changelog_write({ src: restored, event: 'media.new' });
     let sockets = await this.yp.await_proc('entity_sockets', restored.hub_id);
     await RedisStore.sendData(
@@ -1116,6 +1697,12 @@ class __private_media extends Media {
     let sockets = [];
 
     for (var m of show_node) {
+      const restoredThread = await this._directFileThreadSnapshot(
+        m.hub_id,
+        m.nid || m.id,
+        m.db_name || m.actual_db
+      );
+      await this._transitionDirectFileThreadAccess(restoredThread, "active", "direct_restore");
       let changelog = await this.changelog_write({ src: m, event: "media.new" });
       let dest = await this.yp.await_proc("entity_sockets", m.hub_id);
       sockets = sockets.concat(dest);
@@ -1404,12 +1991,20 @@ class __private_media extends Media {
     // Snapshot filename/filetype before mfs_pre_trash_next moves rows
     // to trash_media — needed for human-readable audit log lines.
     const auditTargets = [];
+    const directAccessTargets = [];
+    const directAccessKeys = new Set();
     for (const g of granted) {
       try {
         const hub_db = await this.yp.await_func('get_db_name', g.hub_id);
         if (!hub_db) continue;
         const attr = await this.yp.await_proc(`${hub_db}.mfs_node_attr`, g.nid);
         if (!attr) continue;
+        const directTarget = await this._directFileThreadSnapshot(g.hub_id, g.nid, hub_db);
+        const directKey = directTarget && `${directTarget.hub_id}:${directTarget.file_nid}`;
+        if (directTarget && !directAccessKeys.has(directKey)) {
+          directAccessKeys.add(directKey);
+          directAccessTargets.push(directTarget);
+        }
         auditTargets.push({
           hub_db,
           nid: g.nid,
@@ -1418,12 +2013,37 @@ class __private_media extends Media {
         });
       } catch (e) { /* best-effort */ }
     }
-    let data = await this.db.await_proc(
-      "mfs_pre_trash_next",
-      granted,
-      this.uid,
-      Permission.MODIFY
-    );
+    const reservedTargets = [];
+    for (const target of directAccessTargets) {
+      const reservation = await this._reserveDirectFileThreadTrash(target);
+      if (!reservation || reservation.failed || Number(reservation.reserved) !== 1) {
+        await this._releaseDirectFileThreadTrashBatch(reservedTargets);
+        this.exception.user((reservation && reservation.status) || "FILE_THREAD_TRASH_CONFLICT");
+        return;
+      }
+      reservedTargets.push(target);
+    }
+
+    let data;
+    try {
+      data = await this.db.await_proc(
+        "mfs_pre_trash_next",
+        granted,
+        this.uid,
+        Permission.MODIFY
+      );
+    } catch (error) {
+      await this._releaseDirectFileThreadTrashBatch(reservedTargets);
+      throw error;
+    }
+    for (const target of directAccessTargets) {
+      const transition = await this._transitionDirectFileThreadAccess(
+        target, "unavailable", "direct_trash"
+      );
+      if (!transition || transition.failed || Number(transition.transitioned) !== 1) {
+        await this._releaseDirectFileThreadTrash(target);
+      }
+    }
     let keys = [Attr.nid, Attr.hub_id];
     let service = "media.remove";
     let recipients;

--- a/service/private/media.js
+++ b/service/private/media.js
@@ -229,7 +229,10 @@ class __private_media extends Media {
    *
    */
   async transact_show(node) {
-    const { des_db, nid } = node;
+    // `nid` is reassigned to actual_home_id for a hub node below, so it cannot
+    // be destructured as const — that threw on the first hub row it met.
+    const { des_db } = node;
+    let { nid } = node;
     //const exclude = [this.input.get(Attr.socket_id)];
     let oldItems = {};
     let recipients = await this.yp.await_proc("entity_sockets", {
@@ -2093,7 +2096,10 @@ class __private_media extends Media {
    * Show trsh content
    */
   show_bin() {
-    const page = this.input.get(Attr.page);
+    // `let`, not `const`: the default below reassigns it. As a const this threw
+    // "Assignment to constant variable" on every call that omitted `page` or
+    // sent 0 — i.e. the default was unreachable, not merely unused.
+    let page = this.input.get(Attr.page);
     if (page == null || page == undefined || page == 0) page = 1;
     this.db.call_proc("mfs_show_bin", page, this.output.list);
   }

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -228,6 +228,43 @@ class __secure_share extends Mfs {
   }
 
   /**
+   * Turn the sender's "notify me when someone opens this" preference on or off
+   * for one of their OWN links, after the link has been created.
+   *
+   * notify_on_open was writable only at create time, but the panel's toggle sits
+   * below the Get-link button, so turning it off once the link existed persisted
+   * nothing and the sender kept receiving open notifications with the toggle
+   * visibly off. Both notification paths already honour the stored flag (the
+   * real-time secure_share_opened push in dmz.js, and the share_open feed row
+   * via secure_share_open_feed), so persisting it is all that was missing.
+   *
+   * The SP is scoped to creator_id, so a user can only ever change their own
+   * link, and returns nothing when the token is not theirs — which is also why
+   * "no such token" and "not yours" are answered identically here.
+   * Endpoint: POST /secure_share.set_notify_on_open
+   */
+  async set_notify_on_open() {
+    const token = this.input.need(Attr.token);
+    const raw   = this.input.need('notify_on_open');
+    // Explicit setter, so read the caller's intent strictly rather than reusing
+    // create()'s "absent means ON" default: only a recognised truthy form turns
+    // notifications on. The value is required above, so this never has to guess
+    // for a missing field. The SP's own IF(... = 0, 0, 1) is the last-resort net.
+    const notify_on_open = (raw === 1 || raw === '1' || raw === true) ? 1 : 0;
+
+    const row = toArray(
+      await this.yp.await_proc('secure_share_set_notify_on_open', token, this.uid, notify_on_open)
+    )[0] || {};
+
+    if (isEmpty(row)) {
+      return this.output.data({ status: 'NOT_FOUND' });
+    }
+    // Echo what was actually STORED, not what was asked for, so the panel can
+    // revert its toggle if the two ever disagree.
+    this.output.data({ status: 'OK', notify_on_open: Number(row.notify_on_open) ? 1 : 0 });
+  }
+
+  /**
    * Revoke a secure share token (soft delete).
    * Broadcasts a real-time event so the recipient loses access immediately.
    */

--- a/service/private/task.js
+++ b/service/private/task.js
@@ -796,20 +796,27 @@ class __private_task extends Entity {
   }
 
   /**
-   * Delete one's own comment. Params: id (required), task_id (required — so the
-   * broadcast can target the right task's feed).
+   * Delete one's own comment. Deleting a root also deletes the replies under it
+   * (the proc cascades — a reply with no question above it is not a comment),
+   * so `removed_replies` travels with the answer and the broadcast: a client
+   * holding the feed can drop the whole thread instead of just the root.
+   * Params: id (required), task_id (required — so the broadcast can target the
+   * right task's feed).
    */
   async comment_delete() {
     const id = this.input.need('id');
     const task_id = this.input.need('task_id');
     const data = await this.db.await_proc('task_comment_delete', id, this.uid);
     const row = Array.isArray(data) ? data[0] : data;
-    await this._broadcast('task.comment_delete', {
+    const result = {
       id,
       task_id,
       affected: row && row.affected,
-    });
-    this.output.data({ id, task_id, affected: row && row.affected });
+      // Older procs (pre-cascade) return no such column — 0, not undefined.
+      removed_replies: (row && row.removed_replies) || 0,
+    };
+    await this._broadcast('task.comment_delete', result);
+    this.output.data(result);
   }
 
   /**

--- a/service/private/templates/butler/workspace-invite-member.html
+++ b/service/private/templates/butler/workspace-invite-member.html
@@ -242,9 +242,9 @@ var _external = (typeof workspace_external !== 'undefined') && workspace_externa
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
                 <tr>
                   <td align="center" bgcolor="#433cc5" style="background:#433cc5;border-radius:4px;">
-                    <!-- href uses the ESCAPE delimiter, not interpolate: the internal
-                         CTA is a query URL, so its & must become &amp; to be a valid
-                         attribute value (the parser hands the raw & back to the browser). -->
+                    <!-- href uses the ESCAPE delimiter, not interpolate: the CTA is a
+                         query URL, so any & must become &amp; to be a valid attribute
+                         value (the parser hands the raw & back to the browser). -->
                     <a href="<%- link %>" style="display:block;width:100%;background:#433cc5;color:#ffffff;text-decoration:none;font-family:'Geist','SF Pro Display',-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;font-weight:600;font-size:16px;line-height:24px;text-align:center;padding:16px 24px;border-radius:4px;box-sizing:border-box;">
                       Join Drumee to view this folder &rarr;
                     </a>

--- a/service/signup.js
+++ b/service/signup.js
@@ -20,6 +20,7 @@ const {
 } = require("@drumee/server-essentials");
 const { resolve } = require('path');
 const { isEmpty } = require("lodash");
+const { notifyMemberJoined } = require("./lib/notify-member-joined");
 const { Mfs } = require("@drumee/server-core");
 
 class __signup extends Mfs {
@@ -195,6 +196,10 @@ class __signup extends Mfs {
         } catch (err) {
           this.warn(`[signup._resolve_pending_invitation] WS notify failed for hub ${hub_id}:`, err && err.message);
         }
+
+        // Tell online members a member joined so an open permission matrix
+        // refreshes (mirrors butler.js _resolve_pending_invitation).
+        await notifyMemberJoined(this, hub_id, newUser.id);
       } catch (err) {
         this.warn(`[signup._resolve_pending_invitation] Failed for hub ${hub_id}:`, err && err.message);
       }


### PR DESCRIPTION
Release train `test` → `preview`. Deploy **after** `schemas`, **before** `ui-team`.

Depends on: drumee/schemas#111 — this code calls the new procedures directly and will fail at runtime without them.

## Authorization

Every file-thread-derived operation now resolves through one canonical resolver plus a current `mfs_access_node` read check: info, messages, post, acknowledge, folder list, scoped search, reply enrichment, react, delete, export, bookmark, jump. A cached `message_id` or thread id no longer grants access to a file the caller can no longer read.

Two paths needed more than a gate:

- **acknowledge** was broadcasting the full `channel_get` row. It now emits an acknowledgement DTO (`message_id`, canonical `file_thread_id`, `reader_id`, seen/read flags) and verifies the message/thread pair before mutating.
- **live delivery** filters each recipient socket by that recipient's own access at send time — one member losing the file doesn't stop the others receiving, and doesn't let them keep receiving if they lost it too.

## Root cards kept, not dropped

`channel.messages` used to drop a `file.thread` root card when access failed. That made an entire thread vanish on reload once its file was trashed, which reads as data loss. The card now stays, flagged `_file_thread_unavailable`, and the client renders it inert — the thread is unreachable either way.

The label comes from `trash_media`, which holds only trashed nodes. A `NO_PERMISSION` card (file still live, caller never had read access) has no trash row, so it carries no name and the client falls back to a generic label. No name leaks to someone who was never allowed to know the file existed.

The per-recipient broadcast loop **clones** each message before flagging: `messages` is shared across iterations and the caller's own response, so marking in place would leak one recipient's verdict into another's payload.

## Cross-hub move

`media.move_cross_hub` — server-owned, single-destination, with a durable saga: server-minted operation/lineage ids, CAS transitions (`copy_pending → copy_verified → source_removed → committed`), staging verification, and compensation. Client `moved_in`, filename, hash, and metadata are never trusted as thread identity. Existing `media.copy` fan-out stays copy-only and never takes lineage ownership.

## New event

`channel.file_thread_access_changed` fires after each durable transition, carrying a monotonic per-lineage `access_revision` — the only ordering token clients can rely on. Existing `media.*` envelopes are unchanged, so older clients are unaffected.

## Verification

- `node --check` on all changed JS; ACL JSON parses
- Deployed to stage, both services restarted clean, logs clear
- Direct trash → revoke → restore verified with two sessions, both UI layouts

## Not yet verified

**Cross-hub move saga has had no two-session stage run.** Compensation, replay, expiry, forged lineage, and destination-conflict paths rest on static assertions. The endpoint is additive and no shipped UI calls it.

Known limits, called out rather than papered over:
- `mfs_move_all` commits destination rows before returning canonical ids, so a short destination-visible-before-physical-finalize window is unavoidable. Saga states make it recoverable; the code does not claim atomicity.
- A crash between direct reservation and trash/release leaves the lineage fail-closed in `moving`; there is no reaper yet.
- `export_fetch` revalidates per request, but an already-issued X-Accel symlink can outlive revocation until the next fetch or temp cleanup.

Also carries 4 unrelated commits already on `test`.