### PR TITLE
feat(desk): push the referral row when a first workspace is created

### DIFF
--- a/service/private/desk.js
+++ b/service/private/desk.js
@@ -538,7 +538,59 @@ class __private_desk extends Media {
    * asked for, so the form reports it and this records what it reported.
    */
   async track_workspace() {
+    // The services_log row is already written by the router's `log` flag (see
+    // above), so by the time we run, referral_members can already see this
+    // workspace and will report the row's new status. Publishing before that
+    // would push the status the user just left.
+    this._pushReferralLive(this.uid);
     this.output.data({ ok: 1 });
+  }
+
+  /**
+   * Tell any open analytics dashboard that this user's referral row changed.
+   *
+   * Creating a first real workspace is the Onboarding -> Activated transition
+   * on the Referral users board. Without this the board shows the old badge
+   * until its two-minute poll comes round; with it the row turns over about as
+   * fast as the click.
+   *
+   * NOT AWAITED AND NEVER THROWS, for the same reason nothing else in
+   * track_workspace is allowed to fail: this service exists to report on a
+   * workspace that has already been created, and an analytics push must never
+   * be the thing that makes creating one look broken.
+   *
+   * THE ROW COMES FROM referral_members — the procedure that owns the status
+   * CASE. Nothing here re-derives a status, which is what keeps the live badge
+   * and the polled badge from ever disagreeing. It is also the cohort gate:
+   * most workspaces are made by users who were never referred, and for them it
+   * answers nothing and no push goes out.
+   *
+   * This is the mirror of loby service/onboarding.js _pushReferralLive, which
+   * reports the New -> Onboarding half. Keep the payload shape identical.
+   *
+   * @param {String} uid the user whose referral row moved
+   */
+  async _pushReferralLive(uid) {
+    try {
+      if (!uid) return;
+      const rows = toArray(await this.yp.await_proc('referral_members', { uid }));
+      const model = rows && rows[0];
+      if (!model) return; // not a referred user — nothing on that board to move
+      const sockets = toArray(await this.yp.await_proc('referral_live_sockets'));
+      if (!sockets || !sockets.length) return; // no dashboard open anywhere
+      await RedisStore.sendData(
+        {
+          model,
+          // No top-level `service` here on purpose: router/push stamps the
+          // envelope "live.update", which routes it to the client's `live`
+          // event. This name is how the widget knows what it received.
+          options: { service: 'live.referral_member', keys: '*' },
+        },
+        sockets
+      );
+    } catch (e) {
+      this.warn('[desk] referral live push failed', e && e.message);
+    }
   }
 
   /**


### PR DESCRIPTION
Creating a real workspace is the Onboarding -> Activated transition on the analytics Referral users board, which polls every two minutes. The row now turns over about as fast as the click.

Published from track_workspace, after the services_log row the router's `log` flag writes — so referral_members can already see the workspace and reports the status the user just reached rather than the one they left. Not awaited and it swallows its own errors, for the same reason nothing else in track_workspace is allowed to fail: this service exists to report on a workspace that has already been created, and an analytics push must never be what makes creating one look broken.

The row comes from referral_members, the procedure that owns the status CASE, so nothing here re-derives a status and the live badge cannot drift from the polled one. That call is also the cohort gate: most workspaces are made by users who were never referred, it answers nothing for them, and no push goes out.

Recipients come from referral_live_sockets (analytics-server schemas): every active socket of every user permitted to read the analytics hub, which is the same rule get_env gates on and covers every open tab.

The mirror of this is loby onboarding.update_profile, which reports the New -> Onboarding half.