### PR TITLE
fix(secure-share): keep the access list live when open notifications are off

### DIFF
--- a/offline/test/secure-share-session.test.js
+++ b/offline/test/secure-share-session.test.js
@@ -366,23 +366,35 @@ const invariants = [
     );
   }],
 
-  ['the two open-notification paths still honour notify_on_open', async () => {
-    // The whole point of the setter is that these gates exist. If either one is
-    // removed, turning the toggle off goes silently back to notifying the sender.
+  ['secure_share_opened is a panel refresh, NOT a notification, so it is never gated', async () => {
+    // Corrected invariant. This push has exactly one consumer: the sender's own
+    // sharing panel, which refreshes its links list and access list on any
+    // 'share.track_event'. The activity panel narrows that same service down to
+    // 'secure_share_access_requested', so this event notifies nobody.
+    //
+    // Notification suppression belongs to the two feed procedures, which carry
+    // `AND t.notify_on_open != 0` (secure_share_open_feed and
+    // secure_share_list_open_notifications). Gating HERE as well meant turning
+    // the toggle off also killed the live refresh, so the access list only
+    // caught up on a reload -- the opposite of the requirement, which is no
+    // notification but an access list that keeps updating normally.
     const dmz = src('service/dmz.js');
-    assert.ok(
-      /info\.notify_on_open\s*!=\s*0/.test(dmz),
-      'dmz.js must still gate the real-time secure_share_opened push on notify_on_open'
-    );
-    const gateIdx = dmz.search(/info\.notify_on_open\s*!=\s*0/);
     const pushIdx = dmz.indexOf("event           : 'secure_share_opened'");
     assert.ok(pushIdx > 0, 'secure_share_opened push not found');
-    assert.ok(gateIdx > 0 && gateIdx < pushIdx, 'the gate must precede the push');
-    // The access log / access-event write must NOT be inside that gate: turning
-    // notifications off still records the open in the access list.
+
+    // Isolate the guard that wraps the push and assert notify_on_open is not in it.
+    const guardIdx = dmz.lastIndexOf('if (row.hub_id', pushIdx);
+    assert.ok(guardIdx > 0, 'the push guard was not found');
+    const guard = dmz.slice(guardIdx, pushIdx);
+    assert.ok(
+      !/notify_on_open/.test(guard),
+      'the secure_share_opened push must NOT be gated on notify_on_open -- that kills the live access-list refresh'
+    );
+
+    // The access-event write must still happen before the push, and outside any gate.
     const logIdx = dmz.indexOf("'secure_share_log_access_event'");
     assert.ok(logIdx > 0, 'access-event log not found');
-    assert.ok(logIdx < gateIdx, 'the access list must be recorded BEFORE/outside the notify gate');
+    assert.ok(logIdx < guardIdx, 'the access list must be recorded before the push guard');
   }],
 ];
 

--- a/service/dmz.js
+++ b/service/dmz.js
@@ -488,10 +488,24 @@ class __dmz extends Mfs {
         this.warn('[dmz.login] secure_share access_event failed:', e && e.message);
       }
       const row   = toArray(track)[0] || {};
-      // The access counter always updates above; the SENDER notification only
-      // fires when the share has notify_on_open enabled (default 1; legacy rows
-      // without the field keep notifying). info comes from secure_share_info.
-      if (row.hub_id && info.notify_on_open != 0) {
+      // This push is NOT a notification and must never be gated on
+      // notify_on_open. Its only consumer is the sender's own sharing panel,
+      // which refreshes its links list and access list on any
+      // 'share.track_event' — the activity panel narrows the same service down
+      // to 'secure_share_access_requested', so 'secure_share_opened' notifies
+      // nobody.
+      //
+      // Notification suppression lives entirely in the two feed procedures,
+      // which both carry `AND t.notify_on_open != 0`
+      // (secure_share_open_feed and secure_share_list_open_notifications).
+      // Gating here as well meant turning the toggle off also killed the live
+      // refresh, so the access list only caught up on a reload or on reopening
+      // the folder — while the requirement is the opposite: no notification,
+      // but the access list keeps updating normally.
+      //
+      // It was invisible until now only because notify_on_open could not
+      // actually be set to 0 before the panel toggle was made to persist.
+      if (row.hub_id) {
         const recipients = await this.yp.await_proc('entity_sockets', { hub_id: row.hub_id });
         await RedisStore.sendData(
           this.payload(


### PR DESCRIPTION
## Problem — found by Duy on drumee.in

With the "Notify me when someone opens this" toggle **off**, the access list stopped updating in real time: it only caught up after a reload or reopening the folder. The requirement is the opposite — no notification, but *"chỉ update ở access list bình thường"*.

## Root cause — a side effect of making the toggle work

`secure_share_opened` was doing **double duty**. Its only consumer is the sender's own sharing panel, which refreshes its links list and access list on any `share.track_event`. Yet it sat behind `notify_on_open`, so turning the toggle off silently killed the live refresh.

Three things establish this:

- **The event notifies nobody.** The activity panel narrows the same service down to `secure_share_access_requested` (`panel/activity/index.js`), so `secure_share_opened` never produces a notification.
- **Notification suppression already lives entirely in the two feed procedures**, which both carry `AND t.notify_on_open != 0` — proven on stage: with the flag at 0, `secure_share_open_feed` and `secure_share_list_open_notifications` both return empty while the access-list row survives.
- **It affected every mode, public included.** `dmz.login` checks `secure_share_info` first and returns early, so all secure-share links take `_loginSecureShare`; the legacy ungated `link_opened` push is never reached. It only looked mode-specific because a reopened panel shows correct data anyway.

It was invisible until now because `notify_on_open` could not actually be set to `0` before the panel toggle was made to persist — so this is a side effect of that change, not a pre-existing bug.

## Change

The push guard becomes `if (row.hub_id)`. Nothing else moves; the access-event write already happened before it and stays there.

## The canary was wrong and is replaced

The canary I added with the toggle asserted that this gate **existed** — it encoded the wrong invariant. It now asserts the opposite: the push must **not** be gated on `notify_on_open`, and the access-event write must still precede the push guard.

Negative-controlled both ways: reintroducing the gate fails it, and breaking the access-log write fails it. Suite **26/26**.

## Verification

Live on drumee.in and **confirmed working by Duy** ("it works on drumee.in now") — with notifications off, the access list now updates without a reload, in both require-email and allow-list modes, and no notification is received.

Related: drumee/schemas (`hotfix/secure-share-list-require-email`) and drumee/ui-team (`hotfix/secure-share-access-label`) fix the second half of the same report — a require-email link being labelled "Public link".