### PR TITLE
fix(secure-share): persist the open-notification toggle after the link exists

### DIFF
--- a/acl/secure_share.json
+++ b/acl/secure_share.json
@@ -169,6 +169,26 @@
         }
       }
     },
+    "set_notify_on_open": {
+      "doc": "Turn the sender's open-notification preference on or off for one of their own links, after the link has been created. notify_on_open was create-time only, so the panel's toggle could not persist. Scoped server-side to the caller's own shares; answers NOT_FOUND identically for an unknown token and someone else's token.",
+      "scope": "hub",
+      "permission": {
+        "src": "write"
+      },
+      "log": true,
+      "params": {
+        "token": {
+          "type": "string",
+          "required": true,
+          "doc": "Secure share token whose notification preference to change"
+        },
+        "notify_on_open": {
+          "type": "integer",
+          "required": true,
+          "doc": "1 to notify the sender each time a recipient opens the share, 0 to stop notifying. The access list keeps recording opens either way."
+        }
+      }
+    },
     "revoke": {
       "doc": "Revoke a secure share token (soft delete — sets revoked_at timestamp). Broadcasts a secure_share_revoked event via Redis to all hub socket connections so the recipient loses access instantly.",
       "scope": "hub",

--- a/offline/test/secure-share-session.test.js
+++ b/offline/test/secure-share-session.test.js
@@ -332,6 +332,58 @@ const invariants = [
     // than the apex) — the property that makes it un-usable as the apex auth session.
     assert.ok(/host\s*=\s*this\.input\.host\(\)/.test(page), 'host-scoping of the isolated cookie missing');
   }],
+
+  ['set_notify_on_open is creator-scoped and never takes an owner id from the client', async () => {
+    const ss = src('service/private/secure_share.js');
+    const idx = ss.indexOf('async set_notify_on_open()');
+    assert.ok(idx > 0, 'set_notify_on_open method not found');
+    const body = ss.slice(idx, idx + 1200);
+    // The ONLY thing standing between this setter and "edit anyone's link" is that
+    // the creator scope comes from the session (this.uid), never from the request.
+    assert.ok(
+      /await_proc\(\s*'secure_share_set_notify_on_open'\s*,\s*token\s*,\s*this\.uid\s*,/.test(body),
+      'creator scope must be this.uid, passed as the 2nd arg of the SP'
+    );
+    assert.ok(
+      !/creator_id/.test(body),
+      'must never read a creator/owner id from the request'
+    );
+    // An unknown token and someone else's token must be indistinguishable, else the
+    // endpoint becomes a probe for other people's tokens.
+    assert.ok(
+      /isEmpty\(row\)\)\s*\{?\s*\n?\s*return this\.output\.data\(\{\s*status:\s*'NOT_FOUND'/.test(body),
+      'empty SP result must answer NOT_FOUND'
+    );
+    // Explicit setter: only a recognised truthy form may turn notifications ON.
+    assert.ok(
+      /raw === 1 \|\| raw === '1' \|\| raw === true\) \? 1 : 0/.test(body),
+      'notify_on_open must be coerced strictly from an explicit value'
+    );
+    // Echo the STORED value so the panel can revert a toggle that did not persist.
+    assert.ok(
+      /notify_on_open:\s*Number\(row\.notify_on_open\)/.test(body),
+      'response must echo the stored value, not the requested one'
+    );
+  }],
+
+  ['the two open-notification paths still honour notify_on_open', async () => {
+    // The whole point of the setter is that these gates exist. If either one is
+    // removed, turning the toggle off goes silently back to notifying the sender.
+    const dmz = src('service/dmz.js');
+    assert.ok(
+      /info\.notify_on_open\s*!=\s*0/.test(dmz),
+      'dmz.js must still gate the real-time secure_share_opened push on notify_on_open'
+    );
+    const gateIdx = dmz.search(/info\.notify_on_open\s*!=\s*0/);
+    const pushIdx = dmz.indexOf("event           : 'secure_share_opened'");
+    assert.ok(pushIdx > 0, 'secure_share_opened push not found');
+    assert.ok(gateIdx > 0 && gateIdx < pushIdx, 'the gate must precede the push');
+    // The access log / access-event write must NOT be inside that gate: turning
+    // notifications off still records the open in the access list.
+    const logIdx = dmz.indexOf("'secure_share_log_access_event'");
+    assert.ok(logIdx > 0, 'access-event log not found');
+    assert.ok(logIdx < gateIdx, 'the access list must be recorded BEFORE/outside the notify gate');
+  }],
 ];
 
 // Behavioural tests only when their (private) dep loaded; canaries always.

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -228,6 +228,43 @@ class __secure_share extends Mfs {
   }
 
   /**
+   * Turn the sender's "notify me when someone opens this" preference on or off
+   * for one of their OWN links, after the link has been created.
+   *
+   * notify_on_open was writable only at create time, but the panel's toggle sits
+   * below the Get-link button, so turning it off once the link existed persisted
+   * nothing and the sender kept receiving open notifications with the toggle
+   * visibly off. Both notification paths already honour the stored flag (the
+   * real-time secure_share_opened push in dmz.js, and the share_open feed row
+   * via secure_share_open_feed), so persisting it is all that was missing.
+   *
+   * The SP is scoped to creator_id, so a user can only ever change their own
+   * link, and returns nothing when the token is not theirs — which is also why
+   * "no such token" and "not yours" are answered identically here.
+   * Endpoint: POST /secure_share.set_notify_on_open
+   */
+  async set_notify_on_open() {
+    const token = this.input.need(Attr.token);
+    const raw   = this.input.need('notify_on_open');
+    // Explicit setter, so read the caller's intent strictly rather than reusing
+    // create()'s "absent means ON" default: only a recognised truthy form turns
+    // notifications on. The value is required above, so this never has to guess
+    // for a missing field. The SP's own IF(... = 0, 0, 1) is the last-resort net.
+    const notify_on_open = (raw === 1 || raw === '1' || raw === true) ? 1 : 0;
+
+    const row = toArray(
+      await this.yp.await_proc('secure_share_set_notify_on_open', token, this.uid, notify_on_open)
+    )[0] || {};
+
+    if (isEmpty(row)) {
+      return this.output.data({ status: 'NOT_FOUND' });
+    }
+    // Echo what was actually STORED, not what was asked for, so the panel can
+    // revert its toggle if the two ever disagree.
+    this.output.data({ status: 'OK', notify_on_open: Number(row.notify_on_open) ? 1 : 0 });
+  }
+
+  /**
    * Revoke a secure share token (soft delete).
    * Broadcasts a real-time event so the recipient loses access immediately.
    */


### PR DESCRIPTION
## Problem

The link-share panel's **"Notify me when someone opens this"** toggle could not be turned off. `notify_on_open` was sent only in the `secure_share.create` payload, but the toggle row sits *below* the Get-link button — so turning it off once the link existed changed nothing server-side. The sender kept receiving "Someone opened …" with the switch visibly off.

There was **no update service at all**: `acl/secure_share.json` carried the parameter only on `create`.

Prod: **420 of 421 tokens are at `1`**; the single one at `0` is correctly excluded from the feed. The gates already honoured the flag — only the write path was missing.

## Change

New `secure_share.set_notify_on_open` (`scope: hub`, `src: write`, `log: true` — mirrors `revoke`).

- Creator scope comes from **`this.uid`**, never from the request. There is no `creator_id` input, so the caller cannot target someone else's link.
- An unknown token and someone else's token both answer **`NOT_FOUND`**, so the endpoint cannot be used to probe for other people's tokens.
- Strict coercion — only an explicit truthy value turns notifications on. This deliberately differs from `create()`'s "absent means ON" default, because this is an explicit setter and the value is `need()`-required.
- Responds with the value that was **stored**, not the one requested, so the panel can revert a switch that did not persist.

Depends on `secure_share_set_notify_on_open` (drumee/schemas#112) — **apply that first**; without it the endpoint errors, it does not silently misbehave.

## Why this cannot regress anything

Purely additive (**+109/−0**): one new method, one new ACL entry, two new tests. No existing method, ACL entry or behaviour is touched. The ACL went 12 → 13 services with **zero pre-existing entries changed** and the `modules` block byte-identical. Turning notifications off does **not** affect the access list — the access-event write stays outside the notify gate.

## Verification

- Suite **24/24 → 26/26** (`node offline/test/secure-share-session.test.js`), and the `Test - secure-share regression` CI job passes.
- Two new canaries, **both negative-controlled** on the real files (restored byte-identically afterwards):
  - taking the creator scope from the client instead of the session ⇒ FAIL
  - removing `dmz.js`'s `info.notify_on_open != 0` gate ⇒ FAIL, plus it asserts the access-list write stays *outside* that gate
- Functional matrix against the stage DB: wrong creator ⇒ no change and empty result; notify OFF ⇒ both feed procedures empty **while the access-list row survives**; back ON ⇒ restored.
- Live on drumee.in and verified by Duy.

## Note on CI

`Code quality gate / Lint` reports 2 errors in **`service/private/media.js`** (`258 nid`, `2097 page`, `no-const-assign`). That file is **not in this commit** and those `const` declarations are already on `preview` — it is the pre-existing unowned `show_bin()` issue. The job lints a broader changed-file set than the pushed commit, so unrelated debt surfaces. Both files this PR touches linted clean.

UI side: drumee/ui-team, same branch name.