### PR TITLE
fix(deps): @drumee/server-core ^1.1.83 — stops the mfs_home-on-yp alert flood

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.9.94",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
-        "@drumee/server-core": "^1.1.81",
+        "@drumee/server-core": "^1.1.83",
         "@drumee/server-essentials": "^1.3.1",
         "@drumee/ui-core": "^1.1.43",
         "@hyzyla/pdfium": "^2.1.9",
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@drumee/server-core": {
-      "version": "1.1.81",
-      "resolved": "https://registry.npmjs.org/@drumee/server-core/-/server-core-1.1.81.tgz",
-      "integrity": "sha512-moMH4+VU/RyN2EwZ0Mn+DBjey9MfM2t32KhnpaUo6BTxCGeIFJKBIkocLftFAUpRdY62LZ0F5B82HMhGB4Pjcw==",
+      "version": "1.1.83",
+      "resolved": "https://registry.npmjs.org/@drumee/server-core/-/server-core-1.1.83.tgz",
+      "integrity": "sha512-4h5GZyTrWLRbOuKaSv4gEUb43OrykbIwduySqmEuAMKvZ/hAwX+FzDf975TH507E/AVwT1RQkOVzqiPIWT6Y1w==",
       "license": "AGPL V3",
       "dependencies": {
         "@drumee/server-essentials": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@drumee/schemas-utils": "^1.0.0",
-    "@drumee/server-core": "^1.1.81",
+    "@drumee/server-core": "^1.1.83",
     "@drumee/server-essentials": "^1.3.1",
     "@drumee/ui-core": "^1.1.43",
     "@hyzyla/pdfium": "^2.1.9",


### PR DESCRIPTION
Picks up `@drumee/server-core` **1.1.83**, which carries the session-init fix
([server-core#4](https://github.com/drumee/server-core/pull/4), merged `28d181d`, published by
Somanos). This is what stops the PROD alert flood we've had since 31 Jul.

## What it fixes

1.1.81 ran `_initHub()` and `_initUser()` concurrently. But `_initUser` ends in `_assign_user()`,
which fires **START** — and **this repo dispatches on START**:

```js
// service.js:34
session.once(START, function () { Acl.run(session); });
```

On an unresolvable vhost `_initHub` needs a *second* `get_hub` round trip via `_default_hub()`, so
an anonymous `_initUser` won the race and the request began with **no hub**. It then fell into the
public media service and called `mfs_home()` against `yp`, which has no `media` table:

```
mariadb_stub[WARN]: Table 'yp.media' doesn't exist   (sql: call mfs_home())
__media[WARN]: No mfs_home found for { src: 2, scope: 'hub' }
[media.raw][DENIED] to uid=ffffffffffffffff on hub_id=undefined
```

~5k failing queries and alert pages per day on PROD. **No user impact** — the affected requests are
scanners hitting invalid subdomains; every legitimate `media.raw` call carries a real `hub_id`
(107,803 of them GRANTED against ~7,800 denials).

## Why this branches off `preview`, not `test`

`test` currently carries #163 (last-login accuracy) and #164 (mail sender identity), which are
unrelated to this fix. Branching off `preview` keeps the hotfix isolated. The same bump will be
applied to `test` so it doesn't fall behind.

## Verification

- 1.1.81 and 1.1.83 declare **identical dependency sets**, so only the resolved entry and the two
  spec lines change — 4 lines, 2 files, no churn.
- The published 1.1.83 tarball's `lib/session.js` is **byte-identical to server-core `main`**.
- Integrity hash verified against the real tarball with `openssl dgst -sha512`.
- `npm ci --dry-run` exits 0 and resolves `@drumee/server-core 1.1.83`.
- The lock was hand-edited rather than regenerated, so npm didn't rewrite the 24 unrelated `peer`
  flags it churns on every `npm install`.
- The fix itself was verified on the drumee.in stage host before merging upstream: unresolvable Host
  went from 1 warning per request to 0 (now a plain 404), while real vhosts, avatars and
  `media.raw` were unaffected. Evidence is in server-core#4 and its first comment.

## After merge

UAT picks it up automatically. The alerts stop on PROD at the next PROD dispatch.
