### PR TITLE
feat(promo): redeem accepts Pro, and provisions no org for it

### DIFF
--- a/service/private/promo.js
+++ b/service/private/promo.js
@@ -225,9 +225,13 @@ class __private_promo extends Entity {
     if (!code) return this.output.data({ status: 'COUPON_INVALID' });
 
     const plan = String(this.input.use('plan', '') || '').trim().toLowerCase();
-    if (!/^(team|business)$/.test(plan)) {
+    if (!/^(pro|team|business)$/.test(plan)) {
       return this.output.data({ status: 'COUPON_PLAN_UNSUPPORTED', plan });
     }
+    // Pro is PERSONAL (entity_type 'user', organization 0). It grants to the
+    // redeemer themselves, so none of the organisation machinery below —
+    // the move-semantics guard, the provisioning — applies to it.
+    const needsOrg = /^(team|business)$/.test(plan);
     // Same move-semantics guard as the LAUNCH30 claim and the checkout org
     // bootstrap: someone already inside another org's domain cannot be
     // handed a second organisation.
@@ -239,7 +243,7 @@ class __private_promo extends Entity {
     // OK, user presses Redeem again). Let an owner through: org_provision
     // returns their existing org rather than a second one, and the grant
     // proc answers already=1 without re-granting.
-    if (~~this.user.domain_id() > 1) {
+    if (needsOrg && ~~this.user.domain_id() > 1) {
       const own = this._row2(await this.yp.await_proc(
         'organisation_get', String(this.user.domain_id()),
       ));
@@ -290,16 +294,28 @@ class __private_promo extends Entity {
       });
     }
 
-    const org = await this._provisionOrg();
-    if (!org || org.error) {
-      return this.output.data({
-        status: (org && org.error) || 'PROVISION_FAILED',
-      });
+    // Personal plans provision nothing: the grant lands on the redeemer,
+    // on whatever domain they already live on. Creating an organisation for
+    // a Pro redemption would hand them a tenant the plan does not include
+    // (organization 0) and move their domain_id, which is exactly the
+    // irreversible side effect the ordering fix above exists to avoid.
+    let org = null;
+    if (needsOrg) {
+      org = await this._provisionOrg();
+      if (!org || org.error) {
+        return this.output.data({
+          status: (org && org.error) || 'PROVISION_FAILED',
+        });
+      }
     }
 
+    // The proc reads entity_type from the catalog and picks the quota holder
+    // itself; for a personal plan these two arguments are simply unused.
     const row = this._row2(await this.yp.await_proc(
       'mkt_coupon_redeem',
-      code, email, this.uid, plan, org.id, org.domain_id, COUPON_HOLD_TTL_SEC,
+      code, email, this.uid, plan,
+      org ? org.id : '', org ? org.domain_id : 0,
+      COUPON_HOLD_TTL_SEC,
     ));
     if (!row || row.error) {
       return this.output.data({


### PR DESCRIPTION
Direct redeem (`promo.redeem` — free-period code, no checkout, no card) only ever accepted **org** plans, so a Pro-scoped code had nowhere to be spent: not at checkout (a 100%-off code has nothing to charge) and not here.

### The org assumption was in three layers

| Layer | Assumed | Now |
|---|---|---|
| `mkt_coupon_redeem` catalog lookup | `entity_type = 'org'` hardcoded | reads entity_type **from** the catalog |
| …quota write | `$.organization = 1`, keyed to org id | org → org-keyed; user → **payer**-keyed, organization left as the catalog has it |
| …ARGS_INVALID guard | `_org_id` always required | required only when the plan turns out to be an org plan (`ORG_REQUIRED`) |
| `promo.redeem` gate | `team|business` | `pro|team|business` |
| `promo.redeem` provisioning | always `_provisionOrg()` | skipped entirely for a personal plan |
| Redeem box plan pills | Team, Business | **Pro**, Team, Business |

Fixing only the type check would have been worse than the bug: it would have granted Pro **to an organisation the redeemer must never be given**, and moved their `domain_id` — the same irreversible side effect the validate-before-provision ordering exists to prevent.

The org/user split now mirrors `payment_apply_entitlement` exactly, so a Pro granted by coupon and a Pro bought through Stripe produce the same quota row.

### `org_id` now means "entitlement holder"

For a personal grant it holds the **uid**. The expiry worker feeds that column to `payment_clear_entitlement`, which keys on `payer_id` and already has an individual branch (it re-materialises a claim-reward row when the id belongs to a drumate) — so revocation needed no change at all.

### Verified end to end on stage

Created a Pro-scoped 60-day coupon, then through the **real UI**: pick Pro → enter code → Redeem → *"Code T_PRO60 applied — your pro plan runs until Oct 2, 2026"*, Pro card marked current.

- quota row keyed to the payer: `plan=pro, disk=50 GB, seat=1, organization=0, source=mkt-coupon`
- redemption row: `entity_type='user'`
- **no organisation created** (org count unchanged)
- `get_quota` — the path the app actually uses — returns `pro`
- expiry worker (`SIGUSR2`): quota row deleted, status `expired`, back to Free

Also confirmed the guard still bites: the same code redeemed as `team` answers `COUPON_PLAN_MISMATCH`.

Test coupon and all test rows removed; account left on Free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
