### PR TITLE
fix(payment): checkout_result says a deferred switch charged nothing

### DIFF
--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -922,6 +922,21 @@ class __private_payment extends Entity {
         if (pm && pm.card) { card_brand = pm.card.brand; card_last4 = pm.card.last4; }
       }
     } catch (e) { /* card details are cosmetic — leave unset */ }
+    // A DEFERRED cycle switch (month <-> year, `defer` on checkout) charges
+    // nothing today: the new cycle idles on a Stripe trial until the paid
+    // period lapses, so session.amount_total is 0 and Stripe issues a $0
+    // invoice. The client had no way to tell that apart from a genuinely free
+    // purchase and rendered "Total Payment $0.00" over a $290 switch. Say so
+    // here — the banner on the billing page already branches on the same
+    // condition (settings/account/billing skeleton, 'trialing').
+    const subObj = (session.subscription && typeof session.subscription === 'object') ? session.subscription : null;
+    const defer = md.defer === '1' || !!(subObj && subObj.status === 'trialing' && subObj.trial_end);
+    // When the real billing starts, and what it will cost then. unit_amount
+    // comes off the subscription item (subscriptions carry `items` without an
+    // extra expand); the stored row is the fallback for the window before the
+    // webhook has refreshed it.
+    const item = subObj && subObj.items && subObj.items.data && subObj.items.data[0];
+    const unit = item && item.price && item.price.unit_amount;
     this.output.data({
       status: session.status,                          // complete | open | expired
       payment_status: session.payment_status,          // paid | unpaid | no_payment_required
@@ -934,6 +949,11 @@ class __private_payment extends Entity {
       paid_at: (inv && inv.status_transitions && inv.status_transitions.paid_at) || session.created,
       card_brand,
       card_last4,
+      defer,
+      starts_at: (subObj && subObj.trial_end) || null, // epoch seconds
+      upcoming_amount: unit != null
+        ? unit
+        : (sub && sub.price != null ? Math.round(Number(sub.price)) : null),
     });
   }
 }


### PR DESCRIPTION
A deferred cycle switch bills nothing on the day it is bought — the new cycle idles on a Stripe trial until the paid period lapses — so Stripe reports `amount_total: 0` and issues a $0 invoice.

`checkout_result` returned that 0 with nothing to explain it, so the client could not tell a deferred $290 switch apart from a genuinely free purchase and rendered *"Payment Success! / Total Payment $0.00"*.

### What changed

Returns three more fields:

| field | source |
|---|---|
| `defer` | session `metadata.defer`, or the expanded subscription being `trialing` with a `trial_end` |
| `starts_at` | expanded subscription `trial_end` |
| `upcoming_amount` | subscription item `price.unit_amount`, falling back to the stored row |

All come off objects already fetched — **no extra Stripe call**.

Pairs with ui-team PR (`fix/deferred-switch-receipt`).

### Verified

On stage with a real switch (`sub_1U0P60DjnMxCeY360v5xvadK`, Team month → year): `defer: true`, `starts_at` = Sep 3 2026, `upcoming_amount: 29000`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)