### PR TITLE
Promote test to preview — member-role ACL enforcement, secure-share escalation fix, reward live signal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,3 +35,5 @@ jobs:
         run: node offline/test/secure-share-session.test.js
       - name: Run file-move result regression test
         run: node offline/test/mfs-move-result.test.js
+      - name: Run file-thread access event regression test
+        run: node offline/test/file-thread-access-events.test.js

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,14 @@
 name: Test - secure-share regression
 
-# Runs the standalone secure-share session-security regression test on PRs into the
-# mainline branches. It does NOT touch the deploy pipeline (deploy.yml) and is not a
-# required check unless branch protection marks it so — a failure surfaces on the PR
-# but never blocks a deploy.
+# Runs standalone zero-dependency regressions on PRs into the mainline branches.
+# It does NOT touch the deploy pipeline (deploy.yml) and is not a required check
+# unless branch protection marks it so — a failure surfaces on the PR but never
+# blocks a deploy.
 #
-# Deliberately does NOT `npm install`: the source-invariant canaries in the test need
-# only the checked-out source (zero deps), and the behavioural tests self-skip when the
-# private @drumee/server-essentials dep is absent. So this runs on a stock GitHub-hosted
-# runner with no private-registry auth and can never go red for a missing dependency —
-# it only fails if one of the security guards was actually removed/regressed.
+# Deliberately does NOT `npm install`: both test files need only the checked-out
+# source, and the secure-share behavioural tests self-skip when the private
+# @drumee/server-essentials dependency is absent. This runs on a stock
+# GitHub-hosted runner without private-registry auth.
 
 on:
   pull_request:
@@ -34,3 +33,5 @@ jobs:
           node-version: 20
       - name: Run secure-share session regression test
         run: node offline/test/secure-share-session.test.js
+      - name: Run file-move result regression test
+        run: node offline/test/mfs-move-result.test.js

--- a/acl/reward.json
+++ b/acl/reward.json
@@ -14,7 +14,7 @@
       "scope": "hub",
       "permission": { "src": "owner" },
       "params": {
-        "status": { "type": "string", "required": true, "description": "clicked | started | dropped | done | missed" },
+        "status": { "type": "string", "required": true, "description": "clicked | started | left | dropped | done | missed" },
         "step": { "type": "string", "required": false, "description": "step1 | step2 | step3 — the card step the user is on" },
         "campaign": { "type": "string", "required": false, "description": "utm_campaign, defaults to free-storage" }
       },

--- a/offline/test/file-thread-access-events.test.js
+++ b/offline/test/file-thread-access-events.test.js
@@ -1,0 +1,406 @@
+#!/usr/bin/env node
+
+/**
+ * Regression tests for the channel.file_thread_access_changed contract.
+ *
+ * Deletion and cross-workspace movement both revoke a viewer's access to a file
+ * thread, and the browser handles both through the same event. The two emitters
+ * had drifted: the move path left out the file name, the pre-move identity, and
+ * the source-hub grid update that deletion has always sent.
+ *
+ * The delete-path assertions here are a guard, not a description: that path is
+ * live and its payload must not shift while the move path is brought level
+ * with it.
+ *
+ * Standalone runner (no test framework in this repo): `node <thisfile>`.
+ */
+
+const assert = require("assert");
+const { readFileSync, existsSync } = require("fs");
+const { join } = require("path");
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+const MEDIA_SOURCE = readFileSync(
+  join(__dirname, "..", "..", "service", "private", "media.js"),
+  "utf8"
+);
+
+// ── harness ───────────────────────────────────────────────────────────────
+// media.js reaches the database and Redis through instance members, so the
+// methods under test are lifted onto a stub that records what was published
+// instead of standing up MariaDB and Redis.
+function loadMediaMethods() {
+  const source = MEDIA_SOURCE;
+  const methods = {};
+  for (const name of [
+    "_emitCrossHubMoveEvents",
+    "_emitCrossHubCompensationEvents",
+    "_transitionDirectFileThreadAccess",
+    "_reserveDirectFileThreadTrash",
+    "_releaseDirectFileThreadTrash",
+  ]) {
+    const start = source.indexOf(`  async ${name}(`);
+    assert.notStrictEqual(start, -1, `${name} not found in media.js`);
+    // Methods are indented two spaces inside the class body, so the first
+    // line that is exactly "  }" closes the method.
+    const end = source.indexOf("\n  }\n", start);
+    assert.notStrictEqual(end, -1, `${name} has no closing brace`);
+    methods[name] = source.slice(start, end + 4).replace(/^\s*async\s+/, "async function ");
+  }
+  return methods;
+}
+
+// Mirrors the guards in file_thread_access_transition_direct.sql so a stub
+// cannot certify a call the real procedure would reject. An earlier version of
+// this file returned success unconditionally, which let a rejected reason pass
+// every test while emitting nothing in production.
+function transitionDirectProc({ reservations } = {}) {
+  return (transition_id, lineage_id, actor_id, hub_id, file_nid, thread_id,
+    target_state, reason) => {
+    if (!["active", "unavailable"].includes(target_state)
+      || !["direct_trash", "direct_restore"].includes(reason)) {
+      return [{ failed: 1, transitioned: 0, status: "INVALID_DIRECT_TRANSITION" }];
+    }
+    // 'unavailable' requires the lineage to be reserved under this same
+    // transition id — the reserve-then-transition protocol.
+    if (target_state === "unavailable") {
+      const held = reservations && reservations.get(`${hub_id}:${file_nid}`);
+      if (held !== transition_id) {
+        return [{ failed: 0, transitioned: 0, status: "RESERVATION_REQUIRED" }];
+      }
+    }
+    return [{
+      failed: 0,
+      transitioned: 1,
+      transition_id,
+      lineage_id: lineage_id || "lineage-1",
+      access_revision: 7,
+    }];
+  };
+}
+
+function reserveDirectProc(reservations) {
+  return (transition_id, lineage_id, actor_id, hub_id, file_nid) => {
+    reservations.set(`${hub_id}:${file_nid}`, transition_id);
+    return [{ failed: 0, reserved: 1, status: "RESERVED", lineage_id: lineage_id || "lineage-1" }];
+  };
+}
+
+function makeStub({ procs = {}, funcs = {}, saga = {} } = {}) {
+  const sent = [];
+  const warnings = [];
+  const stub = {
+    uid: "actor-uid",
+    sent,
+    warnings,
+    warn: (...args) => warnings.push(args.join(" ")),
+    randomString: () => "randomid00000000",
+    _fileMoveActor: () => ({ id: "actor-uid", fullname: "Actor Name" }),
+    payload: (data, options) => ({ ...data, __service: options && options.service }),
+    yp: {
+      await_proc: async (name, ...args) => {
+        const key = `${name}`.replace(/^[^.]*\./, "");
+        const handler = procs[key] !== undefined ? procs[key] : procs[name];
+        if (typeof handler === "function") return handler(...args);
+        if (handler !== undefined) return handler;
+        return [];
+      },
+      await_func: async (name, ...args) => {
+        const handler = funcs[name];
+        if (typeof handler === "function") return handler(...args);
+        return handler !== undefined ? handler : null;
+      },
+    },
+    saga,
+  };
+  return { stub, sent, warnings };
+}
+
+function runMethod(name, stub, args) {
+  const methods = loadMediaMethods();
+  const RedisStore = {
+    sendData: async (payload, recipients) => {
+      stub.sent.push({ payload, recipients });
+    },
+  };
+  const firstRow = (data) => (Array.isArray(data) ? data[0] : data) || null;
+  const toArray = (data) => (Array.isArray(data) ? data : (data ? [data] : []));
+  const isEmpty = (v) => v == null || (Array.isArray(v) && !v.length);
+  const Attr = { nid: "nid", hub_id: "hub_id" };
+
+  const compile = (body) => {
+    // eslint-disable-next-line no-new-func
+    const factory = new Function(
+      "RedisStore", "firstRow", "toArray", "isEmpty", "Attr",
+      `return (${body});`
+    );
+    return factory(RedisStore, firstRow, toArray, isEmpty, Attr);
+  };
+
+  // Bind every extracted method onto the stub: these methods call each other
+  // (subtree revocation drives the shared transition helper), and a missing
+  // member would surface as a swallowed TypeError rather than a real result.
+  for (const [methodName, body] of Object.entries(methods)) {
+    stub[methodName] = compile(body).bind(stub);
+  }
+  return stub[name](...args);
+}
+
+const accessEvents = (sent) =>
+  sent.filter((s) => s.payload.__service === "channel.file_thread_access_changed");
+
+// ── delete path: must not drift ───────────────────────────────────────────
+
+test("the delete path emits exactly the fields it always has", async () => {
+  const reservations = new Map();
+  const target = {
+    hub_id: "hub-a",
+    file_nid: "file-1",
+    file_thread_id: "thread-1",
+    filename: "Quarterly.pdf",
+  };
+  const { stub, sent } = makeStub({
+    procs: {
+      file_thread_access_transition_direct: transitionDirectProc({ reservations }),
+      file_thread_access_reserve_direct: reserveDirectProc(reservations),
+      entity_sockets: [{ socket_id: "s1", uid: "viewer" }],
+    },
+  });
+
+  await runMethod("_reserveDirectFileThreadTrash", stub, [target]);
+  await runMethod("_transitionDirectFileThreadAccess", stub, [
+    target,
+    "unavailable",
+    "direct_trash",
+  ]);
+
+  const events = accessEvents(sent);
+  assert.strictEqual(events.length, 1);
+  const { payload } = events[0];
+  assert.deepStrictEqual(Object.keys(payload).sort(), [
+    "__service", "access_revision", "actor", "file_nid", "file_thread_id",
+    "filename", "hub_id", "lineage_id", "operation_id", "reason", "state",
+  ]);
+  assert.strictEqual(payload.state, "revoked");
+  assert.strictEqual(payload.filename, "Quarterly.pdf");
+  assert.strictEqual(payload.access_revision, 7);
+  assert.strictEqual(payload.previous_file_nid, undefined,
+    "delete path must not gain move-only fields");
+});
+
+test("a restore keeps the delete path's active state mapping", async () => {
+  const { stub, sent } = makeStub({
+    procs: {
+      file_thread_access_transition_direct: transitionDirectProc({ reservations: new Map() }),
+      entity_sockets: [{ socket_id: "s1" }],
+    },
+  });
+
+  await runMethod("_transitionDirectFileThreadAccess", stub, [
+    { hub_id: "hub-a", file_nid: "f", file_thread_id: "th", filename: "n" },
+    "active",
+    "direct_restore",
+  ]);
+
+  assert.strictEqual(accessEvents(sent)[0].payload.state, "restored");
+});
+
+test("a revoke without a reservation is refused, and emits nothing", async () => {
+  // The stored procedure gates 'unavailable' on the lineage already being
+  // reserved under the same transition id. Skipping the reservation is the
+  // defect this suite previously hid behind an always-succeeding stub.
+  const { stub, sent } = makeStub({
+    procs: {
+      file_thread_access_transition_direct: transitionDirectProc({ reservations: new Map() }),
+      entity_sockets: [{ socket_id: "s1" }],
+    },
+  });
+
+  const transition = await runMethod("_transitionDirectFileThreadAccess", stub, [
+    { hub_id: "hub-a", file_nid: "f", file_thread_id: "th", filename: "n" },
+    "unavailable",
+    "direct_trash",
+  ]);
+
+  assert.strictEqual(Number(transition.transitioned), 0);
+  assert.strictEqual(transition.status, "RESERVATION_REQUIRED");
+  assert.strictEqual(accessEvents(sent).length, 0);
+});
+
+test("a reason the procedure does not whitelist is refused", async () => {
+  const { stub, sent } = makeStub({
+    procs: {
+      file_thread_access_transition_direct: transitionDirectProc({ reservations: new Map() }),
+      entity_sockets: [{ socket_id: "s1" }],
+    },
+  });
+
+  const transition = await runMethod("_transitionDirectFileThreadAccess", stub, [
+    { hub_id: "hub-a", file_nid: "f", file_thread_id: "th", filename: "n" },
+    "unavailable",
+    "workspace_move",
+  ]);
+
+  assert.strictEqual(Number(transition.transitioned), 0);
+  assert.strictEqual(transition.status, "INVALID_DIRECT_TRANSITION");
+  assert.strictEqual(accessEvents(sent).length, 0);
+});
+
+// ── move path: reach parity ───────────────────────────────────────────────
+
+const moveSaga = {
+  operation_id: "op-1",
+  lineage_id: "lin-1",
+  access_revision: 4,
+  source_hub_id: "hub-src",
+  source_file_nid: "file-src",
+  source_thread_id: "thread-src",
+  destination_hub_id: "hub-dst",
+  destination_file_nid: "file-dst",
+  destination_thread_id: "thread-dst",
+};
+
+function moveStub(destinationNode) {
+  return makeStub({
+    procs: {
+      entity_sockets: (hubId) => [{ socket_id: `sock-${hubId}` }],
+      mfs_access_node: destinationNode ? [destinationNode] : [],
+    },
+  });
+}
+
+test("a move names the file it revoked", async () => {
+  const { stub, sent } = moveStub({ id: "file-dst", user_filename: "Budget.xlsx" });
+  await runMethod("_emitCrossHubMoveEvents", stub, [
+    moveSaga, { db_name: "srcdb" }, { db_name: "dstdb" }, "Budget.xlsx",
+  ]);
+
+  const revoked = accessEvents(sent).find((e) => e.payload.state === "revoked");
+  assert.ok(revoked, "a revoke must reach the source hub");
+  assert.strictEqual(revoked.payload.filename, "Budget.xlsx");
+  assert.strictEqual(revoked.payload.hub_id, "hub-src");
+});
+
+test("a resumed saga still names the file, from the destination node", async () => {
+  const { stub, sent } = moveStub({ id: "file-dst", user_filename: "Budget.xlsx" });
+  // Empty filename: the caller re-entered at source_removed and never read the
+  // source snapshot, which is the normal path for any retry.
+  await runMethod("_emitCrossHubMoveEvents", stub, [
+    moveSaga, { db_name: "srcdb" }, { db_name: "dstdb" }, "",
+  ]);
+
+  const revoked = accessEvents(sent).find((e) => e.payload.state === "revoked");
+  assert.strictEqual(revoked.payload.filename, "Budget.xlsx");
+});
+
+test("the destination is told which node the thread used to live on", async () => {
+  const { stub, sent } = moveStub({ id: "file-dst", user_filename: "Budget.xlsx" });
+  await runMethod("_emitCrossHubMoveEvents", stub, [
+    moveSaga, { db_name: "srcdb" }, { db_name: "dstdb" }, "Budget.xlsx",
+  ]);
+
+  const restored = accessEvents(sent).find((e) => e.payload.state === "restored");
+  assert.ok(restored, "a restore must reach the destination hub");
+  assert.strictEqual(restored.payload.previous_file_nid, "file-src");
+  assert.strictEqual(restored.payload.previous_file_thread_id, "thread-src");
+  assert.strictEqual(restored.payload.file_nid, "file-dst");
+});
+
+test("the source hub is told to drop the moved file from its grid", async () => {
+  const { stub, sent } = moveStub({ id: "file-dst", user_filename: "Budget.xlsx" });
+  await runMethod("_emitCrossHubMoveEvents", stub, [
+    moveSaga, { db_name: "srcdb" }, { db_name: "dstdb" }, "Budget.xlsx",
+  ]);
+
+  const removes = sent.filter((s) => s.payload.__service === "media.remove");
+  assert.strictEqual(removes.length, 1);
+  assert.strictEqual(removes[0].payload.nid, "file-src");
+  assert.strictEqual(removes[0].payload.hub_id, "hub-src");
+  assert.deepStrictEqual(removes[0].recipients, [{ socket_id: "sock-hub-src" }]);
+  assert.ok(sent.some((s) => s.payload.__service === "notification.resync"));
+
+  const order = sent.map((s) => s.payload.__service);
+  assert.ok(
+    order.indexOf("channel.file_thread_access_changed") < order.indexOf("media.remove"),
+    "the thread must be frozen before the grid repaints around it"
+  );
+});
+
+test("a rollback restores the source and leaves the destination alone", async () => {
+  // Compensation is only reachable from copy_verified and source_removed, so
+  // the destination hub was never told the thread arrived and must not be sent
+  // a revoke for it.
+  const { stub, sent } = makeStub({
+    procs: {
+      entity_sockets: (hubId) => [{ socket_id: `sock-${hubId}` }],
+      mfs_access_node: [{ id: "file-comp", filename: "Budget.xlsx" }],
+    },
+  });
+
+  await runMethod("_emitCrossHubCompensationEvents", stub, [
+    {
+      ...moveSaga,
+      compensation_file_nid: "file-comp",
+      compensation_thread_id: "thread-comp",
+    },
+    { db_name: "srcdb" },
+  ]);
+
+  const events = accessEvents(sent);
+  assert.strictEqual(events.length, 1);
+  assert.strictEqual(events[0].payload.state, "restored");
+  assert.strictEqual(events[0].payload.hub_id, "hub-src");
+  assert.strictEqual(events[0].payload.previous_file_nid, "file-src");
+});
+
+test("the saga has no edge out of committed, so post-commit rollback is not modelled", () => {
+  const sqlPath = join(__dirname, "..", "..", "..", "schemas", "yellow_page",
+    "procedures", "mfs", "file_move_saga_transition.sql");
+  if (!existsSync(sqlPath)) {
+    console.log("       (skipped: schemas repo not checked out)");
+    return;
+  }
+  const sql = readFileSync(sqlPath, "utf8");
+  assert.doesNotMatch(sql, /_expected_state\s*=\s*'committed'/,
+    "if this ever gains an edge, the compensation path must tell the destination too");
+});
+
+// ── workspace_move: deliberately not handled here ─────────────────────────
+
+test("a workspace move does not attempt a direct thread revocation", () => {
+  // Revoking a file thread inside a moved folder was implemented and reverted.
+  // file_thread_access_transition_direct validates a trash-shaped durable state
+  // (thread row present, media row gone), but mfs_move_all deletes both — its
+  // own media DELETE plus file_thread via channel_migrate_moved_scope — so no
+  // call ordering satisfies it, and the compensating release is blocked by the
+  // mirror guard, stranding the lineage in 'moving' with no sweeper to reclaim
+  // it. This guard fails if that approach is reintroduced without a contract
+  // that survives both rows disappearing.
+  const body = MEDIA_SOURCE.slice(
+    MEDIA_SOURCE.indexOf("async workspace_move()"),
+    MEDIA_SOURCE.indexOf("async relocate()")
+  );
+  assert.doesNotMatch(body, /_transitionDirectFileThreadAccess/,
+    "workspace_move cannot use the direct access procedures — see the comment in it");
+  assert.doesNotMatch(body, /channel_file_thread_list_subtree/);
+});
+
+
+(async () => {
+  let failed = 0;
+  for (const [name, fn] of tests) {
+    try {
+      await fn();
+      console.log(`  ok  - ${name}`);
+    } catch (error) {
+      failed += 1;
+      console.error(`  FAIL - ${name}`);
+      console.error(`         ${error && error.message}`);
+    }
+  }
+
+  console.log(`\n${tests.length - failed}/${tests.length} passed`);
+  process.exit(failed ? 1 : 0);
+})();

--- a/offline/test/mfs-move-result.test.js
+++ b/offline/test/mfs-move-result.test.js
@@ -1,0 +1,182 @@
+#!/usr/bin/env node
+
+/**
+ * Regression tests for selecting the physical move row from mfs_move_all.
+ *
+ * await_proc can return a raw multi-result shape such as
+ * [statusRow, [operationRows...]]. The file-thread move saga needs the
+ * operation row's des_id before it can promote the staged bytes or compensate.
+ *
+ * Standalone runner (no test framework in this repo): `node <thisfile>`.
+ */
+
+const assert = require("assert");
+const { readFileSync } = require("fs");
+const { join } = require("path");
+
+const {
+  findMfsMoveResult,
+  isCompleteMfsThreadMigration,
+  waitForMfsThreadMigration,
+} = require("../../service/lib/mfs-move-result");
+
+const tests = [];
+const test = (name, fn) => tests.push([name, fn]);
+
+const moveRow = {
+  action: "move",
+  nid: "source-file",
+  des_id: "destination-file",
+  category: "document",
+  src_mfs_root: "/source",
+  des_mfs_root: "/destination",
+};
+
+test("selects a move row from a flat operation array", () => {
+  assert.strictEqual(findMfsMoveResult([
+    { action: "show", nid: "destination-file" },
+    moveRow,
+  ], "source-file"), moveRow);
+});
+
+test("selects a move row from a raw nested multi-result", () => {
+  const result = [
+    { affectedRows: 0, warningCount: 0 },
+    [{ action: "showone", nid: "destination-file" }, moveRow],
+  ];
+  assert.strictEqual(findMfsMoveResult(result, "source-file"), moveRow);
+});
+
+test("searches later result sets and ignores metadata packets", () => {
+  const result = [
+    [{ action: "show", nid: "other-file" }],
+    { serverStatus: 2 },
+    [[{ action: "same", nid: "source-file" }], [moveRow]],
+  ];
+  assert.strictEqual(findMfsMoveResult(result, "source-file"), moveRow);
+});
+
+test("returns null for empty or metadata-only results", () => {
+  assert.strictEqual(findMfsMoveResult(null, "source-file"), null);
+  assert.strictEqual(findMfsMoveResult([], "source-file"), null);
+  assert.strictEqual(findMfsMoveResult([{ affectedRows: 1 }], "source-file"), null);
+});
+
+test("does not select a move row for a different source nid", () => {
+  assert.strictEqual(findMfsMoveResult([moveRow], "another-file"), null);
+});
+
+test("polls source-only state until destination migration becomes visible", async () => {
+  const states = [
+    { sourcePosition: { file_thread_id: "thread-id" }, destinationPosition: null },
+    {
+      sourcePosition: null,
+      destinationPosition: {
+        file_thread_id: "thread-id",
+        root_identity_count: 1,
+        stale_child_identity_count: 0,
+      },
+    },
+  ];
+  let reads = 0;
+  let delays = 0;
+
+  const result = await waitForMfsThreadMigration(
+    async () => states[Math.min(reads++, states.length - 1)],
+    { attempts: 5, delay: async () => { delays += 1; } }
+  );
+
+  assert.deepStrictEqual(result, states[1]);
+  assert.strictEqual(reads, 2);
+  assert.strictEqual(delays, 1);
+});
+
+test("keeps ambiguous both and neither states read-only until the bound", async () => {
+  for (const state of [
+    {
+      sourcePosition: { file_thread_id: "thread-id" },
+      destinationPosition: { file_thread_id: "thread-id" },
+    },
+    { sourcePosition: null, destinationPosition: null },
+  ]) {
+    let reads = 0;
+    let delays = 0;
+    const result = await waitForMfsThreadMigration(
+      async () => { reads += 1; return state; },
+      { attempts: 3, delay: async () => { delays += 1; } }
+    );
+    assert.strictEqual(result, state);
+    assert.strictEqual(reads, 3);
+    assert.strictEqual(delays, 2);
+  }
+});
+
+test("returns persistent source-only state after the bounded attempt count", async () => {
+  const state = { sourcePosition: { file_thread_id: "thread-id" }, destinationPosition: null };
+  let reads = 0;
+  let delays = 0;
+  const result = await waitForMfsThreadMigration(
+    async () => { reads += 1; return state; },
+    { attempts: 3, delay: async () => { delays += 1; } }
+  );
+  assert.strictEqual(result, state);
+  assert.strictEqual(reads, 3);
+  assert.strictEqual(delays, 2);
+});
+
+test("requires a destination-only thread with valid root and child identities", () => {
+  const validDestination = {
+    file_thread_id: "thread-id",
+    root_identity_count: "1",
+    stale_child_identity_count: "0",
+  };
+  assert.strictEqual(isCompleteMfsThreadMigration({
+    sourcePosition: null,
+    destinationPosition: validDestination,
+  }), true);
+  assert.strictEqual(isCompleteMfsThreadMigration({
+    sourcePosition: { file_thread_id: "thread-id" },
+    destinationPosition: validDestination,
+  }), false);
+  assert.strictEqual(isCompleteMfsThreadMigration({
+    sourcePosition: null,
+    destinationPosition: { ...validDestination, root_identity_count: 0 },
+  }), false);
+  assert.strictEqual(isCompleteMfsThreadMigration({
+    sourcePosition: null,
+    destinationPosition: { ...validDestination, stale_child_identity_count: 1 },
+  }), false);
+  assert.strictEqual(isCompleteMfsThreadMigration({
+    sourcePosition: null,
+    destinationPosition: null,
+  }), false);
+});
+
+test("the saga uses the selector for forward and compensation plans", () => {
+  const media = readFileSync(join(__dirname, "..", "..", "service", "private", "media.js"), "utf8");
+  const selectorCalls = media.match(/findMfsMoveResult\(/g) || [];
+  assert.strictEqual(selectorCalls.length, 2, "both mfs_move_all paths must select from the raw result");
+});
+
+test("the forward saga uses read-only convergence polling without a write retry", () => {
+  const media = readFileSync(join(__dirname, "..", "..", "service", "private", "media.js"), "utf8");
+  assert.match(media, /waitForMfsThreadMigration\(/);
+  assert.doesNotMatch(media, /channel_migrate_moved_scope/);
+});
+
+(async () => {
+  let failed = 0;
+  for (const [name, fn] of tests) {
+    try {
+      await fn();
+      console.log(`  ok  - ${name}`);
+    } catch (error) {
+      failed += 1;
+      console.error(`  FAIL - ${name}`);
+      console.error(`         ${error && error.message}`);
+    }
+  }
+
+  console.log(`\n${tests.length - failed}/${tests.length} passed`);
+  process.exit(failed ? 1 : 0);
+})();

--- a/service/lib/member-capability.js
+++ b/service/lib/member-capability.js
@@ -1,0 +1,154 @@
+/**
+ * Workspace-member capability gate — the SERVER half of the role model that
+ * `ui/src/drumee/builtins/skeleton/toolkit/permission.js` defines for every
+ * role selector (invite popup, workspace settings, manage-access):
+ *
+ *   view   privilege 0b000011   read
+ *   chat   privilege 0b000111   read + download      <- "download" IS the chat bit
+ *   edit   privilege 0b001111   read + download + write
+ *   admin  privilege 0b011111   ... + admin
+ *   owner  privilege 0b111111
+ *
+ * The ACL already enforces the write/delete/admin tiers (`src: "write"` is
+ * 0b0001000, and a chat member's 0b000111 fails it). What the ACL cannot
+ * express is the CHAT tier: `channel.post` must stay reachable for a chat
+ * member but not for a view-only one, and both satisfy `src: "read"`. These
+ * helpers close that gap at the service layer.
+ *
+ * 🚨 The bit values are written out literally, NOT read from
+ * `Constants.permission`, on purpose. server-essentials 1.3.0 MOVED them
+ * (download 2 -> 4, write 4 -> 8). Against an older package
+ * `Constants.permission.download` still resolves to 2 — which is the READ bit —
+ * so a view-only member (privilege 3) would satisfy `privilege & 2` and
+ * silently gain chat. Pinning the values makes the gate independent of which
+ * package version happens to be installed. (A stale 1.2.44 copy really does sit
+ * in some working trees, so this is not hypothetical.)
+ *
+ * 🚨 NEVER gate chat on `Constants.permission.chat` (0b0000110 = read|download).
+ * It OVERLAPS read, so `privilege & chat` is TRUTHY for a view-only member
+ * (3 & 6 = 2) and the gate silently admits exactly the role it exists to
+ * exclude. Use CAN_CHAT below — the single download bit:
+ *     view 3 & 4 = 0  (refused)      chat 7 & 4 = 4  (allowed)
+ * The same trap applies to the ACL `src` word: use "download", never "chat".
+ */
+
+const CAN_READ = 0b0000010;
+// One bit, two names. Per the product decision, "may chat" and "may download"
+// are the SAME right for a workspace member — a chat member sits above view and
+// is allowed both. Both names are exported so call sites read as what they mean.
+const CAN_DOWNLOAD = 0b0000100;
+const CAN_CHAT = 0b0000100;
+const CAN_WRITE = 0b0001000;
+const CAN_ADMIN = 0b0010000;
+
+/**
+ * Does this stored privilege carry every bit of `bit`?
+ *
+ * Deliberately `(p & bit) === bit` rather than `!== 0`: for a multi-bit mask
+ * the loose form is satisfied by a PARTIAL overlap, which is precisely how
+ * `permission.chat` leaks to view-only members. Identical for single-bit masks,
+ * strictly safer for anything else.
+ */
+function privilegeAllows(privilege, bit) {
+  const p = Number(privilege) || 0;
+  const b = Number(bit) || 0;
+  if (!b) return false;
+  return (p & b) === b;
+}
+
+// A node id as the platform mints them: 16 hex-ish chars. Anything else is a
+// client-supplied oddity — we fall back to the hub root rather than interpolate
+// it. Mirrors channel.js's FILE_THREAD_SELECTOR_RE discipline.
+const NODE_ID_RE = /^[0-9a-zA-Z_-]{1,32}$/;
+
+/**
+ * The hub's ROOT node id, resolved the same way the ACL resolves it:
+ * `mfs_home()` on the hub db (see server-core/lib/acl.js::check_env, which sets
+ * `_start_with = 'mfs_home'` and reads `home.home_id`).
+ *
+ * Deliberately NOT `service.home_id`: despite `room.js`/`desk.js` reading that
+ * property, nothing in server-core or server-essentials ever assigns it on a
+ * service instance, so it is `undefined` there. Memoized per request so a chat
+ * burst costs at most one extra proc call.
+ */
+async function hubRootId(service) {
+  if (service.__memberCapRoot !== undefined) return service.__memberCapRoot;
+  let root = null;
+  try {
+    const home = await service.db.await_proc("mfs_home");
+    root = (home && home.home_id) || null;
+  } catch (e) {
+    root = null;
+  }
+  service.__memberCapRoot = root;
+  return root;
+}
+
+/**
+ * Resolve THIS caller's privilege on the node a hub-scoped request targets, and
+ * test it against `bit`.
+ *
+ * Node resolution mirrors what the ACL itself does: the request's own `nid` when
+ * it carries a well-formed one, else the hub root. Workspace-root chat sends
+ * only `hub_id` (see ui widget/chat/index.js — `nid` is added only for a scoped
+ * sub-folder thread), so the root fallback is the NORMAL path there, not an
+ * edge case.
+ *
+ * Reads `mfs_access_node(uid, nid)` — the same authoritative read
+ * `@drumee/server-core/lib/acl.js` and `channel.js::_resolveFileThreadAccess`
+ * use. It returns only the CALLER's own privilege, so it can never elevate.
+ *
+ * SHARE SESSIONS ARE NOT TOUCHED. A DMZ / secure-share request carries a token
+ * and its session is cookie-bound to the share CREATOR, so `this.uid` would
+ * report the creator's full privilege and this check would be meaningless
+ * anyway. Those paths have their own recipient-derived guards
+ * (`media.js::_secureShareCapAllowed`, `service/lib/secure-share-write-guard`);
+ * this helper defers to them by allowing immediately when a token is present.
+ *
+ * FAIL-OPEN on any resolution failure, by design: this gate is a NEW
+ * restriction layered on top of the existing ACL, so "could not determine"
+ * must reproduce today's behaviour exactly rather than lock out a legitimate
+ * member on a transient DB error. Same posture as
+ * `secure-share-write-guard`'s null verdict. The ACL still ran first.
+ *
+ * @param {object} service  the service instance (`this` in a service method)
+ * @param {number} bit      one of the CAN_* masks above
+ * @returns {Promise<boolean>} true -> may proceed; false -> caller must reject
+ */
+async function memberCan(service, bit) {
+  try {
+    // Share/DMZ recipient: governed by the secure-share guards, not by member
+    // privilege. Allow here so this helper can never change those flows.
+    if (service.input && service.input.get && service.input.get("token")) {
+      return true;
+    }
+
+    let nid = (service.input && service.input.use("nid")) || "";
+    nid = `${nid}`;
+    if (!nid || !NODE_ID_RE.test(nid)) nid = await hubRootId(service);
+    if (!nid) return true;
+
+    const node = await service.db.await_proc("mfs_access_node", service.uid, `${nid}`.substr(0, 16));
+    if (!node) return true;
+
+    const privilege = node.privilege != null ? node.privilege : node.permission;
+    if (privilege == null) return true;
+
+    return privilegeAllows(privilege, bit);
+  } catch (e) {
+    if (service && service.warn) {
+      service.warn("[member-capability] privilege resolution failed", e && e.message);
+    }
+    return true;
+  }
+}
+
+module.exports = {
+  CAN_READ,
+  CAN_DOWNLOAD,
+  CAN_CHAT,
+  CAN_WRITE,
+  CAN_ADMIN,
+  privilegeAllows,
+  memberCan,
+};

--- a/service/lib/mfs-move-result.js
+++ b/service/lib/mfs-move-result.js
@@ -1,0 +1,55 @@
+/**
+ * Find the physical move row returned by mfs_move_all.
+ *
+ * A stored procedure call can arrive as a flat row array or as a raw
+ * multi-result value such as [statusRow, [operationRows...]]. Only the move
+ * row for the requested source node carries the canonical destination id.
+ */
+function findMfsMoveResult(result, sourceNid) {
+  if (sourceNid == null) return null;
+
+  if (Array.isArray(result)) {
+    for (const item of result) {
+      const move = findMfsMoveResult(item, sourceNid);
+      if (move) return move;
+    }
+    return null;
+  }
+
+  if (!result || typeof result !== "object") return null;
+  if (result.action !== "move" || result.nid == null) return null;
+  return String(result.nid) === String(sourceNid) ? result : null;
+}
+
+function isCompleteMfsThreadMigration({ sourcePosition, destinationPosition }) {
+  return Boolean(!sourcePosition && destinationPosition
+    && Number(destinationPosition.root_identity_count) === 1
+    && Number(destinationPosition.stale_child_identity_count) === 0);
+}
+
+/**
+ * Give the database result a short, read-only convergence window. The
+ * failure-isolated migration is not safe to invoke twice because a partial
+ * first pass can already own destination message identities.
+ */
+async function waitForMfsThreadMigration(
+  readPositions,
+  { attempts = 1, delay = async () => { } } = {}
+) {
+  const maxAttempts = Math.max(1, Number(attempts) || 1);
+  let positions;
+
+  for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
+    positions = await readPositions();
+    if (isCompleteMfsThreadMigration(positions)) return positions;
+    if (attempt + 1 < maxAttempts) await delay();
+  }
+
+  return positions;
+}
+
+module.exports = {
+  findMfsMoveResult,
+  isCompleteMfsThreadMigration,
+  waitForMfsThreadMigration,
+};

--- a/service/media.js
+++ b/service/media.js
@@ -22,6 +22,7 @@ const {
 const indexQueue = require("../offline/queues/indexQueue");
 const { writeAudit } = require("./private/_audit");
 const { secureShareWriteVerdict, secureShareCapVerdict, secureShareCapPrivilege } = require("./lib/secure-share-write-guard");
+const { memberCan, CAN_DOWNLOAD } = require("./lib/member-capability");
 const { DENIED } = Events;
 const {
   BATCH_FILE,
@@ -2075,6 +2076,17 @@ class __media extends Mfs {
     if (!(await this._secureShareCapAllowed(["can_download", "can_edit"]))) {
       return this.exception.forbiden();
     }
+    // Workspace MEMBER half of the same rule: download starts at the "View &
+    // chat" tier, so a view-only member (privilege 3) is refused. acl/media.json
+    // asks only for `src: "read"` here, which view satisfies.
+    // Inert for share sessions — memberCan allows whenever a token is present,
+    // so the recipient guard above stays the only authority on that path.
+    // Inline PREVIEW/stream paths (raw / preview / orig / pdf / audio / ogv) are
+    // deliberately untouched: a view-only member must still be able to OPEN and
+    // read a file; only the explicit download/zip action is refused.
+    if (!(await memberCan(this, CAN_DOWNLOAD))) {
+      return this.exception.forbiden();
+    }
     let node = this.source_granted();
     let nid = node.id;
     let socket_id = this.input.need(Attr.socket_id);
@@ -2166,6 +2178,12 @@ class __media extends Mfs {
     // this serves its bytes. A view-only secure-share recipient must not retrieve a
     // previously-staged zip (no token → null → normal ACL, unchanged).
     if (!(await this._secureShareCapAllowed(["can_download", "can_edit"]))) {
+      return this.exception.forbiden();
+    }
+    // Member half, mirroring download() above — same defense-in-depth reasoning:
+    // download() stages the archive, this serves its bytes, and neither should be
+    // reachable by a view-only member.
+    if (!(await memberCan(this, CAN_DOWNLOAD))) {
       return this.exception.forbiden();
     }
     const id = this.input.need(Attr.id);

--- a/service/private/_reward_live.js
+++ b/service/private/_reward_live.js
@@ -1,0 +1,139 @@
+/**
+ * @license
+ * Copyright 2024 Thidima SA. All Rights Reserved.
+ * Licensed under the GNU AFFERO GENERAL PUBLIC LICENSE, Version 3
+ */
+
+const { RedisStore, toArray } = require('@drumee/server-essentials');
+
+/**
+ * Tell every open analytics dashboard that a claim-reward row moved.
+ *
+ * The Claim reward tracking table only re-read itself when the admin sent a
+ * campaign. Everything after that — the user following the CTA, walking the
+ * flow, leaving, declining, finishing — was invisible until someone reloaded
+ * the page by hand, which is the entire life of the campaign and the part the
+ * admin is not driving.
+ *
+ * A SIGNAL, NOT A ROW, and that is the one place this differs from its twin
+ * _referral_live.js.
+ *
+ * That one pushes a fully-built referral_members row because the board patches
+ * it straight into the DOM. The reward table cannot: it is a List.Smart of
+ * widget_user instances with no per-row part names, so there is nothing to
+ * address a patch to. It re-reads instead, through the _reloadRewardTracking()
+ * it already uses after a send — which re-queries the current page WITH its
+ * filters and refreshes the summary chips and slot counter alongside it.
+ *
+ * Letting the client re-read is not a consolation prize. It means the SERVER
+ * decides what the page should contain, so none of the hard parts of the
+ * referral design exist here: no re-matching the row against the open filter,
+ * no page-1-only insert rule, no idempotency requirement, and no reconciling
+ * against a fetch that was already in flight. It also means nothing here has to
+ * build a row in the table's shape, which would need a `uid` argument on
+ * reward_tracking and would create a second definition of a row that could
+ * drift from the polled one.
+ *
+ * The cost is one extra request per change rather than a DOM patch. At campaign
+ * volume — a couple of hundred rows and a handful of moves a day — that is
+ * nothing. It would be the wrong trade on the referral board, where every
+ * signup and every first upload moves a row.
+ *
+ * NEVER THROWS, NEVER AWAITED BY THE CALLER. Every caller is reporting a write
+ * that has already committed, so a failure here would announce a problem with
+ * something that in fact succeeded — and a slow Redis, or a dashboard nobody
+ * has open, must not add latency to a user claiming their reward.
+ */
+
+/**
+ * How long a burst of events for one user is folded into a single trailing
+ * push. A completion is the case that matters: reward.track writes 'done',
+ * reward_claim_track grants the storage in the same call, and the widget's
+ * step posts can land either side of it.
+ */
+const COALESCE_MS = 1500;
+
+/**
+ * uid -> { timer, again }. Module level on purpose: a service instance lives
+ * for one request, and the point is to span the several requests a single run
+ * through the flow makes.
+ */
+const PENDING = new Map();
+
+/**
+ * Send the signal. Resolves to nothing; all failures are swallowed.
+ *
+ * The recipient list IS the authorisation: reward_live_sockets — reused from
+ * the referral board, where it is misleadingly named `referral_live_sockets` —
+ * returns only sockets belonging to users who hold read permission on the
+ * analytics hub. The acting user is somebody else entirely and is never a
+ * recipient of their own push.
+ *
+ * @param {Object} yp    the yp database handle (ctx.yp)
+ * @param {Function} warn
+ * @param {String} uid
+ * @param {String} status the status just written, carried for logging and for
+ *   a future listener that wants to filter; the current client ignores it and
+ *   simply re-reads.
+ */
+async function publish(yp, warn, uid, status) {
+  try {
+    const sockets = toArray(await yp.await_proc('referral_live_sockets'));
+    if (!sockets || !sockets.length) return; // no dashboard open anywhere
+    await RedisStore.sendData(
+      {
+        model: { uid, status: status || '' },
+        // No top-level `service`: router/push stamps the envelope
+        // "live.update", which is what routes it to the client's `live` event.
+        // This name is how the dashboard knows what it received.
+        options: { service: 'live.reward_claim', keys: '*' },
+      },
+      sockets
+    );
+  } catch (e) {
+    if (warn) warn('[reward-live] push failed', e && e.message);
+  }
+}
+
+/**
+ * Report that a claim-reward row may have changed.
+ *
+ * Leading edge fires immediately, so the common case — one status moving once —
+ * reaches the board in well under a second. A trailing push follows only if
+ * more events arrived during the window, so a run through three steps costs two
+ * socket lookups rather than one per post.
+ *
+ * @param {Object} ctx the handler `this` (needs yp.await_proc)
+ * @param {String} uid the user whose row moved
+ * @param {String} [status] the status just written
+ */
+function pushRewardLive(ctx, uid, status) {
+  if (!ctx || !ctx.yp || typeof ctx.yp.await_proc !== 'function') return;
+  if (!uid) return;
+  // Captured rather than reached through `ctx` later: the trailing timer fires
+  // after the request that scheduled it has finished, and the handler instance
+  // is per-request. `yp` is the long-lived pool accessor and is safe to hold.
+  const yp = ctx.yp;
+  const warn = ctx.warn ? ctx.warn.bind(ctx) : null;
+
+  const state = PENDING.get(uid);
+  if (state) {
+    state.again = true;      // fold into the trailing push already scheduled
+    state.status = status;   // ...and let it report the LATEST status
+    return;
+  }
+
+  const entry = { timer: null, again: false, status };
+  PENDING.set(uid, entry);
+  publish(yp, warn, uid, status);
+
+  entry.timer = setTimeout(() => {
+    const s = PENDING.get(uid);
+    PENDING.delete(uid);
+    if (s && s.again) publish(yp, warn, uid, s.status);
+  }, COALESCE_MS);
+  // Do not hold the process open for an analytics message.
+  if (entry.timer && typeof entry.timer.unref === 'function') entry.timer.unref();
+}
+
+module.exports = { pushRewardLive };

--- a/service/private/channel.js
+++ b/service/private/channel.js
@@ -21,6 +21,7 @@ const {
 const { Entity, MfsTools } = require("@drumee/server-core");
 const { remove_node, move_node, copy_node } = MfsTools;
 const { stampAuthorIdentity } = require("../lib/message-author");
+const { memberCan, CAN_CHAT } = require("../lib/member-capability");
 
 const { stringify, parse: jsonParse } = JSON;
 const { isEmpty } = require("lodash");
@@ -1401,6 +1402,24 @@ class __private_channel extends Entity {
    *
    */
   async post() {
+    // Chat starts at the "View & chat" tier: view (privilege 3) must not post,
+    // chat (7) / edit (15) / admin (31) / owner (63) may. acl/channel.json asks
+    // only for `src: "read"` here, which a view-only member satisfies (3 & 2 = 2),
+    // so the chat right is enforced at the service layer instead.
+    //
+    // CAN_CHAT is the DOWNLOAD bit (0b100) — see service/lib/member-capability.js
+    // for why it must never be Constants.permission.chat (0b110), which overlaps
+    // read and is therefore truthy for the very role this gate excludes.
+    //
+    // This is also the meeting-chat gate: the in-meeting conversation posts
+    // through this same service, so one right governs both surfaces.
+    // Share/DMZ recipients are untouched — memberCan defers to the secure-share
+    // guards whenever a share token is present.
+    // First statement in the method: no id is minted and nothing is staged
+    // before the caller is known to be allowed.
+    if (!(await memberCan(this, CAN_CHAT))) {
+      return this.exception.forbiden();
+    }
     let message = this.input.use(Attr.message, "");
     const thread_id = this.input.use(Attr.thread_id);
     let attachment = this.input.use(Attr.attachment, []);
@@ -1790,6 +1809,13 @@ class __private_channel extends Entity {
    * trusted from the client) and the original file is never auto-attached.
    */
   async file_thread_post() {
+    // Same chat right as channel.post — a per-file thread is a conversation, and
+    // the UI already hides it from view-only members on this exact bit
+    // (folder/index.js::_syncChatGate flags .window__file-thread-panel too).
+    // Kept as the first statement so nothing is resolved or staged first.
+    if (!(await memberCan(this, CAN_CHAT))) {
+      return this.exception.forbiden();
+    }
     let file_nid = this.input.use("file_nid");
     if (isEmpty(file_nid)) {
       return this.output.data({ status: "INVALID_FILE" });

--- a/service/private/media.js
+++ b/service/private/media.js
@@ -764,6 +764,13 @@ class __private_media extends Media {
       mfs_root: join(destinationStorage.home_dir, "__storage__", ".file-move-staging"),
     };
 
+    // The revocation notice names the file, and the only place its name is
+    // still readable is the source snapshot below: mfs_move_all deletes the
+    // source row before this function reaches the emit step. Keep it in a
+    // local — `saga` is reassigned from the transition procedure's result on
+    // every state change, so a property hung on that object would not survive.
+    let sourceFilename = "";
+
     if (["copy_pending", "copy_verified"].includes(saga.state)) {
       const source = firstRow(await this.yp.await_proc(
         `${sourceStorage.db_name}.file_move_source_snapshot`, this.uid, saga.source_file_nid
@@ -778,6 +785,7 @@ class __private_media extends Media {
         || !(destination.permission & Permission.WRITE)) {
         return this._failCrossHubMove(saga, "FILE_MOVE_PERMISSION_OR_POSITION_CHANGED");
       }
+      sourceFilename = source.user_filename || "";
 
       if (Math.floor(Date.now() / 1000) >= saga.expires_at) {
         this._removePhysicalNode(stagingNode);
@@ -894,7 +902,17 @@ class __private_media extends Media {
         destination_thread_id: saga.destination_thread_id,
       });
       if (!saga.failed) {
-        await this._emitCrossHubMoveEvents(saga, sourceStorage, destinationStorage);
+        // The saga is durable and the file has physically moved by now, so a
+        // failure to announce it must not surface as a failed move: the client
+        // treats anything but a committed result as a rollback and would leave
+        // the source tile in place. Matches the compensation path's guard.
+        try {
+          await this._emitCrossHubMoveEvents(
+            saga, sourceStorage, destinationStorage, sourceFilename
+          );
+        } catch (error) {
+          this.warn("Cross-hub move event delivery failed", error);
+        }
       }
     }
 
@@ -1114,17 +1132,30 @@ class __private_media extends Media {
     }
   }
 
-  async _emitCrossHubMoveEvents(saga, sourceStorage, destinationStorage) {
+  async _emitCrossHubMoveEvents(saga, sourceStorage, destinationStorage, sourceFilename) {
     const actor = this._fileMoveActor();
+    const sourceSockets = await this.yp.await_proc("entity_sockets", saga.source_hub_id);
+    const destinationSockets = await this.yp.await_proc("entity_sockets", saga.destination_hub_id);
+
+    // Read the destination node first: it is also the filename fallback for a
+    // resumed saga, where the caller re-entered at source_removed and never
+    // saw the source snapshot. A move does not rename, so the destination
+    // name is the same name the source hub knew.
+    const destinationNode = firstRow(await this.yp.await_proc(
+      `${destinationStorage.db_name}.mfs_access_node`, this.uid, saga.destination_file_nid
+    ));
+    const filename = sourceFilename
+      || (destinationNode && (destinationNode.user_filename || destinationNode.filename))
+      || "";
+
     const common = {
       operation_id: saga.operation_id,
       lineage_id: saga.lineage_id,
       access_revision: saga.access_revision,
       actor,
       reason: "cross_hub_move",
+      filename,
     };
-    const sourceSockets = await this.yp.await_proc("entity_sockets", saga.source_hub_id);
-    const destinationSockets = await this.yp.await_proc("entity_sockets", saga.destination_hub_id);
     await RedisStore.sendData(this.payload({
       ...common,
       state: "revoked",
@@ -1132,17 +1163,20 @@ class __private_media extends Media {
       file_nid: saga.source_file_nid,
       file_thread_id: saga.source_thread_id,
     }, { service: "channel.file_thread_access_changed" }), sourceSockets);
+    // previous_file_nid lets a viewer in the destination hub rebind a mounted
+    // card from the old node id to the one that now backs the same thread.
+    // previous_file_thread_id rides along for symmetry with the compensation
+    // event, which has always carried both; no consumer reads it today.
     await RedisStore.sendData(this.payload({
       ...common,
       state: "restored",
       hub_id: saga.destination_hub_id,
       file_nid: saga.destination_file_nid,
       file_thread_id: saga.destination_thread_id,
+      previous_file_nid: saga.source_file_nid,
+      previous_file_thread_id: saga.source_thread_id,
     }, { service: "channel.file_thread_access_changed" }), destinationSockets);
 
-    const destinationNode = firstRow(await this.yp.await_proc(
-      `${destinationStorage.db_name}.mfs_access_node`, this.uid, saga.destination_file_nid
-    ));
     if (destinationNode) {
       destinationNode.args = {
         src: { nid: saga.source_file_nid, hub_id: saga.source_hub_id },
@@ -1153,6 +1187,26 @@ class __private_media extends Media {
         this.payload(destinationNode, { service: "media.move" }),
         destinationSockets
       );
+    }
+
+    // The source hub is only told the thread is gone; nothing above removes
+    // the file from its grid the way trash and workspace_move both do. Best
+    // effort: the move is already committed, so a delivery failure here must
+    // not surface as a failed move.
+    try {
+      await RedisStore.sendData(
+        this.payload(
+          { nid: saga.source_file_nid, hub_id: saga.source_hub_id },
+          { keys: [Attr.nid, Attr.hub_id], service: "media.remove" }
+        ),
+        sourceSockets
+      );
+      await RedisStore.sendData(
+        this.payload({}, { service: "notification.resync" }),
+        sourceSockets
+      );
+    } catch (error) {
+      this.warn("Cross-hub move source removal event delivery failed", error);
     }
   }
 
@@ -1191,6 +1245,11 @@ class __private_media extends Media {
         recipients
       );
     }
+
+    // No destination-side revoke here: compensation is only reachable from
+    // copy_verified and source_removed (file_move_saga_transition.sql has no
+    // edge out of 'committed'), so the destination hub has never been told the
+    // thread arrived and has nothing to take back.
   }
 
   _fileMoveResult(saga) {
@@ -1268,6 +1327,14 @@ class __private_media extends Media {
         recipients
       );
     }
+
+    // A file thread inside a moved folder is NOT revoked here. The direct
+    // access procedures validate a trash-shaped durable state — thread row
+    // present, media row gone — but a cross-hub move deletes both the media
+    // row and the file_thread row, so no ordering around this call satisfies
+    // them, and the compensating release is blocked by the mirror guard,
+    // leaving the lineage stuck in 'moving' with nothing to reclaim it.
+    // Revoking a moved subtree needs its own operation-aware contract.
   }
 
   /** Allow move with low privilege, but restricted to type=hub

--- a/service/private/media.js
+++ b/service/private/media.js
@@ -47,6 +47,11 @@ const { MfsTools, Generator, Document } = require("@drumee/server-core");
 const { check_base, remove_node, move_node, copy_node, mkdir, rmdir, cleanSeen } = MfsTools;
 const Media = require("../media");
 const { writeAudit } = require("./_audit");
+const {
+  findMfsMoveResult,
+  isCompleteMfsThreadMigration,
+  waitForMfsThreadMigration,
+} = require("../lib/mfs-move-result");
 const { stringify } = JSON;
 const { isEmpty, isString, values } = require("lodash");
 const { join, resolve, basename, extname } = require("path");
@@ -60,6 +65,8 @@ const { emptyTrash } = require('../../offline/queues/trashQueue');
 const indexQueue = require('../../offline/queues/indexQueue');
 
 const FILE_MOVE_TTL_SECONDS = 15 * 60;
+const FILE_MOVE_THREAD_SETTLE_ATTEMPTS = 5;
+const FILE_MOVE_THREAD_SETTLE_DELAY_MS = 50;
 
 function firstRow(data) {
   return toArray(data)[0] || null;
@@ -796,29 +803,43 @@ class __private_media extends Media {
 
       let movePlan;
       try {
-        movePlan = toArray(await this.yp.await_proc(
+        movePlan = await this.yp.await_proc(
           `${sourceStorage.db_name}.mfs_move_all`,
           [{ nid: saga.source_file_nid, hub_id: saga.source_hub_id }],
           this.uid,
           saga.destination_parent_nid,
           saga.destination_hub_id
-        ));
+        );
       } catch (error) {
         return this._failCrossHubMove(saga, "FILE_MOVE_DATABASE_STEP_FAILED", true);
       }
 
-      const physicalMove = movePlan.find((row) => row.action === "move" && row.nid === saga.source_file_nid);
+      const physicalMove = findMfsMoveResult(movePlan, saga.source_file_nid);
       const destinationFileNid = physicalMove && physicalMove.des_id;
-      const sourcePosition = firstRow(await this.yp.await_proc(
-        `${sourceStorage.db_name}.file_move_thread_position`, null, saga.source_thread_id
-      ));
-      const destinationPosition = destinationFileNid && firstRow(await this.yp.await_proc(
-        `${destinationStorage.db_name}.file_move_thread_position`, destinationFileNid, null
-      ));
+      let sourcePosition = null;
+      let destinationPosition = null;
 
-      if (!destinationFileNid || sourcePosition || !destinationPosition
-        || Number(destinationPosition.root_identity_count) !== 1
-        || Number(destinationPosition.stale_child_identity_count) !== 0) {
+      if (destinationFileNid) {
+        ({ sourcePosition, destinationPosition } = await waitForMfsThreadMigration(
+          async () => ({
+            sourcePosition: firstRow(await this.yp.await_proc(
+              `${sourceStorage.db_name}.file_move_thread_position`, null, saga.source_thread_id
+            )),
+            destinationPosition: firstRow(await this.yp.await_proc(
+              `${destinationStorage.db_name}.file_move_thread_position`, destinationFileNid, null
+            )),
+          }),
+          {
+            attempts: FILE_MOVE_THREAD_SETTLE_ATTEMPTS,
+            delay: () => new Promise((resolveDelay) =>
+              setTimeout(resolveDelay, FILE_MOVE_THREAD_SETTLE_DELAY_MS)
+            ),
+          }
+        ));
+      }
+
+      if (!destinationFileNid
+        || !isCompleteMfsThreadMigration({ sourcePosition, destinationPosition })) {
         saga.destination_file_nid = destinationFileNid;
         saga.destination_thread_id = destinationPosition && destinationPosition.file_thread_id;
         return this._compensateCrossHubMove(saga, sourceStorage, destinationStorage, stagingNode);
@@ -898,16 +919,14 @@ class __private_media extends Media {
     }
 
     try {
-      const compensationPlan = toArray(await this.yp.await_proc(
+      const compensationPlan = await this.yp.await_proc(
         `${destinationStorage.db_name}.mfs_move_all`,
         [{ nid: saga.destination_file_nid, hub_id: saga.destination_hub_id }],
         this.uid,
         saga.source_parent_nid,
         saga.source_hub_id
-      ));
-      const physicalMove = compensationPlan.find((row) =>
-        row.action === "move" && row.nid === saga.destination_file_nid
       );
+      const physicalMove = findMfsMoveResult(compensationPlan, saga.destination_file_nid);
       const compensationFileNid = physicalMove && physicalMove.des_id;
       if (!compensationFileNid) throw new Error("COMPENSATION_DESTINATION_MISSING");
 

--- a/service/private/reward.js
+++ b/service/private/reward.js
@@ -37,10 +37,28 @@ const SLOTS = 100;
  * Without that distinction anyone who was mailed got the walkthrough on their
  * next login whether or not they ever clicked, which is the step this closes.
  *
- * Terminal states (done, dropped) are excluded; a later send re-arms the row to
- * 'emailed', so a returning user has to click again before they are eligible.
+ * 'left' IS here, and that is what makes going away recoverable. It is written
+ * for an exit nobody confirmed — a refresh, a closed tab — and a refresh cannot
+ * be told apart from a close at unload time, so treating it as terminal would
+ * let one stray F5 cost someone a prize they were three clicks from claiming.
+ * They resume from `step`, on any device.
+ *
+ * 'dropped' is NOT here, and the difference between the two is the point.
+ * Leaving is not refusing. A user who presses "Drop anyway" on the confirmation
+ * has answered the offer, and asking again at their next login — and every
+ * login after that — is not a recovery, it is nagging. For a while both exits
+ * wrote one status, so making the accidental one recoverable silently made the
+ * deliberate one non-binding too; that is the bug the two statuses close.
+ *
+ * The funnel still records the abandon: yp.reward_claim_track ranks 'left'
+ * BELOW 'started', so coming back and reaching a card step clears it by itself
+ * and the dashboard stops calling an active user gone.
+ *
+ * Genuinely terminal states (done, missed) stay out; a later send re-arms the
+ * row to 'emailed', so a returning user has to click again before they are
+ * eligible.
  */
-const OPEN = new Set(['clicked', 'started']);
+const OPEN = new Set(['clicked', 'started', 'left']);
 /** States the client may report. 'clicked' is posted by the desk when it finds
  *  campaign-arrival evidence relayed through login; the rest come from the
  *  widget. 'emailed' is NOT here: it is seeded at send time by analytics-server
@@ -49,8 +67,14 @@ const OPEN = new Set(['clicked', 'started']);
  *  'missed' IS claimable, but reporting it can only ever cost the caller: it is
  *  how the widget says "I showed this user the sold-out screen and they
  *  dismissed it", and the proc's rank order keeps it under 'done', so a user
- *  who already holds a slot cannot post their way out of it. */
-const STATUS = new Set(['clicked', 'started', 'dropped', 'done', 'missed']);
+ *  who already holds a slot cannot post their way out of it.
+ *
+ *  'dropped' is the same shape of claim: the user pressed "Drop anyway" on the
+ *  confirmation, which is the one place they say outright that they do not want
+ *  this. It costs the caller — it is terminal and keeps them out of OPEN — so
+ *  like 'missed' there is nothing to gain by forging it. Kept distinct from
+ *  'left', which merely means they went away: see the OPEN docblock above. */
+const STATUS = new Set(['clicked', 'started', 'left', 'dropped', 'done', 'missed']);
 const STEPS = ['step1', 'step2', 'step3'];
 
 class __reward extends Entity {

--- a/service/private/reward.js
+++ b/service/private/reward.js
@@ -14,6 +14,9 @@
  */
 const { Entity } = require('@drumee/server-core');
 const { Cache, toArray } = require('@drumee/server-essentials');
+// Live updates for the dashboard's Claim reward tracking table. Same shape as
+// desk.js's use of _referral_live: fire-and-forget, never throws.
+const { pushRewardLive } = require('./_reward_live');
 
 const CAMPAIGN = 'free-storage';
 /**
@@ -260,6 +263,18 @@ class __reward extends Entity {
       ))[0];
       granted = row && row.completed_count > 0 ? 1 : 0;
     }
+
+    // Tell any open analytics dashboard the row moved. AFTER the write and
+    // after the read-back, so what the board re-reads is the settled row and
+    // not one still being decided — a 'done' that the cap refuses is a 'missed'
+    // by the time this fires, and pushing before the read would race the board
+    // into showing the wrong one.
+    //
+    // Not awaited and never able to throw: the row is already committed, and
+    // the user's answer must not wait on an analytics message (see
+    // _reward_live.js).
+    pushRewardLive(this, this.uid, status);
+
     this.output.data({ ok: true, status, step, granted });
   }
 }

--- a/service/private/room.js
+++ b/service/private/room.js
@@ -17,6 +17,7 @@
 const { isEmpty, isArray, difference, map } = require('lodash');
 const __public_room = require("../room");
 const { Attr, Privilege, Cache, sysEnv, RedisStore, toArray } = require("@drumee/server-essentials")
+const { memberCan, CAN_WRITE } = require("../lib/member-capability");
 
 //########################################
 class __private_room extends __public_room {
@@ -111,6 +112,21 @@ class __private_room extends __public_room {
    * 
    */
   async book() {
+    // Scheduling a meeting is an EDIT-tier action — it creates a `schedule` node
+    // in the workspace — so view (privilege 3) and chat (7) must be refused.
+    //
+    // The ACL cannot do this: acl/room.json declares `src: "write"` but ALSO
+    // `fast_check: "user_permission"`, and server-core's acl.js short-circuits on
+    // fast_check (check_env returns `{fast_check:1}` before check_source ever
+    // runs), so the declared `src` is never evaluated — any member with a
+    // non-zero privilege passes. Hence the explicit gate here.
+    //
+    // This closes the capability on its own: update() and remove() are already
+    // creator-only (NOT_MEETING_OWNER), so a member who cannot create a meeting
+    // has none of their own to edit or delete.
+    if (!(await memberCan(this, CAN_WRITE))) {
+      return this.exception.forbiden();
+    }
     let lang = this.user.get(Attr.profile).lang || this.input.ua_language();
     let name = this.user.get('fullname');
     const Moment = require('moment');

--- a/service/private/secure_share.js
+++ b/service/private/secure_share.js
@@ -21,6 +21,7 @@ const { Mfs } = require('@drumee/server-core');
 const { isEmpty } = require('lodash');
 const { shouldSendNotification } = require('../lib/email-policy');
 const { hashPassword } = require('../lib/secure-share-password');
+const { memberCan, CAN_WRITE } = require('../lib/member-capability');
 
 class __secure_share extends Mfs {
 
@@ -30,6 +31,26 @@ class __secure_share extends Mfs {
    * Backward compat: still accepts legacy email + domain_restriction fields.
    */
   async create() {
+    // 🔒 PRIVILEGE ESCALATION GUARD.
+    //
+    // acl/secure_share.json declares `src: "write"` for this service, but it
+    // pairs it with `fast_check: "user_permission"`, and server-core's acl.js
+    // short-circuits on fast_check (check_env returns before check_source ever
+    // runs). The declared `src` is therefore NEVER evaluated, and any member
+    // with a non-zero privilege reached this method — including a view-only
+    // one (privilege 3).
+    //
+    // That is an escalation, not just an extra button: a share link can grant
+    // `can_edit`, which dmz.js maps to privilege 15. A view or chat member
+    // could mint a link, open it themselves, and write to a workspace they only
+    // had read access to.
+    //
+    // Enforcing the write bit here makes the ACL's own declared intent real.
+    // Share/DMZ recipients are unaffected: memberCan allows whenever a share
+    // token is present, leaving the secure-share guards the sole authority.
+    if (!(await memberCan(this, CAN_WRITE))) {
+      return this.exception.forbiden();
+    }
     const nid    = this.input.need(Attr.nid);
     const days   = this.input.get(Attr.days)  || 0;
     const hours  = this.input.get(Attr.hours) || 0;


### PR DESCRIPTION
Promotes the whole `test` branch to `preview`, at Huân's request.

### What rides along
- `fix(secure-share)`: a **view** member could mint a `can_edit` link to their own workspace — `secure_share.create` paired `src:write` with `fast_check`, which short-circuits `src`. Real privilege escalation.
- `feat(acl)`: enforce the workspace member role at the service layer (`service/lib/member-capability.js`)
- `fix(media)` ×2: parse `mfs_move_all` multi-results and settle thread migration; give the cross-hub move path the same thread-revocation payload as delete
- `feat(reward)`: push a live signal when a claim-reward row moves; reward declined/dropped status

### Prod DB
Applied first — see drumee/schemas#131. `reward_claim_track` / `reward_claim_emailed` / `conference_join` / `disk_free` / `disk_limit` are live on the prod DB, so this code lands on procs that already speak the new vocabulary.

`referral_live_sockets` (called by the new `_reward_live.js`) was verified present on prod — it is pre-existing, already used by `_referral_live.js` on `preview`.

`preview` had **zero content commits** ahead of `test`, the merge is conflict-free, and the merged tree is byte-identical to `test`'s — no backmerge was needed.
