### PR TITLE
feat(desk): track_workspace — record a workspace creation for analytics

### DIFF
--- a/acl/desk.json
+++ b/acl/desk.json
@@ -294,6 +294,43 @@
         }
       ]
     },
+    "track_workspace": {
+      "doc": "Record that the caller created a workspace from the workspace form (ui-team builtins/media/form). Writes one yp.services_log row per creation — the write is done by the router's `log` flag below, not by the handler — and the analytics Referral users table counts those rows for its Workspaces column and its Activated badge. Exists as its own service because the form's `personal` type is a home-root folder created through media.make_dir, not a hub: it never reaches desk.create_hub or yp.hub, so counting hub ownership cannot see it. Tracking only; never blocks or alters the creation it reports.",
+      "scope": "hub",
+      "permission": {
+        "src": "owner"
+      },
+      "log": true,
+      "params": {
+        "wid": {
+          "type": "string",
+          "required": true,
+          "doc": "Workspace id — hub id for team/share, folder nid for personal. Dedupe key for the backfill in analytics-server."
+        },
+        "type": {
+          "type": "string",
+          "required": true,
+          "enum": ["team", "share", "personal"],
+          "doc": "Workspace type the user picked in the form"
+        },
+        "area": {
+          "type": "string",
+          "required": false,
+          "doc": "yp.entity.area the workspace was created with (private, share, personal)"
+        },
+        "filename": {
+          "type": "string",
+          "required": false,
+          "doc": "Name the user typed"
+        }
+      },
+      "returns": {
+        "ok": {
+          "type": "boolean",
+          "doc": "Always true — the caller does not wait for this"
+        }
+      }
+    },
     "limit": {
       "doc": "Get current quota limits and available storage space",
       "scope": "hub",

--- a/service/private/desk.js
+++ b/service/private/desk.js
@@ -519,6 +519,29 @@ class __private_desk extends Media {
   }
 
   /**
+   * Record that the caller created a workspace from the workspace form
+   * (ui-team builtins/media/form).
+   *
+   * The body is deliberately empty of work: the row this service exists to
+   * write has already been written by the time we run. `"log": true` in
+   * acl/desk.json makes router/rest/index.js call session.log_service(),
+   * which posts yp.analytics_log -> INSERT INTO yp.services_log with the
+   * caller's uid, the posted args and a timestamp. Same mechanism that logs
+   * desk.create_hub, same table the analytics Referral users table already
+   * reads for its Shares column.
+   *
+   * Why a separate service rather than counting desk.create_hub rows: the
+   * form's THIRD workspace type, `personal`, is not a hub at all — it is a
+   * home-root folder created through media.make_dir (see the comment in
+   * media/form/index.js) — so it never touches desk.create_hub or yp.hub.
+   * The form is the only place that knows which of the three types the user
+   * asked for, so the form reports it and this records what it reported.
+   */
+  async track_workspace() {
+    this.output.data({ ok: 1 });
+  }
+
+  /**
    *
    * @param {*} s
    * @param {*} status


### PR DESCRIPTION
New service whose only product is a yp.services_log row. The handler is a stub on purpose: "log": true in acl/desk.json makes router/rest/index.js call session.log_service() BEFORE the handler runs, which posts yp.analytics_log -> INSERT INTO services_log. Same mechanism that already logs desk.create_hub and desk.home, same table the analytics Referral users table already counts for its Shares column. No new table.

It exists separately from desk.create_hub because the workspace form offers three types and only two are hubs: `personal` is a home-root folder created through media.make_dir (media/form routes it there deliberately — a hub would add membership and sidebar semantics that type must not have), so it never reaches desk.create_hub or yp.hub. The form is the only place that knows which type the user picked, so the form reports and this records.

permission.src is owner, matching create_hub and reward.track: only the creator posts their own creation.