### PR TITLE
Promote test → preview: connection log for proc-opened sessions + pinned mail sender identity

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.9.94",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
-        "@drumee/server-core": "^1.1.81",
+        "@drumee/server-core": "^1.1.83",
         "@drumee/server-essentials": "^1.3.1",
         "@drumee/ui-core": "^1.1.43",
         "@hyzyla/pdfium": "^2.1.9",
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@drumee/server-core": {
-      "version": "1.1.81",
-      "resolved": "https://registry.npmjs.org/@drumee/server-core/-/server-core-1.1.81.tgz",
-      "integrity": "sha512-moMH4+VU/RyN2EwZ0Mn+DBjey9MfM2t32KhnpaUo6BTxCGeIFJKBIkocLftFAUpRdY62LZ0F5B82HMhGB4Pjcw==",
+      "version": "1.1.83",
+      "resolved": "https://registry.npmjs.org/@drumee/server-core/-/server-core-1.1.83.tgz",
+      "integrity": "sha512-4h5GZyTrWLRbOuKaSv4gEUb43OrykbIwduySqmEuAMKvZ/hAwX+FzDf975TH507E/AVwT1RQkOVzqiPIWT6Y1w==",
       "license": "AGPL V3",
       "dependencies": {
         "@drumee/server-essentials": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@drumee/schemas-utils": "^1.0.0",
-    "@drumee/server-core": "^1.1.81",
+    "@drumee/server-core": "^1.1.83",
     "@drumee/server-essentials": "^1.3.1",
     "@drumee/ui-core": "^1.1.43",
     "@hyzyla/pdfium": "^2.1.9",

--- a/service/butler.js
+++ b/service/butler.js
@@ -19,6 +19,7 @@ const {
   Attr, Constants, sendSms, Messenger, Cache, sysEnv, uniqueId, RedisStore
 } = require("@drumee/server-essentials");
 const { platform } = require('./lib/env');
+const { logConnection } = require('./lib/connection_log');
 const { resolve } = require('path');
 const { isEmpty, isString } = require("lodash");
 const { notifyMemberJoined } = require("./lib/notify-member-joined");
@@ -428,7 +429,12 @@ class __butler extends Mfs {
         metadata.otp_secret,
         this.input.sid()
       );
-      //await this.log_connection(metadata.uid)
+      // session_login_otp above OPENS A SESSION -- completing a forgot-password
+      // reset signs the user straight in -- and it is a plain proc, so it writes
+      // no services_log row. Without this the reset is a way into the product
+      // that never registers as a login. (The call this replaces was commented
+      // out and named a method that does not exist on this class.)
+      await logConnection(this, metadata.uid);
       await this.yp.await_proc("token_delete", secret);
       await this.yp.await_proc(
         "otp_delete",

--- a/service/lib/butler-mail.js
+++ b/service/lib/butler-mail.js
@@ -7,6 +7,7 @@
 const { readFileSync } = require('fs');
 const { resolve } = require('path');
 const { sysEnv } = require('@drumee/server-essentials');
+const { mailbox } = require('./mail-sender');
 
 let _butlerSender;
 /**
@@ -39,7 +40,10 @@ async function sendButlerMail(msg, { recipient, subject, html, text }) {
   const sender = butlerSender();
   if (!sender) return msg.send({ html });
   const mailOptions = {
-    from: `"Drumee" <${sender}>`,
+    // Via mailbox() rather than a hand-rolled `"Drumee" <${sender}>`: `sender`
+    // is credential-derived (email.json auth.user), so a value that already
+    // carries angle brackets would nest them and ship a "Drumee>" display name.
+    from: mailbox("Drumee", sender),
     to: recipient,
     subject,
     text,

--- a/service/lib/connection_log.js
+++ b/service/lib/connection_log.js
@@ -1,0 +1,85 @@
+/**
+ * @license
+ * Copyright 2026 Thidima SA. All Rights Reserved.
+ * Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE, Version 3.
+ * https://www.gnu.org/licenses/agpl-3.0.html
+ */
+
+/**
+ * Writes to yp.services_log from application code, for sessions that
+ * @drumee/server-core did not open itself.
+ *
+ * server-core records a connection in exactly two places -- session.signin()
+ * and session.login() -- via its private _log_connection, which stamps the row
+ * with args.success=1 plus ip/geodata/headers. Every other way into a live
+ * session opens it with a PROCEDURE (session_login_otp,
+ * session_login_with_oauth, session_login_next) and leaves no trace.
+ *
+ * That matters because two readers treat this table as the record of who got
+ * in and when: yp.show_login_log, and the analytics "Last login" column, which
+ * takes MAX(ctime) over rows carrying args.success='1'. A login that writes no
+ * row is a user who appears never to have signed in.
+ *
+ * Lives here rather than on a base class because the services that need it do
+ * not share one: yp.js extends Entity while lobby.js and butler.js extend Mfs.
+ */
+
+/**
+ * Record an accepted sign-in for `uid`.
+ *
+ * The service instance is passed in rather than bound, so this works from any
+ * scope. `_log_connection` fills in the service name, ip, geodata and headers
+ * from the live request; the explicit uid is what makes it usable before
+ * `this.user` has been populated, which is the normal state on a proc-opened
+ * session.
+ *
+ * NEVER LET THIS BREAK A LOGIN. The caller is already authenticated by the time
+ * we run, so a logging failure must cost an analytics row and not a session.
+ * Every failure is warned and swallowed.
+ *
+ * @param {Object} svc calling service instance (`this`)
+ * @param {String} uid
+ */
+async function logConnection(svc, uid) {
+  try {
+    await svc.session._log_connection({ uid });
+  } catch (e) {
+    svc.warn("connection_log: failed to record login for", uid, e && e.message);
+  }
+}
+
+/**
+ * Take back a connection log that session.signin() wrote before a later gate
+ * refused the sign-in.
+ *
+ * signin() logs as soon as the credentials check out, so a caller that then
+ * tears the session down (see the unverified-email gate in yp.login) leaves a
+ * row behind saying the user got in. Marking it success=0 files it with the
+ * other refusals: both readers select on args.success, so it stops counting as
+ * a login without vanishing from the audit trail.
+ *
+ * Targets the newest success row for the uid, which within a single request is
+ * the one signin() just wrote. A concurrent login by the SAME user in the
+ * window between the two statements could see the wrong row marked; that costs
+ * an analytics timestamp, which is not worth a lock.
+ *
+ * @param {Object} svc calling service instance (`this`)
+ * @param {String} uid
+ * @param {String} reason recorded as args.reason, matching how server-core
+ *                        labels its own refusals (WRONG_CREDENTIALS etc.)
+ */
+async function revokeConnectionLog(svc, uid, reason) {
+  try {
+    await svc.yp.await_query(
+      `UPDATE services_log
+          SET args = JSON_SET(args, '$.success', 0, '$.reason', ?)
+        WHERE uid = ? AND JSON_VALUE(args, '$.success') = '1'
+        ORDER BY sys_id DESC LIMIT 1`,
+      reason, uid
+    );
+  } catch (e) {
+    svc.warn("connection_log: failed to revoke login for", uid, e && e.message);
+  }
+}
+
+module.exports = { logConnection, revokeConnectionLog };

--- a/service/lib/mail-sender.js
+++ b/service/lib/mail-sender.js
@@ -1,0 +1,79 @@
+// service/lib/mail-sender.js
+// The address user-facing Drumee mail is sent FROM, and the RFC 5322 mailbox
+// built from it.
+//
+// Pinned here rather than read from credential/email.json — which is what the
+// butlerSender() copy in each sending module used to do. That file holds the
+// transport's SMTP *login*: an unmonitored `butler@<domain>` mailbox. Deriving
+// the public From from it meant the two could never differ, so a reprovisioned
+// credential silently rewrote who user-facing mail appeared to come from, and on
+// a box whose email.json was written before the domain resolved it addressed
+// mail from the literal `butler@undefined`. A constant can do neither.
+//
+// The login is unaffected: the transport still authenticates as whatever
+// email.json says. Only the header changes.
+//
+// DEPLOYMENT REQUIREMENT, not satisfied by this file. drumee.org is not the
+// domain the relay's DKIM key signs (d=drumee.com), and its SPF record
+// ("v=spf1 a mx ~all") lists only Firebase hosting and Google's MX — not the
+// relay. Its DMARC is published twice (p=none and p=quarantine), which per
+// RFC 7489 makes receivers discard the set entirely. Until drumee.org publishes
+// an SPF entry for the relay and its own DKIM selector, everything sent from
+// this address is unauthenticated mail — and the templates on this path include
+// 2FA codes and email verification, where landing in spam locks a user out of
+// signing in.
+const MAIL_SENDER_NAME = "Drumee";
+const MAIL_SENDER_ADDRESS = "contact@drumee.org";
+
+/**
+ * Build an RFC 5322 mailbox, accepting EITHER a bare address or a mailbox that
+ * already carries its own angle brackets.
+ *
+ * This exists because of a real bug. Every sending module in this repo used to
+ * format its From by hand as `"Drumee" <${sender}>`, which is correct only if
+ * `sender` is a bare address. Hand it a full mailbox and the brackets nest:
+ *
+ *   `"Drumee" <"Drumee" <contact@drumee.org>>`
+ *      -> parsers report { name: "Drumee>", address: "contact@drumee.org" }
+ *
+ * The address still resolves, so the mail is delivered and nothing is logged —
+ * the closing bracket is silently absorbed into the display name and every
+ * recipient sees "Drumee>". Since butlerFrom() returns a full mailbox and
+ * butlerSender() returns a bare address, the two shapes are one keystroke apart
+ * at any call site, so the wrapping is centralised here where it can only
+ * happen once.
+ *
+ * @param {String} name    display name; quotes are escaped, never passed raw
+ * @param {String} address bare address, or a mailbox like `X <a@b>`
+ * @returns {String} e.g. `"Drumee" <contact@drumee.org>`
+ * @throws {Error} if no address can be recovered — a broken From is worse than
+ *                 a loud failure, because it delivers and looks fine in logs
+ */
+function mailbox(name, address) {
+  const raw = String(address == null ? "" : address).trim();
+  // The innermost <...> pair is the address; a value with no pair is already
+  // bare, and any loose bracket on it is stripped rather than re-emitted.
+  const angled = raw.match(/<([^<>]*)>/);
+  const addr = (angled ? angled[1] : raw.replace(/[<>]/g, "")).trim();
+  if (!addr) {
+    throw new Error(`mail-sender: cannot build a From, no address in ${JSON.stringify(address)}`);
+  }
+  // A bare quote in the phrase would terminate it early and turn the rest of
+  // the header into stray tokens — the same class of break as the nested `>`.
+  const phrase = String(name == null ? "" : name).replace(/[\\"]/g, "\\$&");
+  return `"${phrase}" <${addr}>`;
+}
+
+/**
+ * The From header for user-facing mail, display name included.
+ *
+ * The name is what an inbox actually shows; without it the mail arrives as a
+ * bare address no recipient recognises.
+ *
+ * @returns {String} RFC 5322 mailbox, e.g. `"Drumee" <contact@drumee.org>`
+ */
+function butlerFrom() {
+  return mailbox(MAIL_SENDER_NAME, MAIL_SENDER_ADDRESS);
+}
+
+module.exports = { MAIL_SENDER_NAME, MAIL_SENDER_ADDRESS, mailbox, butlerFrom };

--- a/service/lobby.js
+++ b/service/lobby.js
@@ -11,6 +11,7 @@ const {
 } = Constants;
 
 const { Mfs, MfsTools } = require("@drumee/server-core");
+const { logConnection } = require("./lib/connection_log");
 
 const { google } = require("googleapis");
 const oauth2 = google.oauth2("v2");
@@ -364,7 +365,12 @@ class __butler extends Mfs {
         metadata.otp_secret,
         this.input.sid()
       );
-      //await this.log_connection(metadata.uid)
+      // session_login_otp above OPENS A SESSION -- completing a forgot-password
+      // reset signs the user straight in -- and it is a plain proc, so it writes
+      // no services_log row. Without this the reset is a way into the product
+      // that never registers as a login. (The call this replaces was commented
+      // out and named a method that does not exist on this class.)
+      await logConnection(this, metadata.uid);
       await this.yp.await_proc("token_delete", secret);
       await this.yp.await_proc(
         "otp_delete",

--- a/service/otp.js
+++ b/service/otp.js
@@ -20,10 +20,14 @@ const { FORGOT_PASSWORD } = Constants;
 const { Entity } = require("@drumee/server-core");
 const { resolve } = require("path");
 
+const { butlerFrom, mailbox } = require("./lib/mail-sender");
+
 /**
- * Configured envelope sender (email.json -> auth.user), resolved once. Used to
- * build a "Drumee" <addr> display-name From, matching the other butler emails.
- * The address is read at runtime (it differs per deployment) not hardcoded.
+ * Configured envelope sender (email.json -> auth.user), resolved once.
+ *
+ * Only the reset-password mail still builds its From from this. The OTP mail
+ * moved to the pinned brand address (lib/mail-sender); this one was left on the
+ * credential-derived sender because it was not part of that change.
  */
 let _butlerSender;
 function butlerSender() {
@@ -110,11 +114,9 @@ class Otp extends Entity {
     });
     const tplPath = resolve(__dirname, "./templates/otp.html");
     const html = msg.renderFrom(tplPath, data);
-    // Display-name From ("Drumee" <butler@...>) so the inbox shows "Drumee",
-    // matching the other butler emails. Falls back to default sender if unset.
-    const sender = butlerSender();
-    const from = sender ? `"Drumee" <${sender}>` : undefined;
-    const payload = from ? { html, from } : { html };
+    // Display-name From ("Drumee" <contact@drumee.org>) so the inbox shows
+    // "Drumee", matching the other butler emails.
+    const payload = { html, from: butlerFrom() };
 
     // Answer with the secret the moment it's minted — the SMTP round-trip is the
     // slow part (seconds) and the client only needs the secret to open the
@@ -186,8 +188,11 @@ class Otp extends Entity {
     });
     const tplPath = resolve(__dirname, "./templates/reset-password.html");
     const html = msg.renderFrom(tplPath, data);
+    // Via mailbox() rather than a hand-rolled `"Drumee" <${sender}>`: `sender`
+    // is credential-derived (email.json auth.user), so a value that already
+    // carries angle brackets would nest them and ship a "Drumee>" display name.
     const sender = butlerSender();
-    const from = sender ? `"Drumee" <${sender}>` : undefined;
+    const from = sender ? mailbox("Drumee", sender) : undefined;
 
     let sent = 0;
     try {

--- a/service/private/contact.js
+++ b/service/private/contact.js
@@ -15,7 +15,7 @@
  * =============================================================================
  */
 
-const { Attr, Constants, Messenger, utils, RedisStore, Cache, nullValue, sysEnv } = require("@drumee/server-essentials");
+const { Attr, Constants, Messenger, utils, RedisStore, Cache, nullValue } = require("@drumee/server-essentials");
 const { EMAIL_CHECKER } = Constants;
 
 const { readFileSync } = require('fs');
@@ -27,23 +27,7 @@ const { google } = require("googleapis");
 
 const { toArray } = utils;
 const { shouldSendNotification } = require("../lib/email-policy");
-
-/**
- * Configured envelope sender (email.json -> auth.user), resolved once.
- * Used to build a display-name From and a List-Unsubscribe mailto without
- * hardcoding the address (it differs per deployment / tenant).
- */
-let _butlerSender;
-function butlerSender() {
-  if (_butlerSender !== undefined) return _butlerSender;
-  try {
-    const f = resolve(sysEnv().credential_dir, 'email.json');
-    _butlerSender = (JSON.parse(readFileSync(f, 'utf8')).auth || {}).user || null;
-  } catch (e) {
-    _butlerSender = null;
-  }
-  return _butlerSender;
-}
+const { butlerFrom } = require("../lib/mail-sender");
 
 /** ==============================================  */
 const Contact = require('../contact');
@@ -505,7 +489,11 @@ class __private_contact extends Contact {
    * The shared @drumee/server-essentials Messenger.send() emits HTML-only mail
    * with no List-Unsubscribe — both are spam signals for Gmail. This restores
    * the text part and headers without forking the package. Falls back to
-   * msg.send() when no MTA or no usable sender address is configured.
+   * msg.send() when no MTA is configured.
+   *
+   * The From is the pinned brand address (lib/mail-sender), so unlike the old
+   * credential-derived sender it is always available — there is no longer a
+   * "no usable sender" case to fall back from.
    *
    * @param {Messenger} msg
    * @param {{recipient:string, subject:string, html:string, text:string}} parts
@@ -513,10 +501,8 @@ class __private_contact extends Contact {
   async _sendButlerMail(msg, { recipient, subject, html, text }) {
     const mta = await msg.getMTA();
     if (!mta) return msg.send({ html });        // preserves NO_MTA handling
-    const sender = butlerSender();
-    if (!sender) return msg.send({ html });      // no usable From -> old path
     const mailOptions = {
-      from: `"Drumee" <${sender}>`,
+      from: butlerFrom(),
       to: recipient,
       subject,
       text,

--- a/service/private/hub.js
+++ b/service/private/hub.js
@@ -29,25 +29,7 @@ const {
 } = Constants;
 const { resolve } = require("path");
 const { notifyMemberJoined } = require("../lib/notify-member-joined");
-
-/**
- * Configured envelope sender (email.json -> auth.user), resolved once. Used to
- * build a "Drumee" <addr> display-name From for butler invite emails, matching
- * the contact-add emails. The address is read at runtime (it differs per
- * deployment) rather than hardcoded.
- */
-let _butlerSender;
-function butlerSender() {
-  if (_butlerSender !== undefined) return _butlerSender;
-  try {
-    const { readFileSync } = require("fs");
-    const f = resolve(sysEnv().credential_dir, "email.json");
-    _butlerSender = (JSON.parse(readFileSync(f, "utf8")).auth || {}).user || null;
-  } catch (e) {
-    _butlerSender = null;
-  }
-  return _butlerSender;
-}
+const { butlerFrom } = require("../lib/mail-sender");
 const { MfsTools } = require("@drumee/server-core");
 const { remove_dir } = MfsTools;
 const { toArray } = utils;
@@ -1582,16 +1564,14 @@ class __private_hub extends Hub {
     const tplPath = resolve(__dirname, "templates", "butler", `${tpl}.html`);
     const msg = new Messenger({ subject, recipient, handler: this.exception.email });
     const html = msg.renderFrom(tplPath, data);
-    // Display-name From ("Drumee" <butler@...>) so the inbox shows "Drumee",
-    // matching the contact-add emails. Falls back to the default sender when
-    // no address is configured.
-    const sender = butlerSender();
-    const from = sender ? `"Drumee" <${sender}>` : undefined;
+    // Display-name From ("Drumee" <contact@drumee.org>) so the inbox shows
+    // "Drumee", matching the contact-add emails.
+    const from = butlerFrom();
     // Messenger.send() always resolves { recipient, error } — it never rejects
     // (errors are routed to the handler). Inspect `error` so an SMTP-time
     // rejection (e.g. unknown mailbox -> 550) surfaces as a failed invitee
     // instead of a silent status:"ok".
-    const result = msg.dispatch(from ? { html, from } : { html });
+    const result = msg.dispatch({ html, from });
     if (result && result.error) {
       throw new Error(`Email delivery to ${recipient} failed: ${result.error}`);
     }

--- a/service/private/templates/butler/contact-add-drumate.html
+++ b/service/private/templates/butler/contact-add-drumate.html
@@ -10,7 +10,13 @@
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#fff;">
     <tr>
       <td align="center" style="padding:0;">
-        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:100%;background:#fff;border:1px solid #d1d1d6;border-radius:8px;overflow:hidden;">
+        <!-- 600px is the standard email frame width, and the width the sibling
+             templates use. Fluid below it, capped above: uncapped it stretched
+             to the whole viewport, so on a desktop inbox the body copy ran the
+             full width of the screen. The width ATTRIBUTE has to be a number
+             for Outlook, which ignores the style and treats width="100%" as a
+             broken value. Centring comes from the align="center" on the td. -->
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;background:#fff;border:1px solid #d1d1d6;border-radius:8px;overflow:hidden;">
 
           <!-- Header: purple signature -->
           <tr>

--- a/service/private/templates/butler/contact-add-non-drumate.html
+++ b/service/private/templates/butler/contact-add-non-drumate.html
@@ -10,7 +10,13 @@
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:#fff;">
     <tr>
       <td align="center" style="padding:0;">
-        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:100%;background:#fff;border:1px solid #d1d1d6;border-radius:8px;overflow:hidden;">
+        <!-- 600px is the standard email frame width, and the width the sibling
+             templates use. Fluid below it, capped above: uncapped it stretched
+             to the whole viewport, so on a desktop inbox the body copy ran the
+             full width of the screen. The width ATTRIBUTE has to be a number
+             for Outlook, which ignores the style and treats width="100%" as a
+             broken value. Centring comes from the align="center" on the td. -->
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;background:#fff;border:1px solid #d1d1d6;border-radius:8px;overflow:hidden;">
 
           <!-- Header: purple signature -->
           <tr>

--- a/service/templates/otp.html
+++ b/service/templates/otp.html
@@ -10,7 +10,13 @@
   <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="width:100%;background:#fff;">
     <tr>
       <td align="center" style="padding:0;text-align:center;">
-        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" align="center" style="width:100%;max-width:100%;margin:0 auto;background:#fff;border:1px solid #d1d1d6;border-radius:8px;overflow:hidden;">
+        <!-- 600px is the standard email frame width, and the width the sibling
+             templates use. Fluid below it, capped above: uncapped it stretched
+             to the whole viewport, so on a desktop inbox the code block sat
+             marooned in the middle of a full-screen white field. The width
+             ATTRIBUTE has to be a number for Outlook, which ignores the style
+             and treats width="100%" as a broken value. -->
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" align="center" style="width:100%;max-width:600px;margin:0 auto;background:#fff;border:1px solid #d1d1d6;border-radius:8px;overflow:hidden;">
 
           <!-- Header: purple signature -->
           <tr>

--- a/service/yp.js
+++ b/service/yp.js
@@ -26,6 +26,7 @@ const { Entity, FileIo } = require("@drumee/server-core");
 const { existsSync, readFileSync } = require("fs");
 const { isEmpty, isArray, isString } = require("lodash");
 const { get_env, platform } = require('./lib/env');
+const { logConnection, revokeConnectionLog } = require('./lib/connection_log');
 const { resolve } = require("path");
 const { credential_dir } = sysEnv();
 let keyFile = resolve(credential_dir, `crypto/public.pem`);
@@ -226,6 +227,12 @@ class __yp extends Entity {
         await this.yp.await_proc(
           "session_reset", this.input.sid(), r.user.id, this.input.get(Attr.socket_id)
         );
+        // session.signin() logged an accepted connection BEFORE we got here --
+        // it has no idea this gate exists -- so without this the user is refused
+        // entry and their "last login" advances anyway. Take it back rather than
+        // reorder the check: the credentials have to be resolved before there is
+        // a uid to look unverified_email up by.
+        await revokeConnectionLog(this, r.user.id, "EMAIL_NOT_VERIFIED");
         return this.output.data({ status: "EMAIL_NOT_VERIFIED", email: row.unverified_email });
       }
     }
@@ -270,7 +277,14 @@ class __yp extends Entity {
   }
 
   /**
-   * 
+   * Second leg of a 2FA sign-in: verify the emailed code and open the session.
+   *
+   * This COMPLETES the login that login() started -- session.signin() returns at
+   * its `status == "otp"` branch without logging anything, because at that point
+   * nobody is signed in yet. The connection is therefore logged here, and only
+   * here: session_login_otp is a plain proc and writes no services_log row, so
+   * without this every 2FA account showed a permanently stale "Last login" in
+   * analytics while signing in perfectly normally.
    */
   async login_top() {
     const uid = this.input.get(Attr.id) || this.input.get(Attr.uid) || this.uid;
@@ -280,6 +294,7 @@ class __yp extends Entity {
     if (!result || result.status !== 'success') {
       return this.output.data({ status: 'error' });
     }
+    await logConnection(this, uid);
     const user = await this.yp.await_proc('get_user', uid);
     this.output.data(user);
   }

--- a/service/yp.js
+++ b/service/yp.js
@@ -32,23 +32,7 @@ const { credential_dir } = sysEnv();
 let keyFile = resolve(credential_dir, `crypto/public.pem`);
 const publicKey = readFileSync(keyFile);
 
-/**
- * Configured envelope sender (email.json -> auth.user), resolved once. Used to
- * build a "Drumee" <addr> display-name From so the inbox shows "Drumee"
- * instead of the raw butler@ address — matching otp.js and the other butler
- * emails. The address is read at runtime (it differs per deployment).
- */
-let _butlerSender;
-function butlerSender() {
-  if (_butlerSender !== undefined) return _butlerSender;
-  try {
-    const f = resolve(credential_dir, "email.json");
-    _butlerSender = (JSON.parse(readFileSync(f, "utf8")).auth || {}).user || null;
-  } catch (e) {
-    _butlerSender = null;
-  }
-  return _butlerSender;
-}
+const { butlerFrom } = require("./lib/mail-sender");
 
 
 //########################################
@@ -263,13 +247,10 @@ class __yp extends Entity {
     });
     const tplPath = resolve(__dirname, "./templates/otp.html");
     const html = msg.renderFrom(tplPath, data);
-    // Display-name From ("Drumee" <butler@...>) so the inbox shows "Drumee"
-    // instead of the raw sender address, matching otp.js. Falls back to the
-    // default sender if unset.
-    const sender = butlerSender();
-    const from = sender ? `"Drumee" <${sender}>` : undefined;
+    // Display-name From ("Drumee" <contact@drumee.org>) so the inbox shows
+    // "Drumee" instead of the raw sender address, matching otp.js.
     try {
-      await msg.send(from ? { html, from } : { html });
+      await msg.send({ html, from: butlerFrom() });
     } catch (e) {
       this.warn("2FA OTP email send failed", e);
     }


### PR DESCRIPTION
Promotion of `test` → `preview`. No DB payload.

## Payload

| Commit | Change |
|---|---|
| `e4795562` (#163) | **last-login accuracy** — new `service/lib/connection_log.js`. server-core only records a connection in `session.signin()` / `session.login()`; sessions opened by procedure (`session_login_otp`, `session_login_with_oauth`, `session_login_next`) left no row in `yp.services_log`, so those users read as never having signed in. Wired into `yp.js`, `lobby.js`, `butler.js`, `otp.js`. |
| `dbd0baea` (#164) | **mail sender identity** — new `service/lib/mail-sender.js`. The public From was derived from the SMTP credential, so a reprovisioned credential silently rewrote who user-facing mail came from, and could render `butler@undefined`. Now pinned to `"Drumee" <contact@drumee.org>`. Touches `butler-mail.js`, `contact.js`, `hub.js` and the otp / contact-add templates. |
| `ff35bd20` | `@drumee/server-core` `^1.1.83` — **already present on `preview`** as the 08-04 hotfix (#165). Cherry-pick, identical blobs. |

## Verification

- `git merge-tree preview test` merges **clean**, and the merged tree is byte-identical to the `test` tree ⇒ `test` is a strict superset, nothing on `preview` is at risk.
- The only preview-only delta is `package.json` / `package-lock.json`, and both blob SHAs are **identical on the two branches** (`098e26b2`, `2f8731fc`) — the 1.1.83 bump reached each branch by its own commit.
- `_log_connection` confirmed present in the published `@drumee/server-core@1.1.83` (`lib/session.js:567`). Every call is wrapped in try/catch and warned, so a logging failure costs an analytics row, never a session.
- `mail-sender.js` uses a module constant — no `sys_conf`, env or credential-file dependency.
- **No `.sql` and no `schemas/` file in the payload** — nothing to apply to the prod DB.

## CI

`Lint (bug rules only)`, `Secret scan`, `Dependency audit`, `Deploy` all green on the `test` head. `SonarCloud Code Analysis` is red — it is **also red on the current `preview` head** (`648dde98`), i.e. the standing new-code-coverage condition, not a regression from this payload.

## Note for the eventual PROD deploy

Once this rides to prod, all butler / OTP / contact mail is sent from `contact@drumee.org`. Worth confirming the SPF entry for the relay and the drumee.org DKIM selector are live before that dispatch.
