### PR TITLE
feat(over-limit): server enforcement — evaluate at every downgrade, read-only clamp, grace worker

### DIFF
--- a/acl/payment.json
+++ b/acl/payment.json
@@ -173,6 +173,22 @@
           "http_status": 400
         }
       ]
+    },
+    "over_limit_state": {
+      "doc": "Downgrade over-limit: fresh evaluation of the caller's org — recomputes usage/seats vs the current entitlement, persists the two flags and returns state + exact overage numbers for the popup/banner. Any signed-in member may read (the read-only banner is shown to everyone).",
+      "scope": "hub",
+      "permission": {
+        "src": "read"
+      },
+      "params": {}
+    },
+    "over_limit_dismiss": {
+      "doc": "Downgrade over-limit: snooze the owner/admin popup for the CALLING user only, server-side (never localStorage). Cleared automatically when the org returns within limits.",
+      "scope": "hub",
+      "permission": {
+        "src": "read"
+      },
+      "params": {}
     }
   },
   "modules": {

--- a/offline/workers/overLimitGraceWorker.js
+++ b/offline/workers/overLimitGraceWorker.js
@@ -60,10 +60,18 @@ async function initialize() {
 async function lockOne(row) {
   const { org_id, domain_id } = row;
   try {
-    let res = await yp.await_proc('org_over_limit_hard_lock', org_id);
-    if (Array.isArray(res)) res = res[0];
-    if (!res || ~~res.locked !== 1) {
-      // Resolved (or already locked) between the scan and now — nothing to do.
+    await yp.await_proc('org_over_limit_hard_lock', org_id);
+    // Trust the state, not the driver's shape for "SELECT ROW_COUNT()": the
+    // mariadb wrapper returns multi-statement proc results inconsistently
+    // (first run on stage: the flip landed but `locked` read back falsy, so
+    // the WS push was skipped and clients never heard about it). The due
+    // scan only ever lists over_limit rows, so re-reading the row is both
+    // the reliable answer and naturally idempotent — a resolved-in-between
+    // org reads back 'ok'/absent and is skipped the same way.
+    let st = await yp.await_proc('org_over_limit_get', ~~domain_id);
+    if (Array.isArray(st)) st = st[0];
+    if (!st || st.state !== 'hard_lock') {
+      // Resolved between the scan and now — nothing to do.
       return false;
     }
     // Re-evaluate to refresh the numbers and push the hard_lock state to

--- a/offline/workers/overLimitGraceWorker.js
+++ b/offline/workers/overLimitGraceWorker.js
@@ -1,0 +1,148 @@
+/**
+ * Over-Limit Grace Worker
+ *
+ * The second half of the downgrade over-limit state machine
+ * (service/lib/over-limit.js + yp org_over_limit_*): an org that is still
+ * over its downgraded plan's storage or seat limit when the grace deadline
+ * passes flips from over_limit (read-only, everyone can still look) to
+ * hard_lock (owner/admin-only access — everyone else is denied entirely
+ * until the owner resolves). One unresolved flag is enough; nothing is ever
+ * deleted here or anywhere else in the feature.
+ *
+ * Effect first, mark second — org_over_limit_hard_lock is status-guarded
+ * (state='over_limit' AND deadline passed), so a retried tick, or a worker
+ * racing an owner who resolves at the buzzer, is a no-op: the resolution
+ * path already removed the block and ROW_COUNT() comes back 0.
+ *
+ * Model: mirrors promoExpiryWorker.js — plain setTimeout self-rescheduler
+ * (the runtime ships Bull, not `cron`), short interval since deadlines land
+ * at arbitrary times of day.
+ *
+ * Env:
+ *   OVER_LIMIT_GRACE_INTERVAL_SEC  poll cadence (default 900 = 15 min)
+ *
+ * The whole feature is gated by `over_limit_enforcement` in myDrumee.json —
+ * but that global belongs to the service process, not this worker, so the
+ * worker gates on data instead: org_over_limit_due only ever returns rows
+ * that an enabled service wrote. No flags written → nothing to flip.
+ */
+
+const { Mariadb, RedisStore } = require('@drumee/server-essentials');
+const OverLimit = require('../../service/lib/over-limit');
+
+const WORKER_NAME = process.env.WORKER_NAME || 'over-limit-grace-worker-1';
+const INTERVAL_MS = (parseInt(process.env.OVER_LIMIT_GRACE_INTERVAL_SEC, 10) || 900) * 1000;
+
+console.log(`[OverLimitGraceWorker] Starting worker: ${WORKER_NAME}`);
+console.log(`[OverLimitGraceWorker] Poll interval: ${INTERVAL_MS / 1000}s`);
+
+let yp;
+let redisReady = false;
+
+function asArray(x) {
+  if (Array.isArray(x)) return x;
+  return x == null ? [] : [x];
+}
+
+async function initialize() {
+  yp = new Mariadb({ name: 'yp' });
+  console.log('[OverLimitGraceWorker] Database connected');
+  try {
+    await RedisStore.prototype.init.call(new RedisStore());
+    redisReady = true;
+    console.log('[OverLimitGraceWorker] RedisStore initialized');
+  } catch (e) {
+    // Flag-only mode: the lock still lands, clients learn on next boot.
+    console.warn('[OverLimitGraceWorker] RedisStore unavailable:', e.message);
+  }
+}
+
+async function lockOne(row) {
+  const { org_id, domain_id } = row;
+  try {
+    let res = await yp.await_proc('org_over_limit_hard_lock', org_id);
+    if (Array.isArray(res)) res = res[0];
+    if (!res || ~~res.locked !== 1) {
+      // Resolved (or already locked) between the scan and now — nothing to do.
+      return false;
+    }
+    // Re-evaluate to refresh the numbers and push the hard_lock state to
+    // every member's open session. evaluate() keeps hard_lock as-is (it
+    // never un-hard-locks on its own) — this is a refresh + fan-out, not a
+    // second decision.
+    await OverLimit.evaluate(yp, ~~domain_id, {
+      notify: redisReady ? (state) => OverLimit.notifyDomain(yp, RedisStore, state) : null,
+    });
+    console.log(`[OverLimitGraceWorker] hard-locked org=${org_id} domain=${domain_id}`);
+    return true;
+  } catch (error) {
+    console.error(`[OverLimitGraceWorker] failed to lock org=${org_id}:`, error.message);
+    return false;
+  }
+}
+
+async function runGraceJob() {
+  try {
+    const due = asArray(await yp.await_proc('org_over_limit_due'));
+    if (!due.length) return;
+    console.log(`[OverLimitGraceWorker] ${due.length} org(s) past their grace deadline`);
+    let locked = 0;
+    for (const row of due) {
+      if (await lockOne(row)) locked++;
+    }
+    console.log(`[OverLimitGraceWorker] done — ${locked}/${due.length} hard-locked`);
+  } catch (error) {
+    console.error('[OverLimitGraceWorker] job failed:', error);
+  }
+}
+
+function scheduleNext() {
+  setTimeout(async () => {
+    try {
+      await runGraceJob();
+    } finally {
+      scheduleNext();
+    }
+  }, INTERVAL_MS);
+}
+
+async function startWorker() {
+  await initialize();
+  await runGraceJob(); // catch up immediately on boot, then settle into the interval
+  scheduleNext();
+  process.on('SIGUSR2', async () => {
+    console.log('[OverLimitGraceWorker] SIGUSR2 — manual run');
+    await runGraceJob();
+  });
+  console.log('[OverLimitGraceWorker] Worker started. Manual run: kill -USR2', process.pid);
+}
+
+async function shutdown() {
+  console.log('[OverLimitGraceWorker] Shutting down...');
+  try {
+    if (yp && yp.connection) await yp.end();
+  } catch (error) {
+    console.error('[OverLimitGraceWorker] Shutdown error:', error.message);
+  }
+  process.exit(0);
+}
+
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);
+process.on('uncaughtException', (error) => {
+  console.error('[OverLimitGraceWorker] Uncaught exception:', error);
+  process.exit(1);
+});
+process.on('unhandledRejection', (reason) => {
+  console.error('[OverLimitGraceWorker] Unhandled rejection:', reason);
+  process.exit(1);
+});
+
+startWorker().catch((error) => {
+  console.error('[OverLimitGraceWorker] Failed to start worker:', error);
+  process.exit(1);
+});
+
+console.log('[OverLimitGraceWorker] Worker process started (PID:', process.pid, ')');
+
+module.exports = { runGraceJob };

--- a/offline/workers/promoExpiryWorker.js
+++ b/offline/workers/promoExpiryWorker.js
@@ -27,7 +27,8 @@
  *   PROMO_EXPIRY_INTERVAL_SEC  poll cadence (default 900 = 15 min)
  */
 
-const { Mariadb } = require('@drumee/server-essentials');
+const { Mariadb, RedisStore } = require('@drumee/server-essentials');
+const OverLimit = require('../../service/lib/over-limit');
 
 const WORKER_NAME = process.env.WORKER_NAME || 'promo-expiry-worker-1';
 const INTERVAL_MS = (parseInt(process.env.PROMO_EXPIRY_INTERVAL_SEC, 10) || 900) * 1000;
@@ -36,6 +37,7 @@ console.log(`[PromoExpiryWorker] Starting worker: ${WORKER_NAME}`);
 console.log(`[PromoExpiryWorker] Poll interval: ${INTERVAL_MS / 1000}s`);
 
 let yp;
+let redisReady = false;
 
 function asArray(x) {
   if (Array.isArray(x)) return x;
@@ -45,6 +47,34 @@ function asArray(x) {
 async function initialize() {
   yp = new Mariadb({ name: 'yp' });
   console.log('[PromoExpiryWorker] Database connected');
+  // For the over-limit push after a revert. Best-effort: without Redis the
+  // flags are still written; clients pick them up on next boot.
+  try {
+    await RedisStore.prototype.init.call(new RedisStore());
+    redisReady = true;
+    console.log('[PromoExpiryWorker] RedisStore initialized');
+  } catch (e) {
+    console.warn('[PromoExpiryWorker] RedisStore unavailable:', e.message);
+  }
+}
+
+// Downgrade over-limit: a promo/coupon revert is a plan-lowering commit like
+// any Stripe cancel — measure the org against the free tier it just fell to.
+async function evaluateOverLimit(org_id) {
+  try {
+    if (!OverLimit.enabled()) return;
+    let org = await yp.await_query(
+      `SELECT domain_id FROM organisation WHERE id = ? LIMIT 1`, org_id
+    );
+    if (Array.isArray(org)) org = org[0];
+    const dom = ~~(org && org.domain_id);
+    if (dom <= 1) return;
+    await OverLimit.evaluate(yp, dom, {
+      notify: redisReady ? (state) => OverLimit.notifyDomain(yp, RedisStore, state) : null,
+    });
+  } catch (e) {
+    console.warn(`[PromoExpiryWorker] over-limit evaluation failed for org=${org_id}:`, e.message);
+  }
 }
 
 async function expireOne(row) {
@@ -53,6 +83,7 @@ async function expireOne(row) {
     // Same revert path an org's Stripe cancel takes — see the module doc.
     await yp.await_proc('payment_clear_entitlement', org_id);
     await yp.await_proc('promo_launch30_mark_expired', payer_id);
+    await evaluateOverLimit(org_id);
     console.log(`[PromoExpiryWorker] expired promo for payer=${payer_id} org=${org_id}`);
     return true;
   } catch (error) {
@@ -77,6 +108,7 @@ async function expireOneRedemption(row) {
   try {
     await yp.await_proc('payment_clear_entitlement', org_id);
     await yp.await_proc('mkt_coupon_redeem_mark_expired', id);
+    await evaluateOverLimit(org_id);
     console.log(`[PromoExpiryWorker] expired coupon redemption id=${id} code=${code} org=${org_id} email=${email}`);
     return true;
   } catch (error) {

--- a/offline/workers/trashWorker.js
+++ b/offline/workers/trashWorker.js
@@ -74,6 +74,38 @@ trashQueue.process('empty_trash', CONCURRENCY, async (job) => {
     
     console.log(`[TrashWorker] Found ${entities.length} files to purge`);
     
+    // Downgrade over-limit: mfs_empty_trash just decremented yp.disk_usage —
+    // this is the storage-resolving action, so re-measure the hub's domain
+    // and clear/update the flags live. Best-effort: the purge itself must
+    // never fail on it.
+    try {
+      const OverLimit = require('../../service/lib/over-limit');
+      if (OverLimit.enabled()) {
+        let dom = await yp.await_query(
+          `SELECT dom_id FROM entity WHERE id = ? LIMIT 1`, hub_id
+        );
+        if (Array.isArray(dom)) dom = dom[0];
+        if (~~(dom && dom.dom_id) > 1) {
+          const { RedisStore } = require('@drumee/server-essentials');
+          // This worker never initializes Redis on its own — do it lazily,
+          // once, and fall back to flag-only (no live push) when unavailable.
+          if (!global.__overLimitRedisReady) {
+            try {
+              await RedisStore.prototype.init.call(new RedisStore());
+              global.__overLimitRedisReady = true;
+            } catch (e) { /* flags still written below */ }
+          }
+          await OverLimit.evaluate(yp, ~~dom.dom_id, {
+            notify: global.__overLimitRedisReady
+              ? (state) => OverLimit.notifyDomain(yp, RedisStore, state)
+              : null,
+          });
+        }
+      }
+    } catch (e) {
+      console.warn('[TrashWorker] over-limit re-evaluation failed:', e.message);
+    }
+
     // Spawn purge.js (path resolved relative to this worker — see PURGE_WORKER)
     const cmd = PURGE_WORKER;
     const args = { entities, uid };

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -66,6 +66,31 @@ const SECURE_SHARE_READONLY_DENYLIST = new Set([
   "devel.verbosity", "devel.log_over_socket",
 ]);
 
+// Downgrade over-limit clamp (service/lib/over-limit.js). While an org is
+// over its downgraded plan's limits the whole workspace is read-only; these
+// MUTATING services survive the clamp because they are the way OUT of it:
+//   - trash / purge / empty_bin free storage (trash still counts toward
+//     usage, so purging is the resolving action, not deleting);
+//   - member removal frees seats (both console backends);
+//   - server_export honours "export always works" (src:'delete', so the
+//     mutating threshold would eat it);
+//   - drumate.logout is src:'owner' — a locked member must still sign out.
+// payment.* / promo.* are allowed by prefix below — the owner must be able
+// to upgrade or re-subscribe their way out.
+const OVER_LIMIT_MUTATING_ALLOWLIST = new Set([
+  "media.trash", "media.purge", "media.empty_bin",
+  "media.server_export",
+  "adminpanel.member_delete", "admin.hub_member_remove",
+  "drumate.logout",
+]);
+// Once hard-locked, NON-admin members are denied entirely — not even read
+// (Owner/Admin keep view + resolution access). The FE still needs enough to
+// boot into the "workspace locked" screen and leave.
+const HARD_LOCK_SURVIVAL = new Set([
+  "yp.get_env", "desk.get_env", "yp.guest_logout", "drumate.logout",
+]);
+const ADMIN_LEVEL = permissionValue("admin");
+
 
 /**
  *
@@ -344,6 +369,44 @@ class Acl {
           } catch (e) {
             console.warn("[acl] secure-share ceiling check failed (fail-open):", e && e.message);
           }
+        }
+        // Downgrade over-limit read-only clamp. One cached, indexed yp read
+        // (30s TTL inside getState) per domain; personal domains (id<=1) and
+        // platforms without over_limit_enforcement never reach the lookup.
+        // Fail-OPEN like the ceiling above — a failed check keeps the last
+        // known state and never invents a lock.
+        try {
+          const OverLimit = require("../../service/lib/over-limit");
+          if (OverLimit.enabled() && session.user && session.user.get("signed_in")) {
+            const dom = ~~session.user.domain_id();
+            if (dom > 1) {
+              const st = await OverLimit.getState(session.yp, dom);
+              if (st && (st.state === "over_limit" || st.state === "hard_lock")) {
+                const uid = session.user.get("id");
+                if (st.state === "hard_lock" && !HARD_LOCK_SURVIVAL.has(service)) {
+                  // Owner/Admin keep view + resolution access; every other
+                  // role is denied entirely — not even read.
+                  let admin = uid && uid === st.owner_id ? 1 : 0;
+                  if (!admin) {
+                    admin = await session.yp.await_func("domain_permission", uid, dom, ADMIN_LEVEL);
+                  }
+                  if (!admin) {
+                    worker.stop();
+                    return session.exception.unauthorized(`HARD_LOCK_DENIED:${service}`);
+                  }
+                }
+                const survives = OVER_LIMIT_MUTATING_ALLOWLIST.has(service)
+                  || service.startsWith("payment.")
+                  || service.startsWith("promo.");
+                if (mightMutate && !survives) {
+                  worker.stop();
+                  return session.exception.unauthorized(`OVER_LIMIT_READ_ONLY:${service}`);
+                }
+              }
+            }
+          }
+        } catch (e) {
+          console.warn("[over-limit] clamp failed (fail-open):", e && e.message);
         }
         const need = worker.before_granting;
         if (isFunction(worker[need])) {

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -395,9 +395,18 @@ class Acl {
                     return session.exception.unauthorized(`HARD_LOCK_DENIED:${service}`);
                   }
                 }
+                // admin./adminpanel. pass as a family: their src:'admin' is a
+                // PRIVILEGE requirement, not a mutation marker — the threshold
+                // below would read every admin-console READ (member_stats,
+                // member_list, audit) as mutating and lock the owner out of
+                // the very console that resolves the overage. Nothing in
+                // these namespaces grows usage or seats: invites go through
+                // hub.invite (still clamped), uploads through media.*.
                 const survives = OVER_LIMIT_MUTATING_ALLOWLIST.has(service)
                   || service.startsWith("payment.")
-                  || service.startsWith("promo.");
+                  || service.startsWith("promo.")
+                  || service.startsWith("admin.")
+                  || service.startsWith("adminpanel.");
                 if (mightMutate && !survives) {
                   worker.stop();
                   return session.exception.unauthorized(`OVER_LIMIT_READ_ONLY:${service}`);

--- a/router/rest/index.js
+++ b/router/rest/index.js
@@ -82,6 +82,11 @@ const OVER_LIMIT_MUTATING_ALLOWLIST = new Set([
   "media.server_export",
   "adminpanel.member_delete", "admin.hub_member_remove",
   "drumate.logout",
+  // Google Drive migration is OFF while locked (an import only ADDS bytes) —
+  // the whole src:'owner' namespace stays clamped. These two are the
+  // exception: seeing a migration that was already running when the lock
+  // landed, and STOPPING it, make the overage smaller, not bigger.
+  "google_drive.get_state", "google_drive.cancel",
 ]);
 // Once hard-locked, NON-admin members are denied entirely — not even read
 // (Owner/Admin keep view + resolution access). The FE still needs enough to

--- a/service/lib/env.js
+++ b/service/lib/env.js
@@ -140,6 +140,12 @@ function platform() {
   if (global.myDrumee.billing_upgrade !== undefined) {
     platform.billing_upgrade = global.myDrumee.billing_upgrade;
   }
+  // Downgrade over-limit enforcement (read-only lock + resolution flow) —
+  // same rollout pattern as billing_upgrade: cloud feature, off unless the
+  // deployment's myDrumee.json turns it on. Coerced here (unlike above)
+  // because the client only needs on/off; there is no "derive it" third
+  // state for this one.
+  platform.over_limit_enforcement = global.myDrumee.over_limit_enforcement ? 1 : 0;
   platform.cdnHost = global.myDrumee.cdnHost;
   platform.version = global.VERSION;
   platform.TfaMethods = TfaMethods;

--- a/service/lib/over-limit.js
+++ b/service/lib/over-limit.js
@@ -1,0 +1,244 @@
+/**
+ * Downgrade over-limit resolution — the shared evaluation library.
+ *
+ * When a plan goes DOWN (Team->Free, Business->Team, trial expiry, cancel,
+ * dunning) and the org is over the NEW plan's storage or seat limit, the
+ * workspace enters a graced read-only state until the owner resolves it.
+ * The state itself lives in organisation.metadata.$.over_limit and is owned
+ * by the yp proc org_over_limit_set (two INDEPENDENT flags — storage and
+ * seats — plus a one-shot grace deadline). This module is the single JS
+ * entrance to that state machine:
+ *
+ *   evaluate(yp, domainId, opts)  recompute usage + seats vs the org's
+ *                                 CURRENT entitlement and write the flags.
+ *                                 Called after every plan-lowering commit
+ *                                 (stripe_webhook, promo, promoExpiryWorker)
+ *                                 and after every resolution action (purge /
+ *                                 empty_bin / trash, member removal).
+ *   getState(yp, domainId)        cached scalar read for the REST read-only
+ *                                 clamp — 30s TTL so write-op enforcement
+ *                                 costs at most one indexed yp query per
+ *                                 domain per 30s. evaluate() invalidates.
+ *   enabled()                     the whole feature is gated by
+ *                                 `over_limit_enforcement` in myDrumee.json
+ *                                 (same rollout switch pattern as
+ *                                 billing_upgrade) — cloud-only, off by
+ *                                 default, so self-hosted nodes and prod
+ *                                 stay untouched until explicitly enabled.
+ *
+ * Never throws: quota enforcement must not take the request down with it.
+ * On any lookup failure the answer is "last known state" (or 'ok') — the
+ * design's own rule: a failed check never defaults to locked.
+ */
+
+const GRACE_SEC = parseInt(process.env.OVER_LIMIT_GRACE_SEC, 10) || 7 * 24 * 3600;
+
+// Business's seat quota is a 100000 sentinel meaning unlimited (same read as
+// hub.js _seatBudget). Free org rows don't exist (payment_clear_entitlement
+// DELETES the row) — a downgraded-to-free org is capped at 1 seat (the owner)
+// and the free fallback row's disk allowance.
+const SEAT_UNLIMITED = 100000;
+
+// domainId -> { at: epoch-ms, row: {...}|null } — null row = no org / clean.
+const cache = new Map();
+const CACHE_TTL_MS = 30 * 1000;
+
+function enabled() {
+  return !!(global.myDrumee && global.myDrumee.over_limit_enforcement);
+}
+
+function invalidate(domainId) {
+  cache.delete(~~domainId);
+}
+
+function firstRow(r) {
+  return Array.isArray(r) ? r[0] : r;
+}
+
+/**
+ * Cheap cached read for the enforcement clamp. Returns the org_over_limit_get
+ * row ({org_id, owner_id, state, storage_over, seats_over, grace_deadline})
+ * or null when the domain has no org / no over-limit block. state is only
+ * meaningful when non-null: 'over_limit' | 'hard_lock'.
+ */
+async function getState(yp, domainId) {
+  const dom = ~~domainId;
+  if (!enabled() || dom <= 1) return null;
+  const hit = cache.get(dom);
+  if (hit && Date.now() - hit.at < CACHE_TTL_MS) return hit.row;
+  let row = null;
+  try {
+    row = firstRow(await yp.await_proc("org_over_limit_get", dom)) || null;
+    if (row && !row.state) row = null;
+  } catch (e) {
+    // Fail-open: keep the stale row if we have one, otherwise treat as clean.
+    console.warn("[over-limit] state lookup failed (fail-open):", e && e.message);
+    return hit ? hit.row : null;
+  }
+  cache.set(dom, { at: Date.now(), row });
+  return row;
+}
+
+/**
+ * The org's current limits, from its own quota row — or the free tier when
+ * payment_clear_entitlement already deleted it (cancel / trial expiry land
+ * exactly there: members fall back to per-user free, and the org hubs are
+ * measured against the free allowance).
+ */
+async function _limits(yp, domainId, orgId) {
+  let row = firstRow(await yp.await_query(
+    `SELECT plan, disk, seat FROM quota WHERE domain_id = ? AND payer_id = ? LIMIT 1`,
+    ~~domainId, orgId
+  ));
+  if (row && row.disk != null) {
+    return {
+      plan: row.plan || "",
+      disk: Number(row.disk) || 0,
+      seat: row.seat == null ? null : ~~row.seat,
+    };
+  }
+  // No org entitlement row -> free tier. Disk from the canonical free
+  // fallback row (the last tier of every entitlement cascade); seat 1 = the
+  // owner alone, which is what "Free: 1 member" means in the plan matrix.
+  let free = firstRow(await yp.await_query(
+    `SELECT disk FROM quota WHERE payer_id = 'ffffffffffffffff' LIMIT 1`
+  ));
+  return { plan: "free", disk: Number(free && free.disk) || 5000000000, seat: 1 };
+}
+
+/**
+ * Re-evaluate one domain and persist the outcome. Returns the resulting
+ * state row {prev_state, state, storage_over, seats_over, grace_deadline,
+ * disk_used, disk_limit, seats_used, seat_limit, plan} or null when the
+ * domain has no org (personal accounts never lock).
+ *
+ * opts.notify — async (uids, model) fan-out used for the WS push; injected
+ * so entities and workers can share this code (they build the envelope
+ * differently — see notifyDomain below for the ready-made one).
+ */
+async function evaluate(yp, domainId, opts = {}) {
+  const dom = ~~domainId;
+  if (!enabled() || dom <= 1) return null;
+  let out = null;
+  try {
+    const org = firstRow(await yp.await_query(
+      `SELECT id, owner_id FROM organisation WHERE domain_id = ? LIMIT 1`, dom
+    ));
+    if (!org || !org.id) return null;
+
+    // Drift repair BEFORE measuring: quota_usage carries known leaks (version
+    // bytes never reclaimed, restore double-counts) that could otherwise hold
+    // an org "over limit" it cannot fix. recalculate_domain_usage re-sums the
+    // per-hub yp.disk_usage rows for this one domain — cheap, indexed.
+    try { await yp.await_proc("recalculate_domain_usage", dom); } catch (e) { /* keep cached */ }
+
+    const usage = firstRow(await yp.await_query(
+      `SELECT GREATEST(IFNULL(actual_usage, 0), IFNULL(cached_usage, 0)) AS used
+         FROM quota_usage WHERE domain_id = ?`, dom
+    ));
+    const diskUsed = Number(usage && usage.used) || 0;
+
+    const limits = await _limits(yp, dom, org.id);
+
+    // Same occupancy the seat guards and the Admin console show:
+    // members + pending invites (member_list_stats).
+    let seatsUsed = 0;
+    try {
+      const stats = firstRow(await yp.await_proc("member_list_stats", org.id));
+      seatsUsed = ~~(stats && stats.total_members) + ~~(stats && stats.pending_invites);
+    } catch (e) {
+      console.warn("[over-limit] member stats failed, seats flag skipped:", e && e.message);
+    }
+
+    const seatCap = (limits.seat == null || limits.seat <= 0 || limits.seat >= SEAT_UNLIMITED)
+      ? (limits.plan === "free" ? 1 : null)
+      : limits.seat;
+
+    const storageOver = limits.disk > 0 && diskUsed > limits.disk ? 1 : 0;
+    const seatsOver = seatCap != null && seatsUsed > seatCap ? 1 : 0;
+
+    const res = firstRow(await yp.await_proc(
+      "org_over_limit_set",
+      org.id, storageOver, seatsOver, GRACE_SEC,
+      diskUsed, limits.disk, seatsUsed, seatCap == null ? 0 : seatCap, limits.plan
+    ));
+
+    out = {
+      org_id: org.id,
+      owner_id: org.owner_id,
+      domain_id: dom,
+      prev_state: res && res.prev_state,
+      state: (res && res.state) || "ok",
+      storage_over: storageOver,
+      seats_over: seatsOver,
+      grace_deadline: res && res.grace_deadline ? ~~res.grace_deadline : 0,
+      disk_used: diskUsed,
+      disk_limit: limits.disk,
+      seats_used: seatsUsed,
+      seat_limit: seatCap == null ? 0 : seatCap,
+      plan: limits.plan,
+    };
+    invalidate(dom);
+
+    if (opts.notify) {
+      const changed = (out.prev_state || "ok") !== out.state;
+      // Push on every evaluation while a block exists (numbers move as the
+      // owner deletes/removes), and once more on the resolving transition.
+      if (out.state !== "ok" || changed) {
+        try { await opts.notify(out); } catch (e) {
+          console.warn("[over-limit] notify failed:", e && e.message);
+        }
+      }
+    }
+  } catch (e) {
+    console.warn("[over-limit] evaluate failed (state unchanged):", e && e.message);
+  }
+  return out;
+}
+
+/**
+ * Ready-made WS fan-out: pushes the state to EVERY member of the domain (the
+ * lock banner is for everyone, not just the owner). Explicit
+ * {model, options:{service}} envelope — the exact shape reminderWorker uses —
+ * so the FE handler can switch on options.service regardless of transport.
+ */
+async function notifyDomain(yp, RedisStore, state) {
+  const uids = await yp.await_query(
+    `SELECT DISTINCT p.uid FROM privilege p
+      INNER JOIN drumate d ON p.uid = d.id
+      WHERE p.domain_id = ?
+        AND COALESCE(JSON_VALUE(d.profile, '$.category'), '') <> 'system'`,
+    state.domain_id
+  );
+  const list = (Array.isArray(uids) ? uids : [uids]).filter(Boolean).map((r) => r.uid);
+  if (!list.length) return;
+  const recipients = await yp.await_proc("user_sockets", list.join(","));
+  const rows = Array.isArray(recipients) ? recipients : [recipients];
+  if (!rows.filter(Boolean).length) return;
+  await RedisStore.sendData(
+    {
+      model: {
+        state: state.state,
+        flags: { storage: ~~state.storage_over, seats: ~~state.seats_over },
+        grace_deadline: state.grace_deadline,
+        disk_used: state.disk_used,
+        disk_limit: state.disk_limit,
+        seats_used: state.seats_used,
+        seat_limit: state.seat_limit,
+        plan: state.plan,
+        timestamp: Date.now(),
+      },
+      options: { service: "payment.plan_state_changed", keys: "*" },
+    },
+    rows.filter(Boolean)
+  );
+}
+
+module.exports = {
+  GRACE_SEC,
+  enabled,
+  evaluate,
+  getState,
+  invalidate,
+  notifyDomain,
+};

--- a/service/lib/over-limit.js
+++ b/service/lib/over-limit.js
@@ -212,7 +212,10 @@ async function notifyDomain(yp, RedisStore, state) {
   );
   const list = (Array.isArray(uids) ? uids : [uids]).filter(Boolean).map((r) => r.uid);
   if (!list.length) return;
-  const recipients = await yp.await_proc("user_sockets", list.join(","));
+  // user_sockets takes a JSON param — pass the ARRAY like reminderWorker
+  // does. A comma-joined string arrives as one scalar, matches no uid, and
+  // the whole push silently fans out to nobody (found live on stage).
+  const recipients = await yp.await_proc("user_sockets", list);
   const rows = Array.isArray(recipients) ? recipients : [recipients];
   if (!rows.filter(Boolean).length) return;
   await RedisStore.sendData(

--- a/service/private/hub.js
+++ b/service/private/hub.js
@@ -1459,6 +1459,21 @@ class __private_hub extends Hub {
         members: budget.members,
       });
     }
+    // Downgrade over-limit: while the workspace is over its downgraded
+    // plan's limits, growing the membership is paused along with every other
+    // mutation. This has to live HERE, not in the REST clamp: the redeemer
+    // is anonymous / on their own personal domain, so the clamp inspects the
+    // wrong domain. Role upgrades (held > 0 → hubDom 0) stay allowed — they
+    // take no seat.
+    if (hubDom > 0) {
+      try {
+        const OverLimit = require('../lib/over-limit');
+        const st = await OverLimit.getState(this.yp, hubDom);
+        if (st && st.state) {
+          return this.output.data({ status: 'OVER_LIMIT', hub_id });
+        }
+      } catch (e) { /* fail-open, same rule as the clamp */ }
+    }
     await this.yp.await_proc(`${db_name}.add_member`, this.uid, permission, 0);
     await this.yp.await_proc(
       `${db_name}.permission_grant`,

--- a/service/private/media.js
+++ b/service/private/media.js
@@ -1850,10 +1850,31 @@ class __private_media extends Media {
    * To actually purge entire trash bin
    * @params null
    */
+  // Downgrade over-limit: purge / empty_bin are the storage-RESOLVING
+  // actions (trash still counts toward usage — only these decrement
+  // yp.disk_usage), so each one re-measures the domain and clears/updates
+  // the flags live. trash() calls it too: the numbers don't move there, but
+  // the refreshed push keeps the owner's banner honest about that fact.
+  // Best-effort — the operation itself is already committed.
+  async _evaluateOverLimitAfterResolve() {
+    try {
+      const OverLimit = require('../lib/over-limit');
+      if (!OverLimit.enabled()) return;
+      const dom = ~~this.user.domain_id();
+      if (dom <= 1) return;
+      await OverLimit.evaluate(this.yp, dom, {
+        notify: (state) => OverLimit.notifyDomain(this.yp, RedisStore, state),
+      });
+    } catch (e) {
+      this.warn('[over-limit] post-resolve evaluation failed:', e.message);
+    }
+  }
+
   async empty_bin() {
     if (!this.user.get(Attr.settings).trash_expiry) {
       let list = await this.db.await_proc("mfs_empty_trash");
       await this._empty_bin(list)
+      await this._evaluateOverLimitAfterResolve();
       return this.output.data(list)
     }
     try {
@@ -1921,6 +1942,7 @@ class __private_media extends Media {
     if (!isEmpty(data)) {
       await this._empty_bin(data);
     }
+    await this._evaluateOverLimitAfterResolve();
     this.output.list(data);
   }
 
@@ -2089,6 +2111,7 @@ class __private_media extends Media {
       });
     }
 
+    await this._evaluateOverLimitAfterResolve();
     this.output.list(data);
   }
 

--- a/service/private/payment.js
+++ b/service/private/payment.js
@@ -952,6 +952,57 @@ class __private_payment extends Entity {
         : (sub && sub.price != null ? Math.round(Number(sub.price)) : null),
     });
   }
+
+  // ── Downgrade over-limit resolution (service/lib/over-limit.js) ──────────
+  //
+  // over_limit_state: FRESH evaluation of the caller's domain — recomputes
+  // usage + seats against the current entitlement, persists the flags and
+  // returns the numbers the popup/banner render. A read that re-evaluates on
+  // purpose: opening the popup self-heals any drift (and emits the resolved
+  // push if the org has quietly come back within limits).
+  async over_limit_state() {
+    const OverLimit = require('../lib/over-limit');
+    const dom = ~~this.user.domain_id();
+    if (!OverLimit.enabled() || dom <= 1) {
+      return this.output.data({ state: 'ok', enabled: OverLimit.enabled() ? 1 : 0 });
+    }
+    const { RedisStore } = require('@drumee/server-essentials');
+    const res = await OverLimit.evaluate(this.yp, dom, {
+      notify: (state) => OverLimit.notifyDomain(this.yp, RedisStore, state),
+    });
+    if (!res) return this.output.data({ state: 'ok', enabled: 1 });
+    this.output.data({
+      enabled: 1,
+      state: res.state,
+      flags: { storage: res.storage_over, seats: res.seats_over },
+      grace_deadline: res.grace_deadline,
+      disk_used: res.disk_used,
+      disk_limit: res.disk_limit,
+      seats_used: res.seats_used,
+      seat_limit: res.seat_limit,
+      plan: res.plan,
+    });
+  }
+
+  // "Remind me later" — snooze the popup for THIS admin, server-side (the
+  // design forbids localStorage: a dismissal must never outlive its intent;
+  // resolution wipes the whole block, snoozes included). Default 24h,
+  // OVER_LIMIT_SNOOZE_SEC to tune per environment.
+  async over_limit_dismiss() {
+    const OverLimit = require('../lib/over-limit');
+    const dom = ~~this.user.domain_id();
+    if (!OverLimit.enabled() || dom <= 1) return this.output.data({ status: 'OK' });
+    let org = await this.yp.await_query(
+      `SELECT id FROM organisation WHERE domain_id = ? LIMIT 1`, dom
+    );
+    if (Array.isArray(org)) org = org[0];
+    if (!org || !org.id) return this.output.data({ status: 'OK' });
+    const snooze = parseInt(process.env.OVER_LIMIT_SNOOZE_SEC, 10) || 24 * 3600;
+    const until = Math.floor(Date.now() / 1000) + snooze;
+    await this.yp.await_proc('org_over_limit_dismiss', org.id, this.uid, until);
+    OverLimit.invalidate(dom);
+    this.output.data({ status: 'OK', snoozed_until: until });
+  }
 }
 
 module.exports = __private_payment;

--- a/service/private/promo.js
+++ b/service/private/promo.js
@@ -129,6 +129,25 @@ class __private_promo extends Entity {
     await this.yp.await_proc('payment_clear_entitlement', orgId);
     await this.yp.await_proc('promo_launch30_mark_expired', this.uid);
 
+    // Downgrade over-limit: the org just fell to the free tier — measure it
+    // against the free limits and set the flags/grace if it no longer fits.
+    try {
+      const OverLimit = require('../lib/over-limit');
+      if (OverLimit.enabled()) {
+        let org = await this.yp.await_query(
+          `SELECT domain_id FROM organisation WHERE id = ? LIMIT 1`, orgId
+        );
+        if (Array.isArray(org)) org = org[0];
+        const dom = ~~(org && org.domain_id);
+        if (dom > 1) {
+          const { RedisStore } = require('@drumee/server-essentials');
+          await OverLimit.evaluate(this.yp, dom, {
+            notify: (state) => OverLimit.notifyDomain(this.yp, RedisStore, state),
+          });
+        }
+      }
+    } catch (e) { /* best-effort — the revert above is already committed */ }
+
     let quota;
     try {
       quota = await this.yp.await_func('get_quota', this.uid);

--- a/service/public/stripe_webhook.js
+++ b/service/public/stripe_webhook.js
@@ -409,6 +409,36 @@ class __public_stripe_webhook extends Entity {
     } catch (e) { return undefined; }
   }
 
+  // Downgrade over-limit: re-evaluate the org's usage/seats against the
+  // entitlement THIS webhook just wrote. Every plan-lowering path commits
+  // through payment_apply_entitlement / payment_clear_entitlement in this
+  // file, so hooking the three call sites covers checkout-supersede,
+  // change_plan, Billing-Portal downgrades, cancel->free and dunning in one
+  // move. Personal plans never lock a workspace (evaluate() ignores
+  // domain<=1), and upgrades that clear an existing block also flow through
+  // here — that is what flips the workspace back to 'ok' live.
+  // Best-effort by design: the entitlement is already committed, and a
+  // failed evaluation must not 500 the webhook (Stripe would re-deliver).
+  async _evaluateOverLimit(entity_id, entity_type) {
+    try {
+      if (entity_type !== 'org') return;
+      const OverLimit = require('../lib/over-limit');
+      if (!OverLimit.enabled()) return;
+      let org = await this.yp.await_query(
+        `SELECT domain_id FROM organisation WHERE id = ? LIMIT 1`, entity_id
+      );
+      if (Array.isArray(org)) org = org[0];
+      const dom = ~~(org && org.domain_id);
+      if (dom <= 1) return;
+      const { RedisStore } = require('@drumee/server-essentials');
+      await OverLimit.evaluate(this.yp, dom, {
+        notify: (state) => OverLimit.notifyDomain(this.yp, RedisStore, state),
+      });
+    } catch (e) {
+      this.warn && this.warn('[over-limit] post-entitlement evaluation failed:', e && e.message);
+    }
+  }
+
   async receive() {
     let stripe, secret;
     try { stripe = stripeClient(); secret = endpointSecret(); }
@@ -654,6 +684,7 @@ class __public_stripe_webhook extends Entity {
               service: 'payment.plan_updated', plan: eff_plan, status, period_end,
               quota: await this._freshQuota(md.payer_id, entity_id, eff_entity),
             });
+            await this._evaluateOverLimit(entity_id, eff_entity);
             // Resume confirmation email (Figma 3050-96856): a pending cancel
             // flipping back to renewing. previous_attributes carries only the
             // changed fields, so cancel_at_period_end true→false IS the resume
@@ -783,6 +814,7 @@ class __public_stripe_webhook extends Entity {
               service: 'payment.plan_updated', plan: 'free', status: 'canceled',
               quota: await this._freshQuota(md.payer_id, entity_id, etype),
             });
+            await this._evaluateOverLimit(entity_id, etype);
           }
           break;
         }
@@ -826,6 +858,7 @@ class __public_stripe_webhook extends Entity {
                 service: 'payment.plan_updated', plan: eff_plan, status: 'active',
                 quota: await this._freshQuota(md.payer_id, eid, eff_entity),
               });
+              await this._evaluateOverLimit(eid, eff_entity);
               // Payment-receipt email (initial payment AND every renewal both
               // arrive as invoice.paid). A mail failure must never fail the
               // webhook — the entitlement above is already applied and Stripe


### PR DESCRIPTION
Part of the **Downgrade Over-Limit Resolution** feature (4 repos). State machine lives in yp `org_over_limit_*` (schemas PR); this is everything around it.

### Evaluate — one hook at every plan-lowering commit
`service/lib/over-limit.js` — `evaluate()` recomputes usage (after a `recalculate_domain_usage` drift repair — version-byte/restore leaks could otherwise hold an org over a limit it cannot fix) and seats (`member_list_stats`: members + **pending invites**) against the org's CURRENT entitlement (free-tier fallback when `payment_clear_entitlement` deleted the row), persists via `org_over_limit_set`, and fans out over WS. Hooked at all 7 sites every downgrade funnels through: `stripe_webhook` ×3, `promo.cancel`, `promoExpiryWorker` ×2 — and at every storage-RESOLVING action: `media.trash/purge/empty_bin` + Bull `trashWorker` (trash still **counts** toward usage — only purging decrements `yp.disk_usage`).

### Enforce — one clamp at the existing choke point
`router/rest/index.js`, in the same post-GRANT block as the secure-share ceiling. While `over_limit`, every mutating service (src/dest > read, or the existing denylist) is rejected `OVER_LIMIT_READ_ONLY` **except the way out**: trash/purge/empty_bin, member removal, `server_export`, logout, `payment.*`/`promo.*`, and `admin.*`/`adminpanel.*` as a family (their `src:'admin'` is a privilege requirement, not a mutation marker — the console is the resolution tool; nothing in it grows usage or seats, invites go through `hub.invite` which stays clamped). Under `hard_lock` non-admin members are denied entirely (`HARD_LOCK_DENIED`) except `get_env`/logout. Fail-open, 30s-TTL cached lookup, only on mutating traffic. `hub.accept_invite` gets its own guard — the redeemer is on their own domain, so the clamp inspects the wrong one there.

### Deliver
- `payment.over_limit_state` (fresh evaluation — opening the popup self-heals drift) + `payment.over_limit_dismiss` (server-side per-admin snooze) + ACL entries.
- WS push `payment.plan_state_changed` to every domain member — explicit `{model, options:{service}}` envelope (reminderWorker shape); `user_sockets` takes its uids as a JSON **array** (a comma-joined string matches nobody — found live).
- `offline/workers/overLimitGraceWorker.js` — over_limit→hard_lock after the deadline; effect-first + state-read-back (the driver's ROW_COUNT shape is unreliable), then re-evaluate + push. **pm2 registration on hosts is manual** (`pm2 start offline/workers/overLimitGraceWorker.js --name over-limit-grace-worker`) — done on stage.
- Whole feature behind `over_limit_enforcement` in myDrumee.json (billing_upgrade rollout pattern) — **off by default**; prod untouched until enabled. `env.js` forwards it via platform.

### Verified live on stage (domain 18 — genuinely 13 seats on a 10-seat Team plan)
boot popup+banner with exact numbers → clamp (`OVER_LIMIT_READ_ONLY:desk.create_hub`; reads + payment.* pass) → server-side snooze survives reload → worker hard-lock (non-dismissible popup) → resolution to 2/10 flips the desk **live** (teal restored banner, popup auto-close, "+ New" back) with no reload.

Not covered live: member-facing HARD_LOCK_DENIED (no non-admin member creds on the test org — same clamp code path as the verified block) and a real Stripe-webhook-delivered downgrade (the entitlement commit + hook call were exercised via the identical `payment_clear_entitlement` + evaluate sequence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
