### PR TITLE
feat(payment): coupons accept the revived Pro plan

### DIFF
--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -178,8 +178,10 @@ class __private_payment extends Entity {
     if (!code) return this.output.data({ status: 'COUPON_INVALID' });
 
     const plan = String(this.input.use('plan', 'team')).trim().toLowerCase();
-    // Same outer gate as checkout: coupons exist for the paid org tiers.
-    if (!/^(team|business)$/.test(plan)) {
+    // Same outer gate as checkout: any self-serve paid tier. Pro (personal,
+    // 2026-08-03 revival) is couponable like the org tiers — the discount is
+    // applied to the Stripe subscription the same way regardless of holder.
+    if (!/^(pro|team|business)$/.test(plan)) {
       return this.output.data({ status: 'COUPON_PLAN_UNSUPPORTED', plan });
     }
 
@@ -472,7 +474,7 @@ class __private_payment extends Entity {
           return this.output.data({ status: 'COUPON_WITH_ACTIVE_SUB' });
         }
       }
-      if (!/^(team|business)$/.test(String(plan))) {
+      if (!/^(pro|team|business)$/.test(String(plan))) {
         return this.output.data({ status: 'COUPON_PLAN_UNSUPPORTED', plan });
       }
       if (!email) {


### PR DESCRIPTION
[Pro plan] Pricing gets its fifth card — Pro, the personal tier.

**$5/mo · $50/yr** — 1 hub, 1 member + unlimited guests, 50 GB, unlimited share links, 7-day version history, community support. Positioning: *"For one person who shares."* (pricing table 2026-08-03).

This is **not** the old pro: the tier retired on 2026-07-24 was org-shaped (5 seats, pro_seat add-on). The new Pro is strictly personal — `entity_type 'user'`, `organization: 0`, no admin console.

### Flows verified on stage with a real test-card purchase

| Flow | Result |
|---|---|
| Free → Pro checkout | ✅ Go Pro → $5.00 summary → Stripe Hosted Checkout → paid → webhook grants quota `plan=pro / 50 GB / seat 1` |
| UI reflects it | ✅ sidebar badge "Pro Plan", banner "renews Sep 3, 2026", Pro card marked current |
| Pro → Team / Business | ✅ upgrade popup names Pro and prices Team ($29/mo or $290/yr) — supersede checkout, unchanged machinery |
| Team/Business → Pro | rank map makes it a downgrade: consequences popup warns storage >50 GB and members >1 |
| Cancel / Resume | ✅ cancel → Stripe `cancel_at_period_end=true`, banner "ends on … / Resume Subscription"; resume → `false`, banner back to "renews" — both confirmed against the Stripe API |
| Cross cycle switches | untouched — same defer/immediate logic and popups as before |

### The one deep change

`planKey` stops mapping `'pro'` → team. That mapping existed to grandfather legacy hand-granted rows, and the 2026-07-24 patch rewrote **all** of them onto Team — keeping it would mislabel every *new* Pro subscriber. Found live, not in review: the first purchased Pro sub highlighted the **Team** card as "Your current plan" (the widget's own normaliser had the same mapping).

### Also

- seat = **1**, not 0, in the quota — `isFreeSoloPlan()` reads seat 0 as "block every invite", and Pro sells unlimited guests
- coupons accept pro (preview + checkout reserve); `promo.redeem` deliberately stays team|business — it provisions an ORG, which a personal plan must not trigger
- analytics coupon plan-scope dropdown offers Pro (server reads the catalog with `entity_type IN ('org','user')`)
- schemas patch re-activates its own rows after the 2026-07-24 blanket retirement, so fresh DBs replaying patches in order still end with Pro on sale
- stage Stripe: `prod_V0LddGDUstqU66`, `price_1U0Kvl…` ($5), `price_1U0Kvm…` ($50) — prod needs its own prices seeded out-of-band as usual

### Not done here

- **Figma**: I cannot edit the design file (no Figma access from this session) — the doc/table is implemented, the Figma update stays with you
- Free card copy changes from the new table (2 GB, 3 links/7-day expiry) — the ask was to ADD Pro; Free's published specs are a separate product decision

🤖 Generated with [Claude Code](https://claude.com/claude-code)
