### PR TITLE
fix(payment): apply a deferred cycle switch in place, without Checkout

### DIFF
--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -861,24 +861,106 @@ class __private_payment extends Entity {
       metadata: { ...live_md, plan, period },
     };
     if (defer) {
-      // Swap the price, charge nothing, keep the anchor: the customer keeps
-      // every day they have paid for and the new interval bills at the
-      // existing period end. No proration in either direction — there is
-      // nothing to settle, they are simply on a different price from the next
-      // renewal onward.
+      // A deferred interval change cannot be an update at all.
       //
-      // This replaces routing the switch through Stripe Checkout with a
-      // trial_end, which is how it used to be done. That produced a $0
-      // Checkout session Stripe presents as "N days free" with a "Start
-      // trial" button — its fixed trial copy, which cannot be reworded — for
-      // a customer who is not starting a trial and whose remaining days were
-      // already paid for. Nothing needed collecting: they are an active payer
-      // with a card on file, so there was never a reason to send them to a
-      // payment page at all.
-      params.proration_behavior = 'none';
-      params.billing_cycle_anchor = 'unchanged';
-      // Nothing is invoiced, so there is no payment to keep atomic.
-      delete params.payment_behavior;
+      // The obvious shape — swap the price with proration_behavior 'none' and
+      // billing_cycle_anchor 'unchanged' — is rejected outright by Stripe:
+      // "Changing plan intervals. There's no way to leave billing cycle
+      // unchanged." Changing the interval always resets the anchor, and a
+      // reset anchor invoices the new price today, which is the immediate
+      // switch, not this one.
+      //
+      // A subscription schedule is the primitive that does express it: phase
+      // one is the period already paid for at the current price, phase two
+      // starts the new price the moment it ends. Nothing is charged today and
+      // no Checkout session exists — which is the point. Routing this through
+      // Checkout forced "no charge now" to be modelled as a trial_end, and
+      // Stripe renders any trial as "N days free" under a "Start trial"
+      // button: fixed copy, unchangeable, and wrong twice over here. The
+      // customer is not starting a trial, and the days it calls free are days
+      // they have already paid for.
+      //
+      // end_behavior 'release' hands the subscription back once phase two has
+      // run, so it keeps renewing on the new price as an ordinary
+      // subscription instead of ending when the schedule does.
+      try {
+        // Reuse the schedule already on the subscription when there is one:
+        // Stripe refuses a second, and a caller who switches, changes their
+        // mind and switches back must not hit a dead end on their own
+        // previous decision.
+        const created = live.schedule
+          ? await stripe.subscriptionSchedules.retrieve(
+            typeof live.schedule === 'string' ? live.schedule : live.schedule.id
+          )
+          : await stripe.subscriptionSchedules.create({
+            from_subscription: subscription_id,
+          });
+        // The phase in flight is the one to preserve; on a schedule that has
+        // already been rewritten once, that is still phase 0.
+        const p0 = (created.phases && created.phases[0]) || {};
+        const cur_price = (item && item.price && item.price.id) || null;
+        // Phase one is the period the customer has ALREADY PAID FOR, restated
+        // exactly as it stands. Anything the live subscription carries and
+        // this phase omits is dropped when the schedule takes over — and a
+        // dropped trial is not cosmetic: rewriting a trialing subscription
+        // without its trial_end ends the trial on the spot, opens a fresh
+        // paid period, and invoices the full amount the same day. Observed
+        // doing exactly that: a subscription trialing until Sep 3 came back
+        // 'active' with a period end one year out, billed immediately.
+        const phase_one = {
+          items: [{ price: cur_price, quantity: 1 }],
+          start_date: p0.start_date,
+          end_date: p0.end_date,
+        };
+        const trial_end = ~~live.trial_end;
+        if (String(live.status) === 'trialing'
+          && trial_end > Math.floor(Date.now() / 1000)) {
+          phase_one.trial_end = trial_end;
+        }
+        const sched = await stripe.subscriptionSchedules.update(created.id, {
+          end_behavior: 'release',
+          phases: [
+            phase_one,
+            {
+              items: [{ price: plan_row.stripe_price_id, quantity: 1 }],
+              metadata: { ...live_md, plan, period },
+            },
+          ],
+          metadata: { ...live_md, plan, period, pending_switch: '1' },
+        });
+        const next = (sched.phases && sched.phases[1]) || {};
+        // What phase two will cost. payment_get_plan carries the price ID but
+        // not the figure, and the caller has to name it ("$290.00 on
+        // September 3") or the confirmation says nothing useful.
+        let amount = 0;
+        try {
+          const pr = await stripe.prices.retrieve(plan_row.stripe_price_id);
+          amount = (pr && pr.unit_amount) || 0;
+        } catch (e) { /* the date alone still beats a wrong number */ }
+        return this.output.data({
+          status: 'OK',
+          plan,
+          period,
+          defer: true,
+          scheduled: true,
+          schedule_id: sched.id,
+          amount,
+          currency: plan_row.currency || CURRENCY,
+          // When the new price takes over = when the paid period runs out.
+          period_end: next.start_date || p0.end_date || sub.period_end || 0,
+          subscription_status: live.status || 'active',
+        });
+      } catch (e) {
+        // Leave the subscription exactly as it was and say so; the caller's
+        // fallback is the immediate switch or trying again.
+        try {
+          const s = await stripe.subscriptions.retrieve(subscription_id);
+          if (s && s.schedule) await stripe.subscriptionSchedules.release(s.schedule);
+        } catch (e2) { /* nothing to unwind */ }
+        return this.output.data({
+          status: 'CHANGE_FAILED', error: (e && e.message) || 'schedule failed',
+        });
+      }
     } else if (cur_period !== period) {
       // Interval changed and the caller wants it now: restart the cycle today.
       // They pay the new price immediately (minus the unused-time credit) and

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -657,6 +657,39 @@ class __private_payment extends Entity {
       if (Array.isArray(u)) u = u[0];
       if (u && u.used != null) row.disk_used = Number(u.used) || 0;
     }
+    // A cycle switch waiting for the current period to end lives in a Stripe
+    // subscription schedule, and the subscription itself says nothing about
+    // it: status stays 'active', the price and period end do not move. The
+    // mirror therefore cannot know, and the billing page would keep saying
+    // "renews on <date>" for a plan that is about to become a different one.
+    //
+    // Read it from Stripe rather than mirroring it: this is one call on a page
+    // a user opens rarely, and it cannot drift out of date the way a cached
+    // copy would. Silent on any failure — a schedule lookup must never be the
+    // reason the billing page fails to load.
+    if (row && row.subscription_id) {
+      try {
+        const stripe = this._stripe();
+        const live = await stripe.subscriptions.retrieve(row.subscription_id, {
+          expand: ['schedule'],
+        });
+        const sch = live && live.schedule;
+        const phases = (sch && typeof sch === 'object' && sch.phases) || [];
+        const now = Math.floor(Date.now() / 1000);
+        // The first phase that has not started yet is the pending change; its
+        // plan and period were stamped on the schedule when it was created,
+        // so no reverse price_id -> plan lookup is needed.
+        const next = phases.find((p) => ~~p.start_date > now);
+        const md = (sch && sch.metadata) || {};
+        if (next && md.period && md.period !== row.period) {
+          row.pending_switch = {
+            plan: md.plan || row.plan,
+            period: md.period,
+            starts_at: ~~next.start_date,
+          };
+        }
+      } catch (e) { /* the page is more useful without this than not at all */ }
+    }
     this.output.data(row);
   }
 

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -845,6 +845,12 @@ class __private_payment extends Entity {
       });
     }
 
+    // A DEFERRED cycle switch — same plan, other interval, effective when the
+    // paid period runs out. Only meaningful for that shape; anything else
+    // ignores the flag.
+    const defer = !!this.input.use('defer', '')
+      && cur_plan === plan && cur_period !== period;
+
     const params = {
       items: [{ id: item.id, price: plan_row.stripe_price_id, quantity: 1 }],
       proration_behavior: 'always_invoice',
@@ -854,10 +860,32 @@ class __private_payment extends Entity {
       cancel_at_period_end: false,
       metadata: { ...live_md, plan, period },
     };
-    // When the billing interval changes, restart the cycle today: the caller
-    // pays the new price now (minus the unused-time credit) and renews a clean
-    // month/year from today, instead of a stub period on the old anchor.
-    if (cur_period !== period) params.billing_cycle_anchor = 'now';
+    if (defer) {
+      // Swap the price, charge nothing, keep the anchor: the customer keeps
+      // every day they have paid for and the new interval bills at the
+      // existing period end. No proration in either direction — there is
+      // nothing to settle, they are simply on a different price from the next
+      // renewal onward.
+      //
+      // This replaces routing the switch through Stripe Checkout with a
+      // trial_end, which is how it used to be done. That produced a $0
+      // Checkout session Stripe presents as "N days free" with a "Start
+      // trial" button — its fixed trial copy, which cannot be reworded — for
+      // a customer who is not starting a trial and whose remaining days were
+      // already paid for. Nothing needed collecting: they are an active payer
+      // with a card on file, so there was never a reason to send them to a
+      // payment page at all.
+      params.proration_behavior = 'none';
+      params.billing_cycle_anchor = 'unchanged';
+      // Nothing is invoiced, so there is no payment to keep atomic.
+      delete params.payment_behavior;
+    } else if (cur_period !== period) {
+      // Interval changed and the caller wants it now: restart the cycle today.
+      // They pay the new price immediately (minus the unused-time credit) and
+      // renew a clean month/year from today, instead of a stub period on the
+      // old anchor.
+      params.billing_cycle_anchor = 'now';
+    }
 
     let s;
     try {
@@ -881,6 +909,12 @@ class __private_payment extends Entity {
       status: 'OK',
       plan,
       period,
+      // Whether the new price starts now or at the period end, and what it
+      // will cost then. The caller has to tell the user which of the two just
+      // happened, and only this side knows.
+      defer,
+      amount: (new_items[0] && new_items[0].price && new_items[0].price.unit_amount) || 0,
+      currency: s.currency || CURRENCY,
       subscription_status: s.status || 'active',
       period_end: s.current_period_end || (new_items[0] && new_items[0].current_period_end) || sub.period_end || 0,
     });


### PR DESCRIPTION
Switching month ↔ year on the same plan takes no money today, but still went through Stripe Checkout. Checkout cannot express "no charge now" except as a trial, so the switch was sent with `trial_end` — and Stripe renders any trial as **"N days free"** under a **"Start trial"** button. Fixed copy, unchangeable, and wrong twice over: the customer is not starting a trial, and the days it calls free are days they already paid for. It also produced the $0 session behind the "Total Payment $0.00" receipt.

### What changed

`change_plan` accepts `defer` and, for a same-plan interval change, applies it with a **Stripe subscription schedule**: phase one is the period already paid for, phase two starts the new price the moment it ends. `end_behavior: 'release'` hands the subscription back afterwards so it keeps renewing normally. No session, no trial, no $0 invoice.

`subscription_status` now reports `pending_switch`. A schedule keeps status `active` and moves neither price nor period end, so the mirror cannot know about it and the billing page kept promising a renewal of the plan the user is leaving.

### Two Stripe constraints found by testing, both fixed

1. The obvious shape — swap the price with `proration_behavior: 'none'` and `billing_cycle_anchor: 'unchanged'` — is **rejected outright**: *"Changing plan intervals. There's no way to leave billing cycle unchanged."* Changing the interval always resets the anchor, and a reset anchor invoices today. Hence the schedule.
2. Phase one must restate the live subscription **including its trial**. Rewriting a trialing subscription without `trial_end` ends the trial on the spot, opens a fresh paid period and invoices the full amount the same day — observed doing exactly that on stage before the fix.

### Verified on stage

From a clean Business monthly subscription (`sub_1U0YSLDjnMxCeY36IXZ4ocTO`, active, period end 2026-09-04):

- no Checkout session created
- subscription unchanged after the call — `month` / `active` / `9900` / period end `2026-09-04`
- `pending_switch` = `{plan: business, period: year, starts_at: Sep 4 2026}`

Pairs with ui-team `fix/cycle-switch-no-checkout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
