### PR TITLE
chore(deps): bump @drumee/server-core to ^1.1.84 (main_domain leak fix)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.9.94",
       "dependencies": {
         "@drumee/schemas-utils": "^1.0.0",
-        "@drumee/server-core": "^1.1.83",
+        "@drumee/server-core": "^1.1.84",
         "@drumee/server-essentials": "^1.3.1",
         "@drumee/ui-core": "^1.1.43",
         "@hyzyla/pdfium": "^2.1.9",
@@ -137,9 +137,9 @@
       }
     },
     "node_modules/@drumee/server-core": {
-      "version": "1.1.83",
-      "resolved": "https://registry.npmjs.org/@drumee/server-core/-/server-core-1.1.83.tgz",
-      "integrity": "sha512-4h5GZyTrWLRbOuKaSv4gEUb43OrykbIwduySqmEuAMKvZ/hAwX+FzDf975TH507E/AVwT1RQkOVzqiPIWT6Y1w==",
+      "version": "1.1.84",
+      "resolved": "https://registry.npmjs.org/@drumee/server-core/-/server-core-1.1.84.tgz",
+      "integrity": "sha512-blQmqjWRFrjerhPs3Vd2ZKEEp0XqCjy9cMFIvnKf0kN9CNrwdmDrXkbOapFco6AWjl8NTcwHZzO62DvWanne+w==",
       "license": "AGPL V3",
       "dependencies": {
         "@drumee/server-essentials": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@drumee/schemas-utils": "^1.0.0",
-    "@drumee/server-core": "^1.1.83",
+    "@drumee/server-core": "^1.1.84",
     "@drumee/server-essentials": "^1.3.1",
     "@drumee/ui-core": "^1.1.43",
     "@hyzyla/pdfium": "^2.1.9",


### PR DESCRIPTION
Picks up the `runtimeEnv` `main_domain` fix released in **@drumee/server-core 1.1.84** ([server-core PR #5](https://github.com/drumee/server-core/pull/5)).

## The bug it fixes

`getSettings()` assigned to the **module-scoped** `main_domain` when a request arrived with `Host: localhost`. That binding is process-wide and was never restored, so **one** such request permanently pinned every later page the worker rendered to `main_domain: "localhost"`.

The client builds absolute URLs from `bootstrap().main_domain`, so the share page's **Login / Join Workspace / See more** buttons sent real visitors to `https://localhost/-/#/welcome/signin`. It also feeds `serviceUrl` and `websocketApi`. The page server is a **single fork process**, so one request broke 100% of pages until restart — and the trigger is **anonymous and remote**.

Duy hit it on drumee.in. Prod and preview were clean at the time but run the same 1.1.83 and were exposed identically.

## This PR

Two files, +5/−5 — the dependency range, and `version` / `resolved` / `integrity` / root range in the lock.

- **Hand-edited, not `npm install`** — `npm install` rewrites the lock and churns ~24 unrelated `peer` flags, burying the change.
- 1.1.83 and 1.1.84 declare **identical dependency sets**, so this is the entire delta.
- The deploy runs **`npm install`**, not `npm ci`. `npm install` keeps a lock that already satisfies the declared range, so bumping `package.json` alone would **not** have picked 1.1.84 up — the lock edit is what makes the deploy take it.
- `integrity` computed with `openssl dgst -sha512 -binary | openssl base64 -A`; the method was validated by reproducing 1.1.83's published hash exactly.
- The published 1.1.84 tarball was verified to contain the merged fix (`lib/runtimeEnv.js` md5 matches the file tested on stage) before bumping.
- `npm ci --dry-run` → exit 0.

## ⚠️ `Guard preview source` fails by design

This is a hotfix branch, not `test`, so `guard-preview-source.yml` errors with `PR into preview must come from branch 'test'`. That is expected and correct for a hotfix — the point is to carry **only** this change and not drag `test`'s unreleased work onto a prod-trigger branch. Base is `preview` @ `3e71d52`, which is identical to `main`.
